### PR TITLE
Support non-directory-aligned prefixes in S3 ListObjectsV2

### DIFF
--- a/s2test/e2e/run.sh
+++ b/s2test/e2e/run.sh
@@ -131,6 +131,27 @@ run_test "ListPrefixWithTrailingSlash" sh -c '
   echo "$out" | grep -q "b.txt"
 '
 
+# Non-directory-aligned S3 prefix matching (e.g. "im" matches "images/")
+run_test "ListPartialPrefixMatchesSubdir" sh -c '
+  EP="'"$ENDPOINT"'"
+  echo -n "1" | aws s3 --endpoint-url "$EP" cp - s3://test-bucket/images/a.png
+  echo -n "2" | aws s3 --endpoint-url "$EP" cp - s3://test-bucket/images/b.png
+  # list-objects-v2 with prefix=im delimiter=/ should return CommonPrefix images/
+  out=$(aws s3api --endpoint-url "$EP" list-objects-v2 \
+    --bucket test-bucket --prefix im --delimiter / \
+    --query "CommonPrefixes[].Prefix" --output text)
+  [ "$out" = "images/" ]
+'
+
+run_test "ListDirAndPartialFilename" sh -c '
+  EP="'"$ENDPOINT"'"
+  # prefix=images/a delimiter=/ should return only images/a.png in Contents
+  out=$(aws s3api --endpoint-url "$EP" list-objects-v2 \
+    --bucket test-bucket --prefix images/a --delimiter / \
+    --query "Contents[].Key" --output text)
+  [ "$out" = "images/a.png" ]
+'
+
 # Cleanup
 run_test "DeleteBucket" sh -c '
   aws s3 --endpoint-url "'"$ENDPOINT"'" rm s3://test-bucket --recursive

--- a/server/handlers/s3api/objects.go
+++ b/server/handlers/s3api/objects.go
@@ -22,6 +22,47 @@ const (
 	defaultMaxKeys  = 1000
 )
 
+// splitS3Prefix splits an S3 prefix at the last "/" so the directory portion
+// can be passed to a directory-oriented List call and the remainder used as a
+// basename filter on the entries.
+//
+//	"images/a"  -> ("images/", "a")
+//	"images/"   -> ("images/", "")
+//	"im"        -> ("",        "im")
+//	""          -> ("",        "")
+func splitS3Prefix(prefix string) (listDir, baseFilter string) {
+	if i := strings.LastIndex(prefix, "/"); i >= 0 {
+		return prefix[:i+1], prefix[i+1:]
+	}
+	return "", prefix
+}
+
+// entryBasename returns the portion of a full key after the listDir, which is
+// the basename of the entry inside the listed directory.
+func entryBasename(key, listDir string) string {
+	return strings.TrimPrefix(key, listDir)
+}
+
+func filterObjectsByBasename(objs []s2.Object, listDir, baseFilter string) []s2.Object {
+	out := objs[:0]
+	for _, obj := range objs {
+		if strings.HasPrefix(entryBasename(obj.Name(), listDir), baseFilter) {
+			out = append(out, obj)
+		}
+	}
+	return out
+}
+
+func filterPrefixesByBasename(prefixes []string, listDir, baseFilter string) []string {
+	out := prefixes[:0]
+	for _, p := range prefixes {
+		if strings.HasPrefix(entryBasename(p, listDir), baseFilter) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
 func handleListObjects(s *server.Server, w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	bucketName := r.PathValue("bucket")
@@ -57,16 +98,26 @@ func handleListObjects(s *server.Server, w http.ResponseWriter, r *http.Request)
 	var objs []s2.Object
 	var prefixes []string
 	if delimiter == "" {
+		// Recursive: ListRecursive already does string-prefix matching, so an
+		// arbitrary S3 prefix (e.g. "im" matching "images/a.png") works as-is.
 		if after != "" {
 			objs, err = strg.ListRecursiveAfter(ctx, prefix, fetchLimit, after)
 		} else {
 			objs, err = strg.ListRecursive(ctx, prefix, fetchLimit)
 		}
 	} else {
+		// Delimited: S3 prefixes are arbitrary strings, but storage.List has
+		// directory semantics. Split the prefix at the last "/" so we list the
+		// directory portion and filter the entries by the remaining basename.
+		listDir, baseFilter := splitS3Prefix(prefix)
 		if after != "" {
-			objs, prefixes, err = strg.ListAfter(ctx, prefix, fetchLimit, after)
+			objs, prefixes, err = strg.ListAfter(ctx, listDir, fetchLimit, after)
 		} else {
-			objs, prefixes, err = strg.List(ctx, prefix, fetchLimit)
+			objs, prefixes, err = strg.List(ctx, listDir, fetchLimit)
+		}
+		if err == nil && baseFilter != "" {
+			objs = filterObjectsByBasename(objs, listDir, baseFilter)
+			prefixes = filterPrefixesByBasename(prefixes, listDir, baseFilter)
 		}
 	}
 	if err != nil {

--- a/server/handlers/s3api/objects_test.go
+++ b/server/handlers/s3api/objects_test.go
@@ -140,6 +140,97 @@ func (s *ObjectsTestSuite) TestListObjects() {
 		s.Empty(result.CommonPrefixes)
 	})
 
+	s.Run("non-directory-aligned prefix with delimiter", func() {
+		s.putObject("nda", "images/a.png", "a")
+		s.putObject("nda", "images/b.png", "b")
+		s.putObject("nda", "docs/c.txt", "c")
+
+		testCases := []struct {
+			caseName       string
+			prefix         string
+			wantContents   []string
+			wantPrefixes   []string
+		}{
+			{
+				caseName:     "partial prefix matches subdir as common prefix",
+				prefix:       "im",
+				wantContents: nil,
+				wantPrefixes: []string{"images/"},
+			},
+			{
+				caseName:     "partial prefix matching nothing",
+				prefix:       "z",
+				wantContents: nil,
+				wantPrefixes: nil,
+			},
+			{
+				caseName:     "directory + partial filename",
+				prefix:       "images/a",
+				wantContents: []string{"images/a.png"},
+				wantPrefixes: nil,
+			},
+			{
+				caseName:     "directory + nonexistent partial filename",
+				prefix:       "images/z",
+				wantContents: nil,
+				wantPrefixes: nil,
+			},
+			{
+				caseName:     "directory with trailing slash lists contents",
+				prefix:       "images/",
+				wantContents: []string{"images/a.png", "images/b.png"},
+				wantPrefixes: nil,
+			},
+		}
+		for _, tc := range testCases {
+			s.Run(tc.caseName, func() {
+				url := "/s3api/nda?delimiter=/&prefix=" + tc.prefix
+				req := httptest.NewRequest("GET", url, nil)
+				req.SetPathValue("bucket", "nda")
+				w := httptest.NewRecorder()
+				handleListObjects(s.server, w, req)
+
+				s.Equal(http.StatusOK, w.Code)
+				var result ListBucketResult
+				s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &result))
+
+				gotContents := make([]string, len(result.Contents))
+				for i, c := range result.Contents {
+					gotContents[i] = c.Key
+				}
+				gotPrefixes := make([]string, len(result.CommonPrefixes))
+				for i, p := range result.CommonPrefixes {
+					gotPrefixes[i] = p.Prefix
+				}
+				if len(gotContents) == 0 {
+					gotContents = nil
+				}
+				if len(gotPrefixes) == 0 {
+					gotPrefixes = nil
+				}
+				s.Equal(tc.wantContents, gotContents)
+				s.Equal(tc.wantPrefixes, gotPrefixes)
+			})
+		}
+	})
+
+	s.Run("non-directory-aligned prefix without delimiter (recursive)", func() {
+		s.putObject("ndr", "images/a.png", "a")
+		s.putObject("ndr", "images/b.png", "b")
+
+		req := httptest.NewRequest("GET", "/s3api/ndr?prefix=im", nil)
+		req.SetPathValue("bucket", "ndr")
+		w := httptest.NewRecorder()
+		handleListObjects(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		var result ListBucketResult
+		s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &result))
+		s.Len(result.Contents, 2)
+		s.Equal("images/a.png", result.Contents[0].Key)
+		s.Equal("images/b.png", result.Contents[1].Key)
+	})
+
 	s.Run("nonexistent prefix without trailing slash returns empty", func() {
 		s.createBucket("np2")
 		s.putObject("np2", "real.txt", "x")


### PR DESCRIPTION
S3 prefixes are arbitrary strings, not directory paths. Previously the S3 handler passed the prefix straight to storage.List, which has directory semantics, so requests like 'prefix=im delimiter=/' did not match a real S3 sibling 'images/' (and prefix='images/a' did not match the file 'images/a.png').

Split the S3 prefix at the last '/' in the handler: list the directory portion via storage.List and post-filter the entries by the basename remainder. The recursive (no-delimiter) path already does string-prefix matching via ListRecursive and is unchanged.

storage.List keeps its directory semantics, which the Web Console and the Go library users continue to rely on.