### PR TITLE
Update S3 API docs and add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+## Prerequisites
+
+- Go 1.26+
+- Docker (for E2E tests)
+
+## Build
+
+```sh
+make build
+```
+
+## Tests
+
+```sh
+# Unit tests only (fast)
+make test
+
+# Integration tests — starts an in-process HTTP server, exercises S3 API via AWS SDK
+make test-integration
+
+# E2E tests — builds a Docker image, runs AWS CLI against it
+make test-e2e
+```
+
+`make test` uses `-short` to skip integration tests. Running `go test ./...` without `-short` includes them.

--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -72,10 +72,20 @@ Authentication is disabled by default.
 
 | Method | Path | Operation |
 |---|---|---|
-| GET | `/s3api/{bucket}` | ListObjects |
-| GET | `/s3api/{bucket}/{key}` | GetObject |
-| PUT | `/s3api/{bucket}/{key}` | PutObject |
+| GET | `/s3api` | ListBuckets |
+| PUT | `/s3api/{bucket}` | CreateBucket |
+| HEAD | `/s3api/{bucket}` | HeadBucket |
+| DELETE | `/s3api/{bucket}` | DeleteBucket |
+| GET | `/s3api/{bucket}` | ListObjectsV2 |
+| GET | `/s3api/{bucket}/{key}` | GetObject (Range supported) |
+| HEAD | `/s3api/{bucket}/{key}` | HeadObject |
+| PUT | `/s3api/{bucket}/{key}` | PutObject / CopyObject |
 | DELETE | `/s3api/{bucket}/{key}` | DeleteObject |
+| POST | `/s3api/{bucket}?delete` | DeleteObjects |
+| POST | `/s3api/{bucket}/{key}?uploads` | CreateMultipartUpload |
+| PUT | `/s3api/{bucket}/{key}?uploadId&partNumber` | UploadPart |
+| POST | `/s3api/{bucket}/{key}?uploadId` | CompleteMultipartUpload |
+| DELETE | `/s3api/{bucket}/{key}?uploadId` | AbortMultipartUpload |
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -302,11 +302,22 @@ s2-server -f config.json
 | Method | Path | Operation |
 |--------|------|-----------|
 | GET | `/s3api` | ListBuckets |
-| GET | `/s3api/{bucket}` | ListObjects |
-| GET | `/s3api/{bucket}/{key...}` | GetObject |
+| PUT | `/s3api/{bucket}` | CreateBucket |
+| HEAD | `/s3api/{bucket}` | HeadBucket |
+| DELETE | `/s3api/{bucket}` | DeleteBucket |
+| GET | `/s3api/{bucket}?location` | GetBucketLocation |
+| GET | `/s3api/{bucket}` | ListObjectsV2 |
+| GET | `/s3api/{bucket}/{key...}` | GetObject (Range supported) |
 | HEAD | `/s3api/{bucket}/{key...}` | HeadObject |
-| PUT | `/s3api/{bucket}/{key...}` | PutObject |
+| PUT | `/s3api/{bucket}/{key...}` | PutObject / CopyObject |
 | DELETE | `/s3api/{bucket}/{key...}` | DeleteObject |
+| POST | `/s3api/{bucket}?delete` | DeleteObjects |
+| POST | `/s3api/{bucket}/{key...}?uploads` | CreateMultipartUpload |
+| PUT | `/s3api/{bucket}/{key...}?uploadId&partNumber` | UploadPart |
+| POST | `/s3api/{bucket}/{key...}?uploadId` | CompleteMultipartUpload |
+| DELETE | `/s3api/{bucket}/{key...}?uploadId` | AbortMultipartUpload |
+
+Custom metadata is supported via `x-amz-meta-*` headers on PutObject/CopyObject and returned on GetObject/HeadObject.
 
 ## Why S2?
 


### PR DESCRIPTION
- Add missing endpoints (bucket CRUD, DeleteObjects, multipart upload, Range, CopyObject, metadata) to the S3 API tables in README.md and DOCKER_HUB_README.md. 
- Add CONTRIBUTING.md with build and test instructions.