### PR TITLE
test(s3api): cover presigned URL GET/PUT via AWS SDK PresignClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,8 @@ aws --profile s2 s3 ls
 
 When `S2_SERVER_USER` is empty (the default), authentication is disabled.
 
+**Presigned URLs** — S2 verifies AWS SigV4 signatures passed in the query string (`X-Amz-Algorithm=AWS4-HMAC-SHA256`, `X-Amz-Signature`, …), so URLs produced by `s3.NewPresignClient` (Go) or `s3.getSignedUrl` (JavaScript) work for GET and PUT. The body of a presigned PUT is treated as `UNSIGNED-PAYLOAD`.
+
 ### Config File
 
 ```json

--- a/s2test/e2e/run.sh
+++ b/s2test/e2e/run.sh
@@ -152,6 +152,23 @@ run_test "ListDirAndPartialFilename" sh -c '
   [ "$out" = "images/a.png" ]
 '
 
+# Presigned URL (query-string SigV4)
+run_test "PresignedGetObject" sh -c '
+  EP="'"$ENDPOINT"'"
+  echo -n "presigned body" | aws s3 --endpoint-url "$EP" cp - s3://test-bucket/presigned.txt
+  url=$(aws s3 presign --endpoint-url "$EP" s3://test-bucket/presigned.txt --expires-in 300)
+  out=$(curl -sS -f "$url")
+  [ "$out" = "presigned body" ]
+'
+
+run_test "PresignedGetObject_TamperedSignatureRejected" sh -c '
+  EP="'"$ENDPOINT"'"
+  url=$(aws s3 presign --endpoint-url "$EP" s3://test-bucket/presigned.txt --expires-in 300)
+  tampered=$(echo "$url" | sed "s/X-Amz-Signature=[0-9a-f]*/X-Amz-Signature=deadbeef/")
+  status=$(curl -sS -o /dev/null -w "%{http_code}" "$tampered")
+  [ "$status" = "403" ]
+'
+
 # Cleanup
 run_test "DeleteBucket" sh -c '
   aws s3 --endpoint-url "'"$ENDPOINT"'" rm s3://test-bucket --recursive

--- a/server/handlers/s3api/integration_test.go
+++ b/server/handlers/s3api/integration_test.go
@@ -3,9 +3,12 @@ package s3api
 import (
 	"bytes"
 	"context"
+	"io"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -511,6 +514,96 @@ func (s *IntegrationSuite) TestGetObject_NoSuchKey() {
 		Key:    aws.String("missing.txt"),
 	})
 	s.Error(err)
+}
+
+// --- Presigned URL ---
+
+func (s *IntegrationSuite) TestPresignedGetObject() {
+	ctx := context.Background()
+	bucket := "presign-get-bucket"
+	s.createTestBucket(bucket)
+
+	body := "presigned download"
+	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("file.txt"),
+		Body:   strings.NewReader(body),
+	})
+	s.Require().NoError(err)
+
+	presigner := s3.NewPresignClient(s.client)
+	req, err := presigner.PresignGetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("file.txt"),
+	}, s3.WithPresignExpires(5*time.Minute))
+	s.Require().NoError(err)
+
+	resp, err := http.Get(req.URL)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	s.Equal(http.StatusOK, resp.StatusCode)
+	got, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+	s.Equal(body, string(got))
+}
+
+func (s *IntegrationSuite) TestPresignedPutObject() {
+	ctx := context.Background()
+	bucket := "presign-put-bucket"
+	s.createTestBucket(bucket)
+
+	presigner := s3.NewPresignClient(s.client)
+	req, err := presigner.PresignPutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("uploaded.txt"),
+	}, s3.WithPresignExpires(5*time.Minute))
+	s.Require().NoError(err)
+
+	body := "uploaded via presigned URL"
+	httpReq, err := http.NewRequest(http.MethodPut, req.URL, strings.NewReader(body))
+	s.Require().NoError(err)
+	resp, err := http.DefaultClient.Do(httpReq)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	s.Equal(http.StatusOK, resp.StatusCode)
+
+	// Verify via the SDK client
+	out, err := s.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("uploaded.txt"),
+	})
+	s.Require().NoError(err)
+	defer out.Body.Close()
+	got, err := io.ReadAll(out.Body)
+	s.Require().NoError(err)
+	s.Equal(body, string(got))
+}
+
+func (s *IntegrationSuite) TestPresignedGetObject_TamperedSignatureRejected() {
+	ctx := context.Background()
+	bucket := "presign-tamper-bucket"
+	s.createTestBucket(bucket)
+
+	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("file.txt"),
+		Body:   strings.NewReader("secret"),
+	})
+	s.Require().NoError(err)
+
+	presigner := s3.NewPresignClient(s.client)
+	req, err := presigner.PresignGetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("file.txt"),
+	}, s3.WithPresignExpires(5*time.Minute))
+	s.Require().NoError(err)
+
+	// Tamper: replace the signature with an obvious bad value.
+	tampered := strings.Replace(req.URL, "X-Amz-Signature=", "X-Amz-Signature=deadbeef&_=", 1)
+	resp, err := http.Get(tampered)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	s.Equal(http.StatusForbidden, resp.StatusCode)
 }
 
 // --- Helpers ---


### PR DESCRIPTION
## Summary
- Add three integration tests that exercise the presigned URL flow end-to-end: the AWS SDK generates the URL via `s3.NewPresignClient`, a plain `net/http` client issues the request, and the server validates the query-mode SigV4 signature.
- Cases: presigned GET, presigned PUT (UNSIGNED-PAYLOAD), tampered-signature rejection.
- Update README to document presigned URL support under the Authentication section.

## Stacked on
mojatter/s2#23 (PR-B: presigned verification). Merge that first.

## Why
PR-B has unit tests for the signature logic, but the highest-value regression guard is "does a URL generated by the real AWS SDK actually work against the real server handler?". This PR adds that.

## Test plan
- [x] `go test ./server/handlers/s3api/... -run TestIntegration/TestPresigned`
- [x] `go test ./...`
- [x] `golangci-lint run ./...`