### PR TITLE
Support graceful shutdown on SIGINT/SIGTERM

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -7,8 +7,10 @@ import (
 	"html/template"
 	"net/http"
 	"os"
+	"os/signal"
 	"runtime/debug"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -80,15 +82,15 @@ func Run(args []string) error {
 		return err
 	}
 
-	srv, err := NewServer(context.Background(), cfg)
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	srv, err := NewServer(ctx, cfg)
 	if err != nil {
 		return err
 	}
 	fmt.Printf("Listening on %s\n", cfg.Listen)
-	if err := srv.Start(); err != nil {
-		return err
-	}
-	return nil
+	return srv.Start(ctx)
 }
 
 // Server is a web server that provides a Web Console and S3-compatible API for S2.
@@ -128,15 +130,32 @@ func (s *Server) Handler() http.Handler {
 	return mux
 }
 
-// Start starts the server.
-func (s *Server) Start() error {
-	server := &http.Server{
+// Start starts the server and shuts it down gracefully when ctx is cancelled.
+func (s *Server) Start(ctx context.Context) error {
+	srv := &http.Server{
 		Addr:              s.Config.Listen,
 		Handler:           s.Handler(),
 		ReadHeaderTimeout: 30 * time.Second,
 	}
 	fmt.Printf("Server listening on %s\n", s.Config.Listen)
-	return server.ListenAndServe()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.ListenAndServe()
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		fmt.Println("Shutting down...")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			return fmt.Errorf("shutdown: %w", err)
+		}
+		return nil
+	}
 }
 
 type HandlerFunc func(srv *Server, w http.ResponseWriter, r *http.Request)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"testing"
 	"time"
@@ -112,6 +113,66 @@ func TestRegisterHandleFunc(t *testing.T) {
 		assert.PanicsWithValue(t, "s2: handler already registered for GET /test", func() {
 			RegisterHandleFunc("GET /test", noop)
 		})
+	})
+}
+
+func TestStart(t *testing.T) {
+	t.Run("returns nil on context cancel", func(t *testing.T) {
+		// Pick a free port upfront so we know what to dial
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		addr := ln.Addr().String()
+		ln.Close()
+
+		cfg := DefaultConfig()
+		cfg.Root = t.TempDir()
+		cfg.Listen = addr
+
+		srv, err := NewServer(context.Background(), cfg)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- srv.Start(ctx)
+		}()
+
+		// Wait for server to be listening
+		require.Eventually(t, func() bool {
+			conn, dialErr := net.Dial("tcp", addr)
+			if dialErr != nil {
+				return false
+			}
+			conn.Close()
+			return true
+		}, 3*time.Second, 10*time.Millisecond)
+
+		cancel()
+
+		select {
+		case err := <-errCh:
+			assert.NoError(t, err)
+		case <-time.After(15 * time.Second):
+			t.Fatal("Start did not return after context cancel")
+		}
+	})
+
+	t.Run("returns error on port conflict", func(t *testing.T) {
+		// Occupy a port
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer ln.Close()
+
+		cfg := DefaultConfig()
+		cfg.Root = t.TempDir()
+		cfg.Listen = ln.Addr().String()
+
+		srv, err := NewServer(context.Background(), cfg)
+		require.NoError(t, err)
+
+		err = srv.Start(context.Background())
+		assert.Error(t, err)
 	})
 }
 


### PR DESCRIPTION
Server.Start now accepts a context and shuts down gracefully when the context is cancelled, allowing in-flight requests up to 10s to complete before the server stops.
