### PR TITLE
Fix list nonexistent prefix

### DIFF
--- a/fs/storage.go
+++ b/fs/storage.go
@@ -92,22 +92,29 @@ func (s *storage) List(ctx context.Context, prefix string, limit int) ([]s2.Obje
 }
 
 func (s *storage) ListAfter(ctx context.Context, prefix string, limit int, after string) ([]s2.Object, []string, error) {
-	if prefix == "" {
-		prefix = "."
-	}
 	if limit <= 0 {
 		limit = 1000
 	}
-	entries, err := fs.ReadDir(s.fsys, prefix)
+	// Normalize prefix into a directory path acceptable to fs.ReadDir.
+	// S3 callers commonly pass a trailing slash (e.g. "dir/"), which fs.ValidPath rejects.
+	dir := strings.TrimSuffix(prefix, "/")
+	if dir == "" {
+		dir = "."
+	}
+	entries, err := fs.ReadDir(s.fsys, dir)
 	if err != nil {
+		// A non-existent prefix is not an error in S3 semantics; return an empty result.
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil, nil
+		}
 		return nil, nil, fmt.Errorf("failed to read dir: %w", err)
 	}
 	prefixes := make([]string, 0)
 	objs := make([]s2.Object, 0, len(entries))
 	for _, entry := range entries {
 		name := entry.Name()
-		if prefix != "." {
-			name = filepath.Join(prefix, entry.Name())
+		if dir != "." {
+			name = filepath.Join(dir, entry.Name())
 		}
 		if after != "" && name <= after {
 			continue

--- a/s2test/e2e/run.sh
+++ b/s2test/e2e/run.sh
@@ -114,6 +114,23 @@ run_test "MultipartUpload" sh -c '
   [ "$out" = "part1datapart2data" ]
 '
 
+# Listing nonexistent / trailing-slash prefixes (regression for ListAfter bug)
+run_test "ListNonexistentPrefix" sh -c '
+  EP="'"$ENDPOINT"'"
+  out=$(aws s3 --endpoint-url "$EP" ls s3://test-bucket/no-such-dir/ 2>&1)
+  # Should succeed and produce no output
+  [ -z "$out" ]
+'
+
+run_test "ListPrefixWithTrailingSlash" sh -c '
+  EP="'"$ENDPOINT"'"
+  echo -n "x" | aws s3 --endpoint-url "$EP" cp - s3://test-bucket/sub/a.txt
+  echo -n "y" | aws s3 --endpoint-url "$EP" cp - s3://test-bucket/sub/b.txt
+  out=$(aws s3 --endpoint-url "$EP" ls s3://test-bucket/sub/)
+  echo "$out" | grep -q "a.txt"
+  echo "$out" | grep -q "b.txt"
+'
+
 # Cleanup
 run_test "DeleteBucket" sh -c '
   aws s3 --endpoint-url "'"$ENDPOINT"'" rm s3://test-bucket --recursive

--- a/server/handlers/s3api/objects_test.go
+++ b/server/handlers/s3api/objects_test.go
@@ -105,6 +105,56 @@ func (s *ObjectsTestSuite) TestListObjects() {
 		s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &errResp))
 		s.Equal("NoSuchBucket", errResp.Code)
 	})
+
+	s.Run("prefix with trailing slash and delimiter", func() {
+		s.putObject("ts", "dir/a.txt", "a")
+		s.putObject("ts", "dir/b.txt", "b")
+		s.putObject("ts", "other.txt", "x")
+
+		req := httptest.NewRequest("GET", "/s3api/ts?delimiter=/&prefix=dir/", nil)
+		req.SetPathValue("bucket", "ts")
+		w := httptest.NewRecorder()
+		handleListObjects(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		var result ListBucketResult
+		s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &result))
+		s.Len(result.Contents, 2)
+		s.Equal("dir/a.txt", result.Contents[0].Key)
+		s.Equal("dir/b.txt", result.Contents[1].Key)
+	})
+
+	s.Run("nonexistent prefix with delimiter returns empty", func() {
+		s.createBucket("np")
+		s.putObject("np", "real.txt", "x")
+
+		req := httptest.NewRequest("GET", "/s3api/np?delimiter=/&prefix=nope/", nil)
+		req.SetPathValue("bucket", "np")
+		w := httptest.NewRecorder()
+		handleListObjects(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		var result ListBucketResult
+		s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &result))
+		s.Empty(result.Contents)
+		s.Empty(result.CommonPrefixes)
+	})
+
+	s.Run("nonexistent prefix without trailing slash returns empty", func() {
+		s.createBucket("np2")
+		s.putObject("np2", "real.txt", "x")
+
+		req := httptest.NewRequest("GET", "/s3api/np2?delimiter=/&prefix=nope", nil)
+		req.SetPathValue("bucket", "np2")
+		w := httptest.NewRecorder()
+		handleListObjects(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		var result ListBucketResult
+		s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &result))
+		s.Empty(result.Contents)
+		s.Empty(result.CommonPrefixes)
+	})
 }
 
 // --- ListObjects pagination ---


### PR DESCRIPTION
ListAfter passed the prefix straight to fs.ReadDir, which has two
problems for S3 callers:

1. A non-existent prefix returned an fs.ErrNotExist that bubbled up as
   a 500 error. S3 semantics require ListObjectsV2 to return an empty
   result for a prefix that matches nothing.

2. A prefix with a trailing slash (e.g. 'dir/'), which is what
   'aws s3 ls s3://bucket/dir/' sends, was rejected by fs.ValidPath.

Normalize the prefix by trimming the trailing slash before calling
fs.ReadDir, and treat fs.ErrNotExist as an empty result.