### PR TITLE
feat(sigv4): support presigned URL (query-string) authentication

### DIFF
--- a/server/middleware/sigv4.go
+++ b/server/middleware/sigv4.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -32,7 +33,15 @@ func SigV4(next server.HandlerFunc) server.HandlerFunc {
 			next(srv, w, r)
 			return
 		}
-		if err := verifySignatureV4(r, srv.Config.User, srv.Config.Password); err != nil {
+		// AWS prefers the Authorization header when both are present.
+		// Fall back to query-string (presigned URL) verification when the header is absent.
+		var err error
+		if r.Header.Get("Authorization") == "" && r.URL.Query().Get("X-Amz-Algorithm") != "" {
+			err = verifyPresignedV4(r, srv.Config.User, srv.Config.Password, time.Now().UTC())
+		} else {
+			err = verifySignatureV4(r, srv.Config.User, srv.Config.Password)
+		}
+		if err != nil {
 			writeS3AuthError(w, r, err.Error())
 			return
 		}
@@ -124,6 +133,84 @@ func verifySignatureV4(r *http.Request, accessKeyID, secretAccessKey string) err
 		return fmt.Errorf("signature mismatch")
 	}
 	return nil
+}
+
+// verifyPresignedV4 verifies an AWS Signature Version 4 presigned URL request.
+// The signature is carried in query parameters (X-Amz-*) instead of the Authorization header,
+// and the body is treated as UNSIGNED-PAYLOAD per the presigned-URL spec.
+func verifyPresignedV4(r *http.Request, accessKeyID, secretAccessKey string, now time.Time) error {
+	q := r.URL.Query()
+	if algo := q.Get("X-Amz-Algorithm"); algo != "AWS4-HMAC-SHA256" {
+		return fmt.Errorf("unsupported X-Amz-Algorithm: %q", algo)
+	}
+	credential := q.Get("X-Amz-Credential")
+	datetime := q.Get("X-Amz-Date")
+	expiresStr := q.Get("X-Amz-Expires")
+	signedHeadersStr := q.Get("X-Amz-SignedHeaders")
+	signature := q.Get("X-Amz-Signature")
+	if credential == "" || datetime == "" || expiresStr == "" || signedHeadersStr == "" || signature == "" {
+		return fmt.Errorf("missing presigned query parameters")
+	}
+
+	// Credential = <access-key>/<date>/<region>/<service>/aws4_request
+	credParts := strings.SplitN(credential, "/", 5)
+	if len(credParts) != 5 {
+		return fmt.Errorf("malformed Credential")
+	}
+	reqAccessKey := credParts[0]
+	date := credParts[1]
+	region := credParts[2]
+	service := credParts[3]
+
+	if subtle.ConstantTimeCompare([]byte(reqAccessKey), []byte(accessKeyID)) != 1 {
+		return fmt.Errorf("invalid access key")
+	}
+
+	reqTime, err := time.Parse("20060102T150405Z", datetime)
+	if err != nil {
+		return fmt.Errorf("invalid X-Amz-Date: %w", err)
+	}
+	expires, err := strconv.Atoi(expiresStr)
+	if err != nil || expires <= 0 {
+		return fmt.Errorf("invalid X-Amz-Expires: %q", expiresStr)
+	}
+	if now.After(reqTime.Add(time.Duration(expires) * time.Second)) {
+		return fmt.Errorf("presigned URL expired")
+	}
+
+	signedHeaders := strings.Split(signedHeadersStr, ";")
+	// X-Amz-Signature must be excluded from the canonical query string.
+	filteredQuery := stripQueryParam(r.URL.RawQuery, "X-Amz-Signature")
+	canonReq := buildCanonicalRequest(r, signedHeaders, filteredQuery, "UNSIGNED-PAYLOAD")
+
+	scope := date + "/" + region + "/" + service + "/aws4_request"
+	stringToSign := "AWS4-HMAC-SHA256\n" + datetime + "\n" + scope + "\n" + hashSHA256(canonReq)
+
+	signingKey := buildSigningKey(secretAccessKey, date, region, service)
+	expected := hex.EncodeToString(hmacSHA256(signingKey, []byte(stringToSign)))
+
+	if subtle.ConstantTimeCompare([]byte(expected), []byte(signature)) != 1 {
+		return fmt.Errorf("signature mismatch")
+	}
+	return nil
+}
+
+// stripQueryParam removes all occurrences of name from a raw (unparsed) query string,
+// preserving the order and exact encoding of the remaining parameters.
+func stripQueryParam(rawQuery, name string) string {
+	if rawQuery == "" {
+		return ""
+	}
+	prefix := name + "="
+	parts := strings.Split(rawQuery, "&")
+	out := parts[:0]
+	for _, p := range parts {
+		if p == name || strings.HasPrefix(p, prefix) {
+			continue
+		}
+		out = append(out, p)
+	}
+	return strings.Join(out, "&")
 }
 
 func parseAuthHeader(s string) map[string]string {

--- a/server/middleware/sigv4_test.go
+++ b/server/middleware/sigv4_test.go
@@ -13,6 +13,40 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// presignRequest rewrites r.URL.RawQuery to embed AWS SigV4 presigned-URL parameters.
+// expires is the validity window in seconds.
+func presignRequest(r *http.Request, accessKey, secretKey string, expires int) {
+	presignRequestAt(r, accessKey, secretKey, expires, time.Now().UTC())
+}
+
+// presignRequestAt is like presignRequest but uses the supplied time as X-Amz-Date.
+func presignRequestAt(r *http.Request, accessKey, secretKey string, expires int, now time.Time) {
+	date := now.Format("20060102")
+	datetime := now.Format("20060102T150405Z")
+	const region, service = "us-east-1", "s3"
+	if r.Host == "" {
+		r.Host = "localhost:9000"
+	}
+	signedHeaders := []string{"host"}
+	scope := date + "/" + region + "/" + service + "/aws4_request"
+
+	q := r.URL.Query()
+	q.Set("X-Amz-Algorithm", "AWS4-HMAC-SHA256")
+	q.Set("X-Amz-Credential", accessKey+"/"+scope)
+	q.Set("X-Amz-Date", datetime)
+	q.Set("X-Amz-Expires", fmt.Sprintf("%d", expires))
+	q.Set("X-Amz-SignedHeaders", strings.Join(signedHeaders, ";"))
+	r.URL.RawQuery = q.Encode()
+
+	canonReq := buildCanonicalRequest(r, signedHeaders, r.URL.RawQuery, "UNSIGNED-PAYLOAD")
+	stringToSign := "AWS4-HMAC-SHA256\n" + datetime + "\n" + scope + "\n" + hashSHA256(canonReq)
+	signingKey := buildSigningKey(secretKey, date, region, service)
+	sig := hex.EncodeToString(hmacSHA256(signingKey, []byte(stringToSign)))
+
+	q.Set("X-Amz-Signature", sig)
+	r.URL.RawQuery = q.Encode()
+}
+
 // signRequest adds AWS Signature V4 headers to r signed at the current time.
 func signRequest(r *http.Request, accessKey, secretKey string) {
 	signRequestAt(r, accessKey, secretKey, time.Now().UTC())
@@ -121,6 +155,134 @@ func TestSigV4(t *testing.T) {
 			handler(srv, w, r)
 
 			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
+}
+
+func TestSigV4Presigned(t *testing.T) {
+	const user, pass = "minioadmin", "minioadmin"
+	testCases := []struct {
+		caseName   string
+		method     string
+		setup      func(r *http.Request)
+		wantStatus int
+	}{
+		{
+			caseName: "valid presigned GET",
+			method:   http.MethodGet,
+			setup: func(r *http.Request) {
+				presignRequest(r, user, pass, 300)
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			caseName: "valid presigned PUT",
+			method:   http.MethodPut,
+			setup: func(r *http.Request) {
+				presignRequest(r, user, pass, 300)
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			caseName: "expired presigned URL",
+			method:   http.MethodGet,
+			setup: func(r *http.Request) {
+				presignRequestAt(r, user, pass, 60, time.Now().UTC().Add(-2*time.Minute))
+			},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			caseName: "tampered signature",
+			method:   http.MethodGet,
+			setup: func(r *http.Request) {
+				presignRequest(r, user, pass, 300)
+				q := r.URL.Query()
+				q.Set("X-Amz-Signature", strings.Repeat("0", 64))
+				r.URL.RawQuery = q.Encode()
+			},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			caseName: "wrong access key",
+			method:   http.MethodGet,
+			setup: func(r *http.Request) {
+				presignRequest(r, "wrongkey", pass, 300)
+			},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			caseName: "wrong secret key",
+			method:   http.MethodGet,
+			setup: func(r *http.Request) {
+				presignRequest(r, user, "wrongsecret", 300)
+			},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			caseName: "missing X-Amz-Signature",
+			method:   http.MethodGet,
+			setup: func(r *http.Request) {
+				presignRequest(r, user, pass, 300)
+				q := r.URL.Query()
+				q.Del("X-Amz-Signature")
+				r.URL.RawQuery = q.Encode()
+			},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			caseName: "header takes precedence over query",
+			method:   http.MethodGet,
+			setup: func(r *http.Request) {
+				// Presigned query is invalid (signature missing) but a valid Authorization header is present.
+				presignRequest(r, user, pass, 300)
+				q := r.URL.Query()
+				q.Set("X-Amz-Signature", strings.Repeat("0", 64))
+				r.URL.RawQuery = q.Encode()
+				signRequest(r, user, pass)
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			caseName: "extra query parameter included in signature",
+			method:   http.MethodGet,
+			setup: func(r *http.Request) {
+				r.URL.RawQuery = "prefix=foo/bar&max-keys=10"
+				presignRequest(r, user, pass, 300)
+			},
+			wantStatus: http.StatusOK,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			srv := &server.Server{Config: &server.Config{User: user, Password: pass}}
+			handler := SigV4(noopHandler)
+
+			r := httptest.NewRequest(tc.method, "/s3api/bucket/key", nil)
+			tc.setup(r)
+			w := httptest.NewRecorder()
+			handler(srv, w, r)
+
+			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
+}
+
+func TestStripQueryParam(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		raw      string
+		name     string
+		want     string
+	}{
+		{caseName: "empty", raw: "", name: "X-Amz-Signature", want: ""},
+		{caseName: "only target", raw: "X-Amz-Signature=abc", name: "X-Amz-Signature", want: ""},
+		{caseName: "target at end", raw: "a=1&X-Amz-Signature=abc", name: "X-Amz-Signature", want: "a=1"},
+		{caseName: "target in middle", raw: "a=1&X-Amz-Signature=abc&b=2", name: "X-Amz-Signature", want: "a=1&b=2"},
+		{caseName: "target absent", raw: "a=1&b=2", name: "X-Amz-Signature", want: "a=1&b=2"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			assert.Equal(t, tc.want, stripQueryParam(tc.raw, tc.name))
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- Add `verifyPresignedV4` to validate AWS SigV4 requests whose signature is carried in `X-Amz-*` query parameters instead of the `Authorization` header.
- Treat the body as `UNSIGNED-PAYLOAD` per the presigned URL spec, and exclude `X-Amz-Signature` from the canonical query string.
- `SigV4` middleware dispatches to header- or query-mode based on which is present. Header wins when both are supplied, matching AWS behavior.
- Add `stripQueryParam` helper and table-driven tests covering: valid GET/PUT, expired URL, tampered signature, wrong access/secret key, missing signature, header precedence, extra query params.

## Stacked on
anthropics/claude-code#22 (PR-A: refactor). Merge PR-A first.

## Why
Before this PR, presigned URLs generated by `s3.getSignedUrl` / `PresignClient` produced valid-looking URLs, but hitting them returned `403 SignatureDoesNotMatch` because the middleware only inspected the `Authorization` header.

## Test plan
- [x] `go test ./server/middleware/...` — 9 new presigned cases pass
- [x] `go test ./...`
- [x] `golangci-lint run ./...`