### PR TITLE
Add S3 API integration tests and Docker-based E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,18 @@ LDFLAGS := -s -w -X github.com/mojatter/s2/server.version=$(VERSION)
 .PHONY: build
 build:
 	go build -ldflags "$(LDFLAGS)" -o bin/s2-server ./cmd/s2-server
+
+.PHONY: test
+test:
+	go test -short ./...
+
+.PHONY: test-integration
+test-integration:
+	go test -v -count=1 ./server/handlers/s3api/ -run Integration
+
+.PHONY: test-e2e
+test-e2e:
+	docker compose -f s2test/e2e/docker-compose.yml run --build --rm test; \
+	rc=$$?; \
+	docker compose -f s2test/e2e/docker-compose.yml down; \
+	exit $$rc

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.7
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
 	github.com/mojatter/wfs v0.4.0
 	github.com/stretchr/testify v1.11.1
@@ -12,7 +13,6 @@ require (
 
 require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.19.7 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.17 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.17 // indirect

--- a/s2test/e2e/docker-compose.yml
+++ b/s2test/e2e/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  s2:
+    build:
+      context: ../..
+      dockerfile: server/Dockerfile
+    environment:
+      S2_SERVER_LISTEN: ":9000"
+      S2_SERVER_USER: "testkey"
+      S2_SERVER_PASSWORD: "testsecret"
+    tmpfs:
+      - /var/lib/s2
+
+  test:
+    image: amazon/aws-cli
+    depends_on:
+      s2:
+        condition: service_started
+    environment:
+      AWS_ACCESS_KEY_ID: "testkey"
+      AWS_SECRET_ACCESS_KEY: "testsecret"
+      AWS_DEFAULT_REGION: "us-east-1"
+    entrypoint: [""]
+    command: ["/bin/sh", "/tests/run.sh"]
+    volumes:
+      - ./run.sh:/tests/run.sh:ro

--- a/s2test/e2e/run.sh
+++ b/s2test/e2e/run.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+set -eu
+
+ENDPOINT="http://s2:9000/s3api"
+
+aws_s3() {
+  aws s3 --endpoint-url "$ENDPOINT" "$@"
+}
+
+aws_s3api() {
+  aws s3api --endpoint-url "$ENDPOINT" "$@"
+}
+
+# Wait for s2-server to be ready
+echo "==> Waiting for s2-server..."
+i=0
+while [ "$i" -lt 30 ]; do
+  if aws_s3api list-buckets >/dev/null 2>&1; then
+    break
+  fi
+  i=$((i + 1))
+  sleep 1
+done
+if [ "$i" -eq 30 ]; then
+  echo "FAIL: s2-server did not become ready"
+  exit 1
+fi
+echo "    s2-server is ready."
+
+passed=0
+failed=0
+
+run_test() {
+  name="$1"
+  shift
+  printf "  TEST %s ... " "$name"
+  if "$@" >/dev/null 2>&1; then
+    echo "PASS"
+    passed=$((passed + 1))
+  else
+    echo "FAIL"
+    failed=$((failed + 1))
+  fi
+}
+
+echo "==> Running E2E tests..."
+
+# Bucket operations
+run_test "CreateBucket" aws_s3api create-bucket --bucket test-bucket
+
+run_test "ListBuckets" sh -c '
+  out=$(aws s3api --endpoint-url "'"$ENDPOINT"'" list-buckets --query "Buckets[].Name" --output text)
+  echo "$out" | grep -q "test-bucket"
+'
+
+run_test "HeadBucket" aws_s3api head-bucket --bucket test-bucket
+
+# Object operations
+run_test "PutObject" sh -c 'echo -n "hello e2e" | aws s3 --endpoint-url "'"$ENDPOINT"'" cp - s3://test-bucket/hello.txt'
+
+run_test "GetObject" sh -c '
+  out=$(aws s3 --endpoint-url "'"$ENDPOINT"'" cp s3://test-bucket/hello.txt -)
+  [ "$out" = "hello e2e" ]
+'
+
+run_test "HeadObject" aws_s3api head-object --bucket test-bucket --key hello.txt
+
+run_test "CopyObject" aws_s3api copy-object \
+  --bucket test-bucket \
+  --key copied.txt \
+  --copy-source test-bucket/hello.txt
+
+run_test "GetCopiedObject" sh -c '
+  out=$(aws s3 --endpoint-url "'"$ENDPOINT"'" cp s3://test-bucket/copied.txt -)
+  [ "$out" = "hello e2e" ]
+'
+
+# List objects
+run_test "ListObjects" sh -c '
+  out=$(aws s3api --endpoint-url "'"$ENDPOINT"'" list-objects-v2 --bucket test-bucket --query "Contents[].Key" --output text)
+  echo "$out" | grep -q "hello.txt"
+  echo "$out" | grep -q "copied.txt"
+'
+
+# Delete operations
+run_test "DeleteObject" aws_s3api delete-object --bucket test-bucket --key copied.txt
+
+run_test "DeleteObjects" aws_s3api delete-objects --bucket test-bucket \
+  --delete '{"Objects":[{"Key":"hello.txt"}],"Quiet":true}'
+
+# Multipart upload
+run_test "MultipartUpload" sh -c '
+  EP="'"$ENDPOINT"'"
+
+  upload_id=$(aws s3api --endpoint-url "$EP" create-multipart-upload \
+    --bucket test-bucket --key large.bin --query "UploadId" --output text)
+
+  printf "part1data" > /tmp/part1.bin
+  printf "part2data" > /tmp/part2.bin
+
+  etag1=$(aws s3api --endpoint-url "$EP" upload-part \
+    --bucket test-bucket --key large.bin --upload-id "$upload_id" \
+    --part-number 1 --body /tmp/part1.bin --query "ETag" --output text)
+
+  etag2=$(aws s3api --endpoint-url "$EP" upload-part \
+    --bucket test-bucket --key large.bin --upload-id "$upload_id" \
+    --part-number 2 --body /tmp/part2.bin --query "ETag" --output text)
+
+  aws s3api --endpoint-url "$EP" complete-multipart-upload \
+    --bucket test-bucket --key large.bin --upload-id "$upload_id" \
+    --multipart-upload "{\"Parts\":[{\"PartNumber\":1,\"ETag\":$etag1},{\"PartNumber\":2,\"ETag\":$etag2}]}"
+
+  out=$(aws s3 --endpoint-url "$EP" cp s3://test-bucket/large.bin -)
+  [ "$out" = "part1datapart2data" ]
+'
+
+# Cleanup
+run_test "DeleteBucket" sh -c '
+  aws s3 --endpoint-url "'"$ENDPOINT"'" rm s3://test-bucket --recursive
+  aws s3api --endpoint-url "'"$ENDPOINT"'" delete-bucket --bucket test-bucket
+'
+
+echo ""
+echo "==> Results: $passed passed, $failed failed"
+[ "$failed" -eq 0 ]

--- a/server/handlers/s3api/integration_test.go
+++ b/server/handlers/s3api/integration_test.go
@@ -1,0 +1,524 @@
+package s3api
+
+import (
+	"bytes"
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/stretchr/testify/suite"
+
+	_ "github.com/mojatter/s2/fs"
+	"github.com/mojatter/s2/server"
+)
+
+const (
+	testAccessKey = "testkey"
+	testSecretKey = "testsecret"
+)
+
+type IntegrationSuite struct {
+	suite.Suite
+	srv    *server.Server
+	ts     *httptest.Server
+	client *s3.Client
+}
+
+func TestIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	suite.Run(t, new(IntegrationSuite))
+}
+
+func (s *IntegrationSuite) SetupTest() {
+	cfg := server.DefaultConfig()
+	cfg.Root = s.T().TempDir()
+	cfg.User = testAccessKey
+	cfg.Password = testSecretKey
+
+	srv, err := server.NewServer(context.Background(), cfg)
+	s.Require().NoError(err)
+	s.srv = srv
+
+	s.ts = httptest.NewServer(srv.Handler())
+
+	s.client = s3.NewFromConfig(aws.Config{
+		Region:      "us-east-1",
+		Credentials: credentials.NewStaticCredentialsProvider(testAccessKey, testSecretKey, ""),
+	}, func(o *s3.Options) {
+		o.BaseEndpoint = aws.String(s.ts.URL + "/s3api")
+		o.UsePathStyle = true
+	})
+}
+
+func (s *IntegrationSuite) TearDownTest() {
+	if s.ts != nil {
+		s.ts.Close()
+	}
+}
+
+// --- Bucket operations ---
+
+func (s *IntegrationSuite) TestCreateAndListBuckets() {
+	ctx := context.Background()
+
+	_, err := s.client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String("test-bucket"),
+	})
+	s.Require().NoError(err)
+
+	out, err := s.client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	s.Require().NoError(err)
+	s.Require().Len(out.Buckets, 1)
+	s.Equal("test-bucket", *out.Buckets[0].Name)
+}
+
+func (s *IntegrationSuite) TestHeadBucket() {
+	ctx := context.Background()
+
+	_, err := s.client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String("head-bucket"),
+	})
+	s.Require().NoError(err)
+
+	_, err = s.client.HeadBucket(ctx, &s3.HeadBucketInput{
+		Bucket: aws.String("head-bucket"),
+	})
+	s.NoError(err)
+
+	_, err = s.client.HeadBucket(ctx, &s3.HeadBucketInput{
+		Bucket: aws.String("no-such-bucket"),
+	})
+	s.Error(err)
+}
+
+func (s *IntegrationSuite) TestDeleteBucket() {
+	ctx := context.Background()
+
+	_, err := s.client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String("del-bucket"),
+	})
+	s.Require().NoError(err)
+
+	_, err = s.client.DeleteBucket(ctx, &s3.DeleteBucketInput{
+		Bucket: aws.String("del-bucket"),
+	})
+	s.Require().NoError(err)
+
+	out, err := s.client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	s.Require().NoError(err)
+	s.Empty(out.Buckets)
+}
+
+// --- Object operations ---
+
+func (s *IntegrationSuite) TestPutAndGetObject() {
+	ctx := context.Background()
+	bucket := "obj-bucket"
+	s.createTestBucket(bucket)
+
+	body := "hello, s2!"
+	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("greeting.txt"),
+		Body:   strings.NewReader(body),
+	})
+	s.Require().NoError(err)
+
+	out, err := s.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("greeting.txt"),
+	})
+	s.Require().NoError(err)
+	defer out.Body.Close()
+
+	var buf bytes.Buffer
+	_, err = buf.ReadFrom(out.Body)
+	s.Require().NoError(err)
+	s.Equal(body, buf.String())
+	s.NotEmpty(*out.ETag)
+}
+
+func (s *IntegrationSuite) TestHeadObject() {
+	ctx := context.Background()
+	bucket := "head-obj-bucket"
+	s.createTestBucket(bucket)
+
+	body := "head me"
+	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("file.txt"),
+		Body:   strings.NewReader(body),
+	})
+	s.Require().NoError(err)
+
+	out, err := s.client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("file.txt"),
+	})
+	s.Require().NoError(err)
+	s.Equal(int64(len(body)), *out.ContentLength)
+	s.NotNil(out.LastModified)
+}
+
+func (s *IntegrationSuite) TestDeleteObject() {
+	ctx := context.Background()
+	bucket := "del-obj-bucket"
+	s.createTestBucket(bucket)
+
+	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("to-delete.txt"),
+		Body:   strings.NewReader("bye"),
+	})
+	s.Require().NoError(err)
+
+	_, err = s.client.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("to-delete.txt"),
+	})
+	s.Require().NoError(err)
+
+	_, err = s.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("to-delete.txt"),
+	})
+	s.Error(err)
+}
+
+func (s *IntegrationSuite) TestDeleteObjects() {
+	ctx := context.Background()
+	bucket := "batch-del-bucket"
+	s.createTestBucket(bucket)
+
+	for _, key := range []string{"a.txt", "b.txt", "c.txt"} {
+		_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+			Body:   strings.NewReader("x"),
+		})
+		s.Require().NoError(err)
+	}
+
+	_, err := s.client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+		Bucket: aws.String(bucket),
+		Delete: &types.Delete{
+			Objects: []types.ObjectIdentifier{
+				{Key: aws.String("a.txt")},
+				{Key: aws.String("b.txt")},
+			},
+			Quiet: aws.Bool(true),
+		},
+	})
+	s.Require().NoError(err)
+
+	out, err := s.client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+		Bucket: aws.String(bucket),
+	})
+	s.Require().NoError(err)
+	s.Require().Len(out.Contents, 1)
+	s.Equal("c.txt", *out.Contents[0].Key)
+}
+
+// --- List objects ---
+
+func (s *IntegrationSuite) TestListObjects() {
+	ctx := context.Background()
+	bucket := "list-bucket"
+	s.createTestBucket(bucket)
+
+	keys := []string{"photos/a.jpg", "photos/b.jpg", "docs/readme.md", "root.txt"}
+	for _, key := range keys {
+		_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+			Body:   strings.NewReader("x"),
+		})
+		s.Require().NoError(err)
+	}
+
+	// With delimiter
+	out, err := s.client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+		Bucket:    aws.String(bucket),
+		Delimiter: aws.String("/"),
+	})
+	s.Require().NoError(err)
+	s.Len(out.Contents, 1) // root.txt
+	s.Len(out.CommonPrefixes, 2) // docs/, photos/
+
+	// With prefix
+	out, err = s.client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+		Bucket: aws.String(bucket),
+		Prefix: aws.String("photos/"),
+	})
+	s.Require().NoError(err)
+	s.Len(out.Contents, 2)
+
+	// Pagination
+	out, err = s.client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+		Bucket:  aws.String(bucket),
+		MaxKeys: aws.Int32(2),
+	})
+	s.Require().NoError(err)
+	s.Len(out.Contents, 2)
+	s.True(*out.IsTruncated)
+	s.NotNil(out.NextContinuationToken)
+
+	out2, err := s.client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+		Bucket:            aws.String(bucket),
+		ContinuationToken: out.NextContinuationToken,
+	})
+	s.Require().NoError(err)
+	s.Len(out2.Contents, 2)
+}
+
+// --- Copy object ---
+
+func (s *IntegrationSuite) TestCopyObject() {
+	ctx := context.Background()
+	src := "copy-src"
+	dst := "copy-dst"
+	s.createTestBucket(src)
+	s.createTestBucket(dst)
+
+	body := "copy me"
+	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(src),
+		Key:    aws.String("original.txt"),
+		Body:   strings.NewReader(body),
+	})
+	s.Require().NoError(err)
+
+	// Same bucket copy
+	_, err = s.client.CopyObject(ctx, &s3.CopyObjectInput{
+		Bucket:     aws.String(src),
+		Key:        aws.String("copied.txt"),
+		CopySource: aws.String(src + "/original.txt"),
+	})
+	s.Require().NoError(err)
+
+	// Cross bucket copy
+	_, err = s.client.CopyObject(ctx, &s3.CopyObjectInput{
+		Bucket:     aws.String(dst),
+		Key:        aws.String("cross.txt"),
+		CopySource: aws.String(src + "/original.txt"),
+	})
+	s.Require().NoError(err)
+
+	out, err := s.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(dst),
+		Key:    aws.String("cross.txt"),
+	})
+	s.Require().NoError(err)
+	defer out.Body.Close()
+	var buf bytes.Buffer
+	buf.ReadFrom(out.Body)
+	s.Equal(body, buf.String())
+}
+
+// --- Range requests ---
+
+func (s *IntegrationSuite) TestGetObjectRange() {
+	ctx := context.Background()
+	bucket := "range-bucket"
+	s.createTestBucket(bucket)
+
+	body := "0123456789"
+	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("data.txt"),
+		Body:   strings.NewReader(body),
+	})
+	s.Require().NoError(err)
+
+	testCases := []struct {
+		name     string
+		rangeStr string
+		want     string
+	}{
+		{"mid range", "bytes=2-5", "2345"},
+		{"from start", "bytes=0-3", "0123"},
+		{"suffix", "bytes=-3", "789"},
+		{"open end", "bytes=7-", "789"},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			out, err := s.client.GetObject(ctx, &s3.GetObjectInput{
+				Bucket: aws.String(bucket),
+				Key:    aws.String("data.txt"),
+				Range:  aws.String(tc.rangeStr),
+			})
+			s.Require().NoError(err)
+			defer out.Body.Close()
+			var buf bytes.Buffer
+			buf.ReadFrom(out.Body)
+			s.Equal(tc.want, buf.String())
+		})
+	}
+}
+
+// --- Multipart upload ---
+
+func (s *IntegrationSuite) TestMultipartUpload() {
+	ctx := context.Background()
+	bucket := "mp-bucket"
+	s.createTestBucket(bucket)
+
+	// Initiate
+	createOut, err := s.client.CreateMultipartUpload(ctx, &s3.CreateMultipartUploadInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("large.bin"),
+	})
+	s.Require().NoError(err)
+	uploadID := createOut.UploadId
+	s.NotEmpty(*uploadID)
+
+	// Upload parts
+	part1 := strings.Repeat("A", 1024)
+	part2 := strings.Repeat("B", 1024)
+
+	up1, err := s.client.UploadPart(ctx, &s3.UploadPartInput{
+		Bucket:     aws.String(bucket),
+		Key:        aws.String("large.bin"),
+		UploadId:   uploadID,
+		PartNumber: aws.Int32(1),
+		Body:       strings.NewReader(part1),
+	})
+	s.Require().NoError(err)
+
+	up2, err := s.client.UploadPart(ctx, &s3.UploadPartInput{
+		Bucket:     aws.String(bucket),
+		Key:        aws.String("large.bin"),
+		UploadId:   uploadID,
+		PartNumber: aws.Int32(2),
+		Body:       strings.NewReader(part2),
+	})
+	s.Require().NoError(err)
+
+	// Complete
+	_, err = s.client.CompleteMultipartUpload(ctx, &s3.CompleteMultipartUploadInput{
+		Bucket:   aws.String(bucket),
+		Key:      aws.String("large.bin"),
+		UploadId: uploadID,
+		MultipartUpload: &types.CompletedMultipartUpload{
+			Parts: []types.CompletedPart{
+				{PartNumber: aws.Int32(1), ETag: up1.ETag},
+				{PartNumber: aws.Int32(2), ETag: up2.ETag},
+			},
+		},
+	})
+	s.Require().NoError(err)
+
+	// Verify assembled object
+	out, err := s.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("large.bin"),
+	})
+	s.Require().NoError(err)
+	defer out.Body.Close()
+	var buf bytes.Buffer
+	buf.ReadFrom(out.Body)
+	s.Equal(part1+part2, buf.String())
+}
+
+func (s *IntegrationSuite) TestMultipartUploadAbort() {
+	ctx := context.Background()
+	bucket := "mp-abort-bucket"
+	s.createTestBucket(bucket)
+
+	createOut, err := s.client.CreateMultipartUpload(ctx, &s3.CreateMultipartUploadInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("aborted.bin"),
+	})
+	s.Require().NoError(err)
+
+	_, err = s.client.UploadPart(ctx, &s3.UploadPartInput{
+		Bucket:     aws.String(bucket),
+		Key:        aws.String("aborted.bin"),
+		UploadId:   createOut.UploadId,
+		PartNumber: aws.Int32(1),
+		Body:       strings.NewReader("part data"),
+	})
+	s.Require().NoError(err)
+
+	_, err = s.client.AbortMultipartUpload(ctx, &s3.AbortMultipartUploadInput{
+		Bucket:   aws.String(bucket),
+		Key:      aws.String("aborted.bin"),
+		UploadId: createOut.UploadId,
+	})
+	s.Require().NoError(err)
+
+	// Object should not exist
+	_, err = s.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("aborted.bin"),
+	})
+	s.Error(err)
+}
+
+// --- Metadata ---
+
+func (s *IntegrationSuite) TestUserMetadata() {
+	ctx := context.Background()
+	bucket := "meta-bucket"
+	s.createTestBucket(bucket)
+
+	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("meta.txt"),
+		Body:   strings.NewReader("metadata test"),
+		Metadata: map[string]string{
+			"author":  "s2test",
+			"version": "42",
+		},
+	})
+	s.Require().NoError(err)
+
+	out, err := s.client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("meta.txt"),
+	})
+	s.Require().NoError(err)
+	s.Equal("s2test", out.Metadata["author"])
+	s.Equal("42", out.Metadata["version"])
+}
+
+// --- Error cases ---
+
+func (s *IntegrationSuite) TestGetObject_NoSuchBucket() {
+	ctx := context.Background()
+	_, err := s.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String("nonexistent"),
+		Key:    aws.String("file.txt"),
+	})
+	s.Error(err)
+}
+
+func (s *IntegrationSuite) TestGetObject_NoSuchKey() {
+	ctx := context.Background()
+	bucket := "err-bucket"
+	s.createTestBucket(bucket)
+
+	_, err := s.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("missing.txt"),
+	})
+	s.Error(err)
+}
+
+// --- Helpers ---
+
+func (s *IntegrationSuite) createTestBucket(name string) {
+	s.T().Helper()
+	_, err := s.client.CreateBucket(context.Background(), &s3.CreateBucketInput{
+		Bucket: aws.String(name),
+	})
+	s.Require().NoError(err)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -117,17 +117,22 @@ func NewServer(ctx context.Context, cfg *Config) (*Server, error) {
 	}, nil
 }
 
-// Start starts the server.
-func (s *Server) Start() error {
+// Handler builds and returns the HTTP handler without starting a listener.
+func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 	for pattern, handler := range handlers {
 		mux.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
 			handler(s, w, r)
 		})
 	}
+	return mux
+}
+
+// Start starts the server.
+func (s *Server) Start() error {
 	server := &http.Server{
 		Addr:              s.Config.Listen,
-		Handler:           mux,
+		Handler:           s.Handler(),
 		ReadHeaderTimeout: 30 * time.Second,
 	}
 	fmt.Printf("Server listening on %s\n", s.Config.Listen)


### PR DESCRIPTION
- Extract Server.Handler() to enable httptest usage, add integration tests exercising the full S3 API through AWS SDK v2 (skippable via -short)
- add Docker Compose E2E tests using amazon/aws-cli.