### PR TITLE
Refactor tests to table-driven style

### DIFF
--- a/server/handlers/s3api/buckets_test.go
+++ b/server/handlers/s3api/buckets_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/mojatter/s2/server"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -47,7 +48,6 @@ func (s *BucketsTestSuite) TestListBuckets() {
 		s.Contains(names, "alpha")
 		s.Contains(names, "beta")
 
-		// CreationDate should be a real timestamp, not a hardcoded mock
 		for _, b := range result.Buckets {
 			s.False(b.CreationDate.IsZero(), "CreationDate should not be zero")
 			s.True(b.CreationDate.Year() >= 2025, "CreationDate should be a recent timestamp")
@@ -104,67 +104,96 @@ func (s *BucketsTestSuite) TestDeleteBucket() {
 // --- GetBucketLocation ---
 
 func (s *BucketsTestSuite) TestGetBucketLocation() {
-	s.Run("existing bucket", func() {
-		s.createBucket("loc")
+	testCases := []struct {
+		caseName     string
+		bucket       string
+		createBucket bool
+		handler      server.HandlerFunc
+		wantStatus   int
+		wantLocation string
+		wantErrCode  string
+	}{
+		{
+			caseName:     "existing bucket",
+			bucket:       "loc",
+			createBucket: true,
+			handler:      handleGetBucketLocation,
+			wantStatus:   http.StatusOK,
+			wantLocation: s2Region,
+		},
+		{
+			caseName:    "nonexistent bucket",
+			bucket:      "no-such",
+			handler:     handleGetBucketLocation,
+			wantStatus:  http.StatusNotFound,
+			wantErrCode: "NoSuchBucket",
+		},
+		{
+			caseName:     "dispatched via handleBucketGET",
+			bucket:       "disp",
+			createBucket: true,
+			handler:      handleBucketGET,
+			wantStatus:   http.StatusOK,
+			wantLocation: s2Region,
+		},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			if tc.createBucket {
+				s.createBucket(tc.bucket)
+			}
+			req := httptest.NewRequest("GET", "/s3api/"+tc.bucket+"?location", nil)
+			req.SetPathValue("bucket", tc.bucket)
+			w := httptest.NewRecorder()
+			tc.handler(s.server, w, req)
 
-		req := httptest.NewRequest("GET", "/s3api/loc?location", nil)
-		req.SetPathValue("bucket", "loc")
-		w := httptest.NewRecorder()
-		handleGetBucketLocation(s.server, w, req)
-
-		s.Equal(http.StatusOK, w.Code)
-		var result LocationConstraint
-		s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &result))
-		s.Equal(s2Region, result.Location)
-	})
-
-	s.Run("nonexistent bucket", func() {
-		req := httptest.NewRequest("GET", "/s3api/no-such?location", nil)
-		req.SetPathValue("bucket", "no-such")
-		w := httptest.NewRecorder()
-		handleGetBucketLocation(s.server, w, req)
-
-		s.Equal(http.StatusNotFound, w.Code)
-		var errResp ErrorResponse
-		s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &errResp))
-		s.Equal("NoSuchBucket", errResp.Code)
-	})
-
-	s.Run("dispatched via handleBucketGET", func() {
-		s.createBucket("disp")
-
-		req := httptest.NewRequest("GET", "/s3api/disp?location", nil)
-		req.SetPathValue("bucket", "disp")
-		w := httptest.NewRecorder()
-		handleBucketGET(s.server, w, req)
-
-		s.Equal(http.StatusOK, w.Code)
-		var result LocationConstraint
-		s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &result))
-		s.Equal("us-east-1", result.Location)
-	})
+			s.Equal(tc.wantStatus, w.Code)
+			if tc.wantLocation != "" {
+				var result LocationConstraint
+				s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &result))
+				s.Equal(tc.wantLocation, result.Location)
+			}
+			if tc.wantErrCode != "" {
+				var errResp ErrorResponse
+				s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &errResp))
+				s.Equal(tc.wantErrCode, errResp.Code)
+			}
+		})
+	}
 }
 
 // --- HeadBucket ---
 
 func (s *BucketsTestSuite) TestHeadBucket() {
-	s.Run("existing", func() {
-		s.createBucket("exists")
+	testCases := []struct {
+		caseName     string
+		bucket       string
+		createBucket bool
+		wantStatus   int
+	}{
+		{
+			caseName:     "existing",
+			bucket:       "exists",
+			createBucket: true,
+			wantStatus:   http.StatusOK,
+		},
+		{
+			caseName:   "not found",
+			bucket:     "nope",
+			wantStatus: http.StatusNotFound,
+		},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			if tc.createBucket {
+				s.createBucket(tc.bucket)
+			}
+			req := httptest.NewRequest("HEAD", "/s3api/"+tc.bucket, nil)
+			req.SetPathValue("bucket", tc.bucket)
+			w := httptest.NewRecorder()
+			handleHeadBucket(s.server, w, req)
 
-		req := httptest.NewRequest("HEAD", "/s3api/exists", nil)
-		req.SetPathValue("bucket", "exists")
-		w := httptest.NewRecorder()
-		handleHeadBucket(s.server, w, req)
-
-		s.Equal(http.StatusOK, w.Code)
-	})
-
-	s.Run("not found", func() {
-		req := httptest.NewRequest("HEAD", "/s3api/nope", nil)
-		req.SetPathValue("bucket", "nope")
-		w := httptest.NewRecorder()
-		handleHeadBucket(s.server, w, req)
-
-		s.Equal(http.StatusNotFound, w.Code)
-	})
+			s.Equal(tc.wantStatus, w.Code)
+		})
+	}
 }

--- a/server/middleware/basicauth_test.go
+++ b/server/middleware/basicauth_test.go
@@ -13,49 +13,74 @@ func noopHandler(_ *server.Server, w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func TestBasicAuth_NoAuth(t *testing.T) {
-	srv := &server.Server{Config: &server.Config{}}
-	handler := BasicAuth(noopHandler)
+func TestBasicAuth(t *testing.T) {
+	testCases := []struct {
+		caseName       string
+		user           string
+		password       string
+		setBasicAuth   bool
+		authUser       string
+		authPass       string
+		wantStatus     int
+		wantWWWAuth    string
+	}{
+		{
+			caseName:   "auth disabled",
+			wantStatus: http.StatusOK,
+		},
+		{
+			caseName:   "missing credentials",
+			user:       "admin",
+			password:   "secret",
+			wantStatus: http.StatusUnauthorized,
+			wantWWWAuth: `Basic realm="s2"`,
+		},
+		{
+			caseName:     "wrong password",
+			user:         "admin",
+			password:     "secret",
+			setBasicAuth: true,
+			authUser:     "admin",
+			authPass:     "wrong",
+			wantStatus:   http.StatusUnauthorized,
+			wantWWWAuth:  `Basic realm="s2"`,
+		},
+		{
+			caseName:     "wrong user",
+			user:         "admin",
+			password:     "secret",
+			setBasicAuth: true,
+			authUser:     "other",
+			authPass:     "secret",
+			wantStatus:   http.StatusUnauthorized,
+			wantWWWAuth:  `Basic realm="s2"`,
+		},
+		{
+			caseName:     "correct credentials",
+			user:         "admin",
+			password:     "secret",
+			setBasicAuth: true,
+			authUser:     "admin",
+			authPass:     "secret",
+			wantStatus:   http.StatusOK,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			srv := &server.Server{Config: &server.Config{User: tc.user, Password: tc.password}}
+			handler := BasicAuth(noopHandler)
 
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
-	w := httptest.NewRecorder()
-	handler(srv, w, r)
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tc.setBasicAuth {
+				r.SetBasicAuth(tc.authUser, tc.authPass)
+			}
+			w := httptest.NewRecorder()
+			handler(srv, w, r)
 
-	assert.Equal(t, http.StatusOK, w.Code)
-}
-
-func TestBasicAuth_MissingCredentials(t *testing.T) {
-	srv := &server.Server{Config: &server.Config{User: "admin", Password: "secret"}}
-	handler := BasicAuth(noopHandler)
-
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
-	w := httptest.NewRecorder()
-	handler(srv, w, r)
-
-	assert.Equal(t, http.StatusUnauthorized, w.Code)
-	assert.Equal(t, `Basic realm="s2"`, w.Header().Get("WWW-Authenticate"))
-}
-
-func TestBasicAuth_WrongCredentials(t *testing.T) {
-	srv := &server.Server{Config: &server.Config{User: "admin", Password: "secret"}}
-	handler := BasicAuth(noopHandler)
-
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
-	r.SetBasicAuth("admin", "wrong")
-	w := httptest.NewRecorder()
-	handler(srv, w, r)
-
-	assert.Equal(t, http.StatusUnauthorized, w.Code)
-}
-
-func TestBasicAuth_CorrectCredentials(t *testing.T) {
-	srv := &server.Server{Config: &server.Config{User: "admin", Password: "secret"}}
-	handler := BasicAuth(noopHandler)
-
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
-	r.SetBasicAuth("admin", "secret")
-	w := httptest.NewRecorder()
-	handler(srv, w, r)
-
-	assert.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, tc.wantStatus, w.Code)
+			if tc.wantWWWAuth != "" {
+				assert.Equal(t, tc.wantWWWAuth, w.Header().Get("WWW-Authenticate"))
+			}
+		})
+	}
 }

--- a/server/middleware/sigv4_test.go
+++ b/server/middleware/sigv4_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/mojatter/s2/server"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // signRequest adds AWS Signature V4 headers to r signed at the current time.
@@ -45,115 +44,169 @@ func signRequestAt(r *http.Request, accessKey, secretKey string, now time.Time) 
 	))
 }
 
-func TestSigV4_ExpiredTimestamp(t *testing.T) {
-	srv := &server.Server{Config: &server.Config{User: "minioadmin", Password: "minioadmin"}}
-	handler := SigV4(noopHandler)
+func TestSigV4(t *testing.T) {
+	testCases := []struct {
+		caseName   string
+		user       string
+		password   string
+		signFunc   func(r *http.Request) // nil = no signing
+		wantStatus int
+	}{
+		{
+			caseName:   "auth disabled",
+			wantStatus: http.StatusOK,
+		},
+		{
+			caseName:   "missing authorization header",
+			user:       "minioadmin",
+			password:   "minioadmin",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			caseName: "valid signature",
+			user:     "minioadmin",
+			password: "minioadmin",
+			signFunc: func(r *http.Request) {
+				signRequest(r, "minioadmin", "minioadmin")
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			caseName: "invalid secret key",
+			user:     "minioadmin",
+			password: "minioadmin",
+			signFunc: func(r *http.Request) {
+				signRequest(r, "minioadmin", "wrongsecret")
+			},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			caseName: "wrong access key",
+			user:     "minioadmin",
+			password: "minioadmin",
+			signFunc: func(r *http.Request) {
+				signRequest(r, "wrongkey", "minioadmin")
+			},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			caseName: "expired timestamp",
+			user:     "minioadmin",
+			password: "minioadmin",
+			signFunc: func(r *http.Request) {
+				signRequestAt(r, "minioadmin", "minioadmin", time.Now().UTC().Add(-16*time.Minute))
+			},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			caseName: "future timestamp",
+			user:     "minioadmin",
+			password: "minioadmin",
+			signFunc: func(r *http.Request) {
+				signRequestAt(r, "minioadmin", "minioadmin", time.Now().UTC().Add(16*time.Minute))
+			},
+			wantStatus: http.StatusForbidden,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			srv := &server.Server{Config: &server.Config{User: tc.user, Password: tc.password}}
+			handler := SigV4(noopHandler)
 
-	r := httptest.NewRequest(http.MethodGet, "/s3api", nil)
-	// Sign with a timestamp 16 minutes in the past
-	signRequestAt(r, "minioadmin", "minioadmin", time.Now().UTC().Add(-16*time.Minute))
-	w := httptest.NewRecorder()
-	handler(srv, w, r)
+			r := httptest.NewRequest(http.MethodGet, "/s3api", nil)
+			if tc.signFunc != nil {
+				tc.signFunc(r)
+			}
+			w := httptest.NewRecorder()
+			handler(srv, w, r)
 
-	assert.Equal(t, http.StatusForbidden, w.Code)
-}
-
-func TestSigV4_FutureTimestamp(t *testing.T) {
-	srv := &server.Server{Config: &server.Config{User: "minioadmin", Password: "minioadmin"}}
-	handler := SigV4(noopHandler)
-
-	r := httptest.NewRequest(http.MethodGet, "/s3api", nil)
-	// Sign with a timestamp 16 minutes in the future
-	signRequestAt(r, "minioadmin", "minioadmin", time.Now().UTC().Add(16*time.Minute))
-	w := httptest.NewRecorder()
-	handler(srv, w, r)
-
-	assert.Equal(t, http.StatusForbidden, w.Code)
-}
-
-func TestSigV4_NoAuth(t *testing.T) {
-	srv := &server.Server{Config: &server.Config{}}
-	handler := SigV4(noopHandler)
-
-	r := httptest.NewRequest(http.MethodGet, "/s3api", nil)
-	w := httptest.NewRecorder()
-	handler(srv, w, r)
-
-	assert.Equal(t, http.StatusOK, w.Code)
-}
-
-func TestSigV4_MissingAuthorizationHeader(t *testing.T) {
-	srv := &server.Server{Config: &server.Config{User: "minioadmin", Password: "minioadmin"}}
-	handler := SigV4(noopHandler)
-
-	r := httptest.NewRequest(http.MethodGet, "/s3api", nil)
-	w := httptest.NewRecorder()
-	handler(srv, w, r)
-
-	assert.Equal(t, http.StatusForbidden, w.Code)
-}
-
-func TestSigV4_ValidSignature(t *testing.T) {
-	srv := &server.Server{Config: &server.Config{User: "minioadmin", Password: "minioadmin"}}
-	handler := SigV4(noopHandler)
-
-	r := httptest.NewRequest(http.MethodGet, "/s3api", nil)
-	signRequest(r, "minioadmin", "minioadmin")
-	w := httptest.NewRecorder()
-	handler(srv, w, r)
-
-	assert.Equal(t, http.StatusOK, w.Code)
-}
-
-func TestSigV4_InvalidSignature(t *testing.T) {
-	srv := &server.Server{Config: &server.Config{User: "minioadmin", Password: "minioadmin"}}
-	handler := SigV4(noopHandler)
-
-	r := httptest.NewRequest(http.MethodGet, "/s3api", nil)
-	signRequest(r, "minioadmin", "wrongsecret")
-	w := httptest.NewRecorder()
-	handler(srv, w, r)
-
-	assert.Equal(t, http.StatusForbidden, w.Code)
-}
-
-func TestSigV4_WrongAccessKey(t *testing.T) {
-	srv := &server.Server{Config: &server.Config{User: "minioadmin", Password: "minioadmin"}}
-	handler := SigV4(noopHandler)
-
-	r := httptest.NewRequest(http.MethodGet, "/s3api", nil)
-	signRequest(r, "wrongkey", "minioadmin")
-	w := httptest.NewRecorder()
-	handler(srv, w, r)
-
-	assert.Equal(t, http.StatusForbidden, w.Code)
-}
-
-func TestParseAuthHeader(t *testing.T) {
-	s := "Credential=AKID/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-date, Signature=abc123"
-	parts := parseAuthHeader(s)
-	require.Equal(t, "AKID/20130524/us-east-1/s3/aws4_request", parts["Credential"])
-	require.Equal(t, "host;x-amz-date", parts["SignedHeaders"])
-	require.Equal(t, "abc123", parts["Signature"])
+			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
 }
 
 func TestCanonicalQueryString(t *testing.T) {
-	assert.Equal(t, "", canonicalQueryString(""))
-	assert.Equal(t, "a=1&b=2", canonicalQueryString("b=2&a=1"))
-	assert.Equal(t, "key=hello%20world", canonicalQueryString("key=hello+world"))
+	testCases := []struct {
+		caseName string
+		input    string
+		want     string
+	}{
+		{caseName: "empty", input: "", want: ""},
+		{caseName: "sorted", input: "b=2&a=1", want: "a=1&b=2"},
+		{caseName: "plus to space", input: "key=hello+world", want: "key=hello%20world"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			assert.Equal(t, tc.want, canonicalQueryString(tc.input))
+		})
+	}
 }
 
 func TestCanonicalURI(t *testing.T) {
-	r := httptest.NewRequest(http.MethodGet, "/s3api/my-bucket/path/to/key", nil)
-	assert.Equal(t, "/s3api/my-bucket/path/to/key", canonicalURI(r))
-
-	r2 := httptest.NewRequest(http.MethodGet, "/s3api/my-bucket/key%20with%20spaces", nil)
-	assert.Equal(t, "/s3api/my-bucket/key%20with%20spaces", canonicalURI(r2))
+	testCases := []struct {
+		caseName string
+		url      string
+		want     string
+	}{
+		{caseName: "simple path", url: "/s3api/my-bucket/path/to/key", want: "/s3api/my-bucket/path/to/key"},
+		{caseName: "encoded spaces", url: "/s3api/my-bucket/key%20with%20spaces", want: "/s3api/my-bucket/key%20with%20spaces"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, tc.url, nil)
+			assert.Equal(t, tc.want, canonicalURI(r))
+		})
+	}
 }
 
 func TestAWSURIEncode(t *testing.T) {
-	assert.Equal(t, "hello", awsURIEncode("hello"))
-	assert.Equal(t, "hello%20world", awsURIEncode("hello world"))
-	assert.Equal(t, "hello%2Fworld", awsURIEncode("hello/world"))
-	assert.Equal(t, "key~_.-", awsURIEncode("key~_.-"))
+	testCases := []struct {
+		caseName string
+		input    string
+		want     string
+	}{
+		{caseName: "plain", input: "hello", want: "hello"},
+		{caseName: "space", input: "hello world", want: "hello%20world"},
+		{caseName: "slash", input: "hello/world", want: "hello%2Fworld"},
+		{caseName: "unreserved chars", input: "key~_.-", want: "key~_.-"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			assert.Equal(t, tc.want, awsURIEncode(tc.input))
+		})
+	}
+}
+
+func TestParseAuthHeader(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		input    string
+		wantKey  string
+		wantVal  string
+	}{
+		{
+			caseName: "credential",
+			input:    "Credential=AKID/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-date, Signature=abc123",
+			wantKey:  "Credential",
+			wantVal:  "AKID/20130524/us-east-1/s3/aws4_request",
+		},
+		{
+			caseName: "signed headers",
+			input:    "Credential=AKID/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-date, Signature=abc123",
+			wantKey:  "SignedHeaders",
+			wantVal:  "host;x-amz-date",
+		},
+		{
+			caseName: "signature",
+			input:    "Credential=AKID/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-date, Signature=abc123",
+			wantKey:  "Signature",
+			wantVal:  "abc123",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			parts := parseAuthHeader(tc.input)
+			assert.Equal(t, tc.wantVal, parts[tc.wantKey])
+		})
+	}
 }


### PR DESCRIPTION
- middleware/basicauth_test.go: 4 individual functions → 1 table-driven
- middleware/sigv4_test.go: 7 individual functions → 1 table-driven, helper tests also converted
- handlers/s3api/buckets_test.go: HeadBucket and GetBucketLocation → table-driven