### PR TITLE
feat(server): conservative default upload limit for memfs (16 MiB)

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -28,7 +28,11 @@ type Config struct {
 	s2.Config
 	// Listen is the address to listen on.
 	Listen string `json:"listen"`
-	// MaxUploadSize is the maximum upload size in bytes (0 = default 5GB).
+	// MaxUploadSize is the maximum upload size in bytes. When 0, a backend-specific
+	// default is used (see EffectiveMaxUploadSize): 5 GiB for osfs/s3, 16 MiB for
+	// memfs. The conservative memfs default protects the host from accidental
+	// OOM when a large upload targets the in-memory backend; set an explicit
+	// value here to override.
 	MaxUploadSize int64 `json:"max_upload_size"`
 	// MaxPreviewSize is the maximum file size for text preview in bytes (0 = default 10MB).
 	MaxPreviewSize int64 `json:"max_preview_size"`
@@ -42,9 +46,24 @@ type Config struct {
 }
 
 const (
-	DefaultMaxUploadSize  = 5 << 30  // 5GB
-	DefaultMaxPreviewSize = 10 << 20 // 10MB
+	DefaultMaxUploadSize      = 5 << 30  // 5 GiB — default for osfs/s3 backends.
+	DefaultMemfsMaxUploadSize = 16 << 20 // 16 MiB — conservative default for the in-memory backend.
+	DefaultMaxPreviewSize     = 10 << 20 // 10 MiB
 )
+
+// EffectiveMaxUploadSize returns the upload size limit to enforce for this
+// configuration. When MaxUploadSize is explicitly set (> 0) it is returned
+// as-is; otherwise a backend-specific default is chosen so that switching
+// Type to memfs does not silently inherit the 5 GiB default.
+func (cfg *Config) EffectiveMaxUploadSize() int64 {
+	if cfg.MaxUploadSize > 0 {
+		return cfg.MaxUploadSize
+	}
+	if cfg.Type == s2.TypeMemFS {
+		return DefaultMemfsMaxUploadSize
+	}
+	return DefaultMaxUploadSize
+}
 
 func DefaultConfig() *Config {
 	return &Config{
@@ -52,8 +71,9 @@ func DefaultConfig() *Config {
 			Type: s2.TypeOSFS,
 			Root: "/var/lib/s2",
 		},
-		Listen:         ":9000",
-		MaxUploadSize:  DefaultMaxUploadSize,
+		Listen: ":9000",
+		// MaxUploadSize intentionally left 0 — EffectiveMaxUploadSize resolves
+		// a backend-appropriate default at request time.
 		MaxPreviewSize: DefaultMaxPreviewSize,
 	}
 }

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -1,0 +1,86 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mojatter/s2"
+)
+
+func TestLoadEnvBuckets(t *testing.T) {
+	t.Setenv(EnvS2ServerBuckets, "foo,bar,baz")
+	cfg := DefaultConfig()
+	require.NoError(t, cfg.LoadEnv())
+	assert.Equal(t, []string{"foo", "bar", "baz"}, cfg.Buckets)
+}
+
+func TestDefaultConfig(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		field    string
+		got      any
+		want     any
+	}{
+		{caseName: "listen", field: "Listen", got: DefaultConfig().Listen, want: ":9000"},
+		{caseName: "type", field: "Type", got: string(DefaultConfig().Type), want: "osfs"},
+		{caseName: "root", field: "Root", got: DefaultConfig().Root, want: "/var/lib/s2"},
+		// MaxUploadSize is intentionally 0 in DefaultConfig; EffectiveMaxUploadSize resolves a backend-specific default.
+		{caseName: "max upload size", field: "MaxUploadSize", got: DefaultConfig().MaxUploadSize, want: int64(0)},
+		{caseName: "effective max upload size (osfs)", field: "EffectiveMaxUploadSize", got: DefaultConfig().EffectiveMaxUploadSize(), want: int64(5 << 30)},
+		{caseName: "max preview size", field: "MaxPreviewSize", got: DefaultConfig().MaxPreviewSize, want: int64(10 << 20)},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.got)
+		})
+	}
+}
+
+func TestEffectiveMaxUploadSize(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		cfg      *Config
+		want     int64
+	}{
+		{
+			caseName: "osfs default",
+			cfg:      DefaultConfig(),
+			want:     DefaultMaxUploadSize,
+		},
+		{
+			caseName: "memfs default",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.Type = s2.TypeMemFS
+				return c
+			}(),
+			want: DefaultMemfsMaxUploadSize,
+		},
+		{
+			caseName: "explicit override on memfs",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.Type = s2.TypeMemFS
+				c.MaxUploadSize = 1 << 30
+				return c
+			}(),
+			want: 1 << 30,
+		},
+		{
+			caseName: "explicit override on osfs",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.MaxUploadSize = 123
+				return c
+			}(),
+			want: 123,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.cfg.EffectiveMaxUploadSize())
+		})
+	}
+}

--- a/server/handlers/buckets/objects.go
+++ b/server/handlers/buckets/objects.go
@@ -139,7 +139,7 @@ func handleUploadFile(s *server.Server, w http.ResponseWriter, r *http.Request) 
 	prefix := r.FormValue("prefix")
 
 	// Enforce upload size limit
-	maxSize := s.Config.MaxUploadSize
+	maxSize := s.Config.EffectiveMaxUploadSize()
 	r.Body = http.MaxBytesReader(w, r.Body, maxSize)
 
 	file, header, err := r.FormFile("file")

--- a/server/handlers/s3api/multipart.go
+++ b/server/handlers/s3api/multipart.go
@@ -96,7 +96,7 @@ func handleUploadPart(s *server.Server, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	maxSize := s.Config.MaxUploadSize
+	maxSize := s.Config.EffectiveMaxUploadSize()
 	r.Body = http.MaxBytesReader(w, r.Body, maxSize)
 
 	data, err := io.ReadAll(unwrapAWSChunkedBody(r))

--- a/server/handlers/s3api/objects.go
+++ b/server/handlers/s3api/objects.go
@@ -321,7 +321,7 @@ func handlePutObject(s *server.Server, w http.ResponseWriter, r *http.Request) {
 	key := r.PathValue("key")
 
 	// Enforce upload size limit
-	maxSize := s.Config.MaxUploadSize
+	maxSize := s.Config.EffectiveMaxUploadSize()
 	if r.ContentLength > maxSize {
 		writeError(w, r, "EntityTooLarge", fmt.Sprintf("Your proposed upload exceeds the maximum allowed size (%d bytes)", maxSize), http.StatusBadRequest)
 		return

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/mojatter/s2"
 )
 
 func TestInitFlags(t *testing.T) {
@@ -239,12 +241,61 @@ func TestDefaultConfig(t *testing.T) {
 		{caseName: "listen", field: "Listen", got: DefaultConfig().Listen, want: ":9000"},
 		{caseName: "type", field: "Type", got: string(DefaultConfig().Type), want: "osfs"},
 		{caseName: "root", field: "Root", got: DefaultConfig().Root, want: "/var/lib/s2"},
-		{caseName: "max upload size", field: "MaxUploadSize", got: DefaultConfig().MaxUploadSize, want: int64(5 << 30)},
+		// MaxUploadSize is intentionally 0 in DefaultConfig; EffectiveMaxUploadSize resolves a backend-specific default.
+		{caseName: "max upload size", field: "MaxUploadSize", got: DefaultConfig().MaxUploadSize, want: int64(0)},
+		{caseName: "effective max upload size (osfs)", field: "EffectiveMaxUploadSize", got: DefaultConfig().EffectiveMaxUploadSize(), want: int64(5 << 30)},
 		{caseName: "max preview size", field: "MaxPreviewSize", got: DefaultConfig().MaxPreviewSize, want: int64(10 << 20)},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.caseName, func(t *testing.T) {
 			assert.Equal(t, tc.want, tc.got)
+		})
+	}
+}
+
+func TestEffectiveMaxUploadSize(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		cfg      *Config
+		want     int64
+	}{
+		{
+			caseName: "osfs default",
+			cfg:      DefaultConfig(),
+			want:     DefaultMaxUploadSize,
+		},
+		{
+			caseName: "memfs default",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.Type = s2.TypeMemFS
+				return c
+			}(),
+			want: DefaultMemfsMaxUploadSize,
+		},
+		{
+			caseName: "explicit override on memfs",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.Type = s2.TypeMemFS
+				c.MaxUploadSize = 1 << 30
+				return c
+			}(),
+			want: 1 << 30,
+		},
+		{
+			caseName: "explicit override on osfs",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.MaxUploadSize = 123
+				return c
+			}(),
+			want: 123,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.cfg.EffectiveMaxUploadSize())
 		})
 	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/mojatter/s2"
 )
 
 func TestInitFlags(t *testing.T) {
@@ -224,78 +222,3 @@ func TestInitBuckets(t *testing.T) {
 	})
 }
 
-func TestLoadEnvBuckets(t *testing.T) {
-	t.Setenv(EnvS2ServerBuckets, "foo,bar,baz")
-	cfg := DefaultConfig()
-	require.NoError(t, cfg.LoadEnv())
-	assert.Equal(t, []string{"foo", "bar", "baz"}, cfg.Buckets)
-}
-
-func TestDefaultConfig(t *testing.T) {
-	testCases := []struct {
-		caseName string
-		field    string
-		got      any
-		want     any
-	}{
-		{caseName: "listen", field: "Listen", got: DefaultConfig().Listen, want: ":9000"},
-		{caseName: "type", field: "Type", got: string(DefaultConfig().Type), want: "osfs"},
-		{caseName: "root", field: "Root", got: DefaultConfig().Root, want: "/var/lib/s2"},
-		// MaxUploadSize is intentionally 0 in DefaultConfig; EffectiveMaxUploadSize resolves a backend-specific default.
-		{caseName: "max upload size", field: "MaxUploadSize", got: DefaultConfig().MaxUploadSize, want: int64(0)},
-		{caseName: "effective max upload size (osfs)", field: "EffectiveMaxUploadSize", got: DefaultConfig().EffectiveMaxUploadSize(), want: int64(5 << 30)},
-		{caseName: "max preview size", field: "MaxPreviewSize", got: DefaultConfig().MaxPreviewSize, want: int64(10 << 20)},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.caseName, func(t *testing.T) {
-			assert.Equal(t, tc.want, tc.got)
-		})
-	}
-}
-
-func TestEffectiveMaxUploadSize(t *testing.T) {
-	testCases := []struct {
-		caseName string
-		cfg      *Config
-		want     int64
-	}{
-		{
-			caseName: "osfs default",
-			cfg:      DefaultConfig(),
-			want:     DefaultMaxUploadSize,
-		},
-		{
-			caseName: "memfs default",
-			cfg: func() *Config {
-				c := DefaultConfig()
-				c.Type = s2.TypeMemFS
-				return c
-			}(),
-			want: DefaultMemfsMaxUploadSize,
-		},
-		{
-			caseName: "explicit override on memfs",
-			cfg: func() *Config {
-				c := DefaultConfig()
-				c.Type = s2.TypeMemFS
-				c.MaxUploadSize = 1 << 30
-				return c
-			}(),
-			want: 1 << 30,
-		},
-		{
-			caseName: "explicit override on osfs",
-			cfg: func() *Config {
-				c := DefaultConfig()
-				c.MaxUploadSize = 123
-				return c
-			}(),
-			want: 123,
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.caseName, func(t *testing.T) {
-			assert.Equal(t, tc.want, tc.cfg.EffectiveMaxUploadSize())
-		})
-	}
-}


### PR DESCRIPTION
## Summary
- Add `DefaultMemfsMaxUploadSize = 16 MiB` alongside the existing `DefaultMaxUploadSize = 5 GiB`.
- Introduce `Config.EffectiveMaxUploadSize()`: returns the explicit `MaxUploadSize` when set (> 0), otherwise a backend-appropriate default — 16 MiB for `memfs`, 5 GiB for everything else.
- `DefaultConfig()` now leaves `MaxUploadSize` at 0 (meaning "auto"); handlers call `EffectiveMaxUploadSize()` so they always see a resolved value.
- Users who genuinely want larger uploads against memfs can still opt in by setting `S2_SERVER_MAX_UPLOAD_SIZE` or `Config.MaxUploadSize` explicitly.

## Why
Before this PR, switching the backend to `memfs` (e.g. via `S2_SERVER_TYPE=memfs`) silently inherited the 5 GiB default. One stray large upload could OOM the process. Since `memfs` is explicitly positioned as a test/dev backend, a conservative default is safer and more surprising to disable than to accept.

## Base
This PR targets the integration branch `feat/memfs-large-file-strategy` and is independent of mojatter/s2#25 (no file overlap).

## Test plan
- [x] `go test ./...` — includes new `TestEffectiveMaxUploadSize` table-driven cases
- [x] `golangci-lint run ./...`