### PR TITLE
Support initial bucket creation on startup

### DIFF
--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -45,6 +45,7 @@ services:
 | `S2_SERVER_ROOT` | `/var/lib/s2` | Root directory for bucket data |
 | `S2_SERVER_USER` | — | Username for authentication (disables auth if empty) |
 | `S2_SERVER_PASSWORD` | — | Password for authentication |
+| `S2_SERVER_BUCKETS` | — | Comma-separated list of buckets to create on startup |
 | `S2_SERVER_CONFIG` | — | Path to JSON config file |
 
 ### Authentication

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# S2 - Simple Storage
+# S2 — Simple Storage
 
 S2 is a lightweight object storage library and S3-compatible server written in Go.
 It provides a unified interface for multiple storage backends and an embeddable S3-compatible server — all in a single package.
@@ -244,8 +244,9 @@ type Storage interface {
 | `S2_SERVER_ROOT` | `/var/lib/s2` | Root directory for bucket data |
 | `S2_SERVER_USER` | — | Username for authentication (disables auth if empty) |
 | `S2_SERVER_PASSWORD` | — | Password for authentication |
+| `S2_SERVER_BUCKETS` | — | Comma-separated list of buckets to create on startup |
 
-`S2_SERVER_LISTEN`, `S2_SERVER_TYPE`, `S2_SERVER_ROOT`, `S2_SERVER_USER`, and `S2_SERVER_PASSWORD` take precedence over the config file.
+Environment variables take precedence over the config file.
 Other settings (such as S3 backend options) are not configurable via environment variables — use `S2_SERVER_CONFIG` to point to a JSON config file instead.
 
 ### Authentication
@@ -289,7 +290,8 @@ When `S2_SERVER_USER` is empty (the default), authentication is disabled.
   "type": "osfs",
   "root": "/var/lib/s2",
   "user": "myuser",
-  "password": "mypassword"
+  "password": "mypassword",
+  "buckets": ["assets", "uploads"]
 }
 ```
 

--- a/server/config.go
+++ b/server/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/mojatter/s2"
 )
@@ -19,6 +20,7 @@ const (
 	EnvS2ServerMaxPreviewSize = "S2_SERVER_MAX_PREVIEW_SIZE"
 	EnvS2ServerUser           = "S2_SERVER_USER"
 	EnvS2ServerPassword       = "S2_SERVER_PASSWORD" // #nosec G101 -- env var name, not a credential
+	EnvS2ServerBuckets        = "S2_SERVER_BUCKETS"
 )
 
 // Config is a configuration for the server.
@@ -35,6 +37,8 @@ type Config struct {
 	User string `json:"user"`
 	// Password is the password for authentication (Basic Auth password for Web Console, Secret Access Key for S3 API).
 	Password string `json:"password"`
+	// Buckets is a list of bucket names to create on startup if they don't already exist.
+	Buckets []string `json:"buckets"`
 }
 
 const (
@@ -94,6 +98,9 @@ func (cfg *Config) LoadEnv() error {
 	}
 	if v := os.Getenv(EnvS2ServerPassword); v != "" {
 		cfg.Password = v
+	}
+	if v := os.Getenv(EnvS2ServerBuckets); v != "" {
+		cfg.Buckets = strings.Split(v, ",")
 	}
 	return nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -90,6 +90,16 @@ func Run(args []string) error {
 	if err != nil {
 		return err
 	}
+	for _, name := range cfg.Buckets {
+		if ok, _ := srv.Buckets.Exists(name); ok {
+			continue
+		}
+		if err := srv.Buckets.Create(ctx, name); err != nil {
+			return fmt.Errorf("create initial bucket %q: %w", name, err)
+		}
+		slog.Info("Created initial bucket", "name", name)
+	}
+
 	slog.Info("Listening", "addr", cfg.Listen)
 	return srv.Start(ctx)
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -176,6 +176,59 @@ func TestStart(t *testing.T) {
 	})
 }
 
+func TestInitBuckets(t *testing.T) {
+	t.Run("creates buckets on startup", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Root = t.TempDir()
+		cfg.Buckets = []string{"alpha", "bravo"}
+
+		srv, err := NewServer(context.Background(), cfg)
+		require.NoError(t, err)
+
+		// Simulate the init-buckets logic from Run
+		for _, name := range cfg.Buckets {
+			if ok, _ := srv.Buckets.Exists(name); !ok {
+				require.NoError(t, srv.Buckets.Create(context.Background(), name))
+			}
+		}
+
+		names, err := srv.Buckets.Names()
+		require.NoError(t, err)
+		assert.Contains(t, names, "alpha")
+		assert.Contains(t, names, "bravo")
+	})
+
+	t.Run("skips existing buckets", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Root = t.TempDir()
+		cfg.Buckets = []string{"existing"}
+
+		srv, err := NewServer(context.Background(), cfg)
+		require.NoError(t, err)
+
+		// Pre-create the bucket
+		require.NoError(t, srv.Buckets.Create(context.Background(), "existing"))
+
+		// Run init logic again — should not error
+		for _, name := range cfg.Buckets {
+			if ok, _ := srv.Buckets.Exists(name); !ok {
+				require.NoError(t, srv.Buckets.Create(context.Background(), name))
+			}
+		}
+
+		names, err := srv.Buckets.Names()
+		require.NoError(t, err)
+		assert.Contains(t, names, "existing")
+	})
+}
+
+func TestLoadEnvBuckets(t *testing.T) {
+	t.Setenv(EnvS2ServerBuckets, "foo,bar,baz")
+	cfg := DefaultConfig()
+	require.NoError(t, cfg.LoadEnv())
+	assert.Equal(t, []string{"foo", "bar", "baz"}, cfg.Buckets)
+}
+
 func TestDefaultConfig(t *testing.T) {
 	testCases := []struct {
 		caseName string


### PR DESCRIPTION
Add S2_SERVER_BUCKETS env var (comma-separated) and "buckets" JSON
config field. Buckets are created on startup if they don't already
exist, removing the need for a separate client like minio/mc.