### PR TITLE
Replace fmt.Printf logging with log/slog

### DIFF
--- a/server/handlers/buckets/objects/view.go
+++ b/server/handlers/buckets/objects/view.go
@@ -3,6 +3,7 @@ package objects
 import (
 	"fmt"
 	"io"
+	"log/slog"
 	"mime"
 	"net/http"
 	"path"
@@ -68,7 +69,7 @@ func handleView(s *server.Server, w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename=\"%s\"", path.Base(objectName)))
 
 	if _, err := io.Copy(w, rc); err != nil {
-		fmt.Printf("Error copying object content: %v\n", err)
+		slog.Error("Failed to copy object content", "error", err)
 	}
 }
 

--- a/server/handlers/s3api/utils.go
+++ b/server/handlers/s3api/utils.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -27,7 +28,7 @@ func writeXML(w http.ResponseWriter, status int, v interface{}) {
 	fmt.Fprintf(w, xml.Header)
 	enc := xml.NewEncoder(w)
 	if err := enc.Encode(v); err != nil {
-		fmt.Printf("Error encoding XML: %v\n", err)
+		slog.Error("Failed to encode XML", "error", err)
 	}
 }
 

--- a/server/middleware/sigv4.go
+++ b/server/middleware/sigv4.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/xml"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"sort"
@@ -54,7 +55,7 @@ func writeS3AuthError(w http.ResponseWriter, r *http.Request, message string) {
 	fmt.Fprint(w, xml.Header)
 	enc := xml.NewEncoder(w)
 	if err := enc.Encode(resp); err != nil {
-		fmt.Printf("Error encoding XML: %v\n", err)
+		slog.Error("Failed to encode XML", "error", err)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"html/template"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -89,7 +90,7 @@ func Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Listening on %s\n", cfg.Listen)
+	slog.Info("Listening", "addr", cfg.Listen)
 	return srv.Start(ctx)
 }
 
@@ -137,7 +138,7 @@ func (s *Server) Start(ctx context.Context) error {
 		Handler:           s.Handler(),
 		ReadHeaderTimeout: 30 * time.Second,
 	}
-	fmt.Printf("Server listening on %s\n", s.Config.Listen)
+	slog.Info("Server listening", "addr", s.Config.Listen)
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -148,7 +149,7 @@ func (s *Server) Start(ctx context.Context) error {
 	case err := <-errCh:
 		return err
 	case <-ctx.Done():
-		fmt.Println("Shutting down...")
+		slog.Info("Shutting down")
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		if err := srv.Shutdown(shutdownCtx); err != nil {


### PR DESCRIPTION
Use structured logging via slog for all runtime log output (server startup, XML encoding errors, object copy errors). CLI output (version, help) remains as fmt to stderr/stdout.