### PR TITLE
Run e2e tests in CI

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,34 @@
+name: E2E
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+  workflow_call:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Run E2E tests
+        run: |
+          docker compose -f s2test/e2e/docker-compose.yml up \
+            --build \
+            --abort-on-container-exit \
+            --exit-code-from test
+      -
+        name: Show s2 logs on failure
+        if: failure()
+        run: docker compose -f s2test/e2e/docker-compose.yml logs s2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,8 +9,13 @@ jobs:
   tests:
     uses: ./.github/workflows/tests.yaml
 
+  e2e:
+    uses: ./.github/workflows/e2e.yaml
+
   release:
-    needs: tests
+    needs:
+      - tests
+      - e2e
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Add a new \`.github/workflows/e2e.yaml\` that runs the docker-compose-based aws-cli test suite under \`s2test/e2e\` on every PR and push to \`main\`/\`develop\`.
- Wire e2e into \`release.yaml\` so tagged releases require both unit tests and e2e to pass before publishing.
- On failure, dump \`s2\` container logs to make CI debugging easier.

## Test plan
- [ ] CI green on this PR (validates the workflow itself runs the e2e suite)
- [ ] Manual: \`cd s2test/e2e && docker compose up --build --abort-on-container-exit --exit-code-from test\` still passes locally