### PR TITLE
Add /healthz endpoint for container health checks

### DIFF
--- a/server/handlers/healthz.go
+++ b/server/handlers/healthz.go
@@ -1,0 +1,17 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/mojatter/s2/server"
+)
+
+func handleHealthz(_ *server.Server, w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+
+func init() {
+	server.RegisterHandleFunc("GET /healthz", handleHealthz)
+}

--- a/server/handlers/healthz_test.go
+++ b/server/handlers/healthz_test.go
@@ -1,0 +1,35 @@
+package handlers
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mojatter/s2/server"
+)
+
+func TestHandleHealthz(t *testing.T) {
+	cfg := server.DefaultConfig()
+	cfg.Root = t.TempDir()
+	cfg.User = "testuser"
+	cfg.Password = "testpass"
+
+	srv, err := server.NewServer(context.Background(), cfg)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	handleHealthz(srv, w, r)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, "ok", string(body))
+}


### PR DESCRIPTION
Returns 200 OK with no authentication required, suitable for Docker HEALTHCHECK and Kubernetes liveness/readiness probes.