### PR TITLE
docs: document memfs limitations and upload cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ The `s2test` package provides reusable assertion helpers (e.g. `s2test.TestStora
 | Type | Import | Description |
 |------|--------|-------------|
 | `osfs` | `github.com/mojatter/s2/fs` | Local filesystem storage |
-| `memfs` | `github.com/mojatter/s2/fs` | In-memory filesystem (great for testing) |
+| `memfs` | `github.com/mojatter/s2/fs` | In-memory filesystem (great for testing; see notes below) |
 | `s3` | `github.com/mojatter/s2/s3` | AWS S3 (and any S3-compatible service) |
 
 Backends are registered via blank imports. Import only what you need:
@@ -428,6 +428,16 @@ S2 aims to cover the parts of the S3 API that matter for local development and l
 - **Replication, lifecycle rules, object lock** — Not implemented.
 
 If your use case needs any of the above, S2 is probably not the right tool — consider AWS S3, Ceph RGW, or SeaweedFS.
+
+### memfs backend
+
+The `memfs` backend holds every object body in process memory. It is designed for **tests and local development**, not production workloads:
+
+- All objects live in RAM for the lifetime of the process; nothing is persisted.
+- The default upload limit is **16 MiB** (vs. 5 GiB for `osfs`/`s3`) to protect the host from accidental OOM. Set `S2_SERVER_MAX_UPLOAD_SIZE` (or `Config.MaxUploadSize`) to raise it if you genuinely need larger uploads against memfs.
+- There is no total-memory budget or backpressure across concurrent uploads.
+
+If you need to handle large files, use the `osfs` or `s3` backend instead.
 
 ## License
 

--- a/server/config.go
+++ b/server/config.go
@@ -28,7 +28,11 @@ type Config struct {
 	s2.Config
 	// Listen is the address to listen on.
 	Listen string `json:"listen"`
-	// MaxUploadSize is the maximum upload size in bytes (0 = default 5GB).
+	// MaxUploadSize is the maximum upload size in bytes. When 0, a backend-specific
+	// default is used (see EffectiveMaxUploadSize): 5 GiB for osfs/s3, 16 MiB for
+	// memfs. The conservative memfs default protects the host from accidental
+	// OOM when a large upload targets the in-memory backend; set an explicit
+	// value here to override.
 	MaxUploadSize int64 `json:"max_upload_size"`
 	// MaxPreviewSize is the maximum file size for text preview in bytes (0 = default 10MB).
 	MaxPreviewSize int64 `json:"max_preview_size"`
@@ -42,9 +46,24 @@ type Config struct {
 }
 
 const (
-	DefaultMaxUploadSize  = 5 << 30  // 5GB
-	DefaultMaxPreviewSize = 10 << 20 // 10MB
+	DefaultMaxUploadSize      = 5 << 30  // 5 GiB — default for osfs/s3 backends.
+	DefaultMemfsMaxUploadSize = 16 << 20 // 16 MiB — conservative default for the in-memory backend.
+	DefaultMaxPreviewSize     = 10 << 20 // 10 MiB
 )
+
+// EffectiveMaxUploadSize returns the upload size limit to enforce for this
+// configuration. When MaxUploadSize is explicitly set (> 0) it is returned
+// as-is; otherwise a backend-specific default is chosen so that switching
+// Type to memfs does not silently inherit the 5 GiB default.
+func (cfg *Config) EffectiveMaxUploadSize() int64 {
+	if cfg.MaxUploadSize > 0 {
+		return cfg.MaxUploadSize
+	}
+	if cfg.Type == s2.TypeMemFS {
+		return DefaultMemfsMaxUploadSize
+	}
+	return DefaultMaxUploadSize
+}
 
 func DefaultConfig() *Config {
 	return &Config{
@@ -52,8 +71,9 @@ func DefaultConfig() *Config {
 			Type: s2.TypeOSFS,
 			Root: "/var/lib/s2",
 		},
-		Listen:         ":9000",
-		MaxUploadSize:  DefaultMaxUploadSize,
+		Listen: ":9000",
+		// MaxUploadSize intentionally left 0 — EffectiveMaxUploadSize resolves
+		// a backend-appropriate default at request time.
 		MaxPreviewSize: DefaultMaxPreviewSize,
 	}
 }

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -1,0 +1,86 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mojatter/s2"
+)
+
+func TestLoadEnvBuckets(t *testing.T) {
+	t.Setenv(EnvS2ServerBuckets, "foo,bar,baz")
+	cfg := DefaultConfig()
+	require.NoError(t, cfg.LoadEnv())
+	assert.Equal(t, []string{"foo", "bar", "baz"}, cfg.Buckets)
+}
+
+func TestDefaultConfig(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		field    string
+		got      any
+		want     any
+	}{
+		{caseName: "listen", field: "Listen", got: DefaultConfig().Listen, want: ":9000"},
+		{caseName: "type", field: "Type", got: string(DefaultConfig().Type), want: "osfs"},
+		{caseName: "root", field: "Root", got: DefaultConfig().Root, want: "/var/lib/s2"},
+		// MaxUploadSize is intentionally 0 in DefaultConfig; EffectiveMaxUploadSize resolves a backend-specific default.
+		{caseName: "max upload size", field: "MaxUploadSize", got: DefaultConfig().MaxUploadSize, want: int64(0)},
+		{caseName: "effective max upload size (osfs)", field: "EffectiveMaxUploadSize", got: DefaultConfig().EffectiveMaxUploadSize(), want: int64(5 << 30)},
+		{caseName: "max preview size", field: "MaxPreviewSize", got: DefaultConfig().MaxPreviewSize, want: int64(10 << 20)},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.got)
+		})
+	}
+}
+
+func TestEffectiveMaxUploadSize(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		cfg      *Config
+		want     int64
+	}{
+		{
+			caseName: "osfs default",
+			cfg:      DefaultConfig(),
+			want:     DefaultMaxUploadSize,
+		},
+		{
+			caseName: "memfs default",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.Type = s2.TypeMemFS
+				return c
+			}(),
+			want: DefaultMemfsMaxUploadSize,
+		},
+		{
+			caseName: "explicit override on memfs",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.Type = s2.TypeMemFS
+				c.MaxUploadSize = 1 << 30
+				return c
+			}(),
+			want: 1 << 30,
+		},
+		{
+			caseName: "explicit override on osfs",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.MaxUploadSize = 123
+				return c
+			}(),
+			want: 123,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.cfg.EffectiveMaxUploadSize())
+		})
+	}
+}

--- a/server/handlers/buckets/objects.go
+++ b/server/handlers/buckets/objects.go
@@ -139,7 +139,7 @@ func handleUploadFile(s *server.Server, w http.ResponseWriter, r *http.Request) 
 	prefix := r.FormValue("prefix")
 
 	// Enforce upload size limit
-	maxSize := s.Config.MaxUploadSize
+	maxSize := s.Config.EffectiveMaxUploadSize()
 	r.Body = http.MaxBytesReader(w, r.Body, maxSize)
 
 	file, header, err := r.FormFile("file")

--- a/server/handlers/s3api/multipart.go
+++ b/server/handlers/s3api/multipart.go
@@ -96,7 +96,7 @@ func handleUploadPart(s *server.Server, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	maxSize := s.Config.MaxUploadSize
+	maxSize := s.Config.EffectiveMaxUploadSize()
 	r.Body = http.MaxBytesReader(w, r.Body, maxSize)
 
 	data, err := io.ReadAll(unwrapAWSChunkedBody(r))

--- a/server/handlers/s3api/objects.go
+++ b/server/handlers/s3api/objects.go
@@ -321,7 +321,7 @@ func handlePutObject(s *server.Server, w http.ResponseWriter, r *http.Request) {
 	key := r.PathValue("key")
 
 	// Enforce upload size limit
-	maxSize := s.Config.MaxUploadSize
+	maxSize := s.Config.EffectiveMaxUploadSize()
 	if r.ContentLength > maxSize {
 		writeError(w, r, "EntityTooLarge", fmt.Sprintf("Your proposed upload exceeds the maximum allowed size (%d bytes)", maxSize), http.StatusBadRequest)
 		return

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/mojatter/s2"
 )
 
 func TestInitFlags(t *testing.T) {
@@ -239,12 +241,61 @@ func TestDefaultConfig(t *testing.T) {
 		{caseName: "listen", field: "Listen", got: DefaultConfig().Listen, want: ":9000"},
 		{caseName: "type", field: "Type", got: string(DefaultConfig().Type), want: "osfs"},
 		{caseName: "root", field: "Root", got: DefaultConfig().Root, want: "/var/lib/s2"},
-		{caseName: "max upload size", field: "MaxUploadSize", got: DefaultConfig().MaxUploadSize, want: int64(5 << 30)},
+		// MaxUploadSize is intentionally 0 in DefaultConfig; EffectiveMaxUploadSize resolves a backend-specific default.
+		{caseName: "max upload size", field: "MaxUploadSize", got: DefaultConfig().MaxUploadSize, want: int64(0)},
+		{caseName: "effective max upload size (osfs)", field: "EffectiveMaxUploadSize", got: DefaultConfig().EffectiveMaxUploadSize(), want: int64(5 << 30)},
 		{caseName: "max preview size", field: "MaxPreviewSize", got: DefaultConfig().MaxPreviewSize, want: int64(10 << 20)},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.caseName, func(t *testing.T) {
 			assert.Equal(t, tc.want, tc.got)
+		})
+	}
+}
+
+func TestEffectiveMaxUploadSize(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		cfg      *Config
+		want     int64
+	}{
+		{
+			caseName: "osfs default",
+			cfg:      DefaultConfig(),
+			want:     DefaultMaxUploadSize,
+		},
+		{
+			caseName: "memfs default",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.Type = s2.TypeMemFS
+				return c
+			}(),
+			want: DefaultMemfsMaxUploadSize,
+		},
+		{
+			caseName: "explicit override on memfs",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.Type = s2.TypeMemFS
+				c.MaxUploadSize = 1 << 30
+				return c
+			}(),
+			want: 1 << 30,
+		},
+		{
+			caseName: "explicit override on osfs",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.MaxUploadSize = 123
+				return c
+			}(),
+			want: 123,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.cfg.EffectiveMaxUploadSize())
 		})
 	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/mojatter/s2"
 )
 
 func TestInitFlags(t *testing.T) {
@@ -224,78 +222,3 @@ func TestInitBuckets(t *testing.T) {
 	})
 }
 
-func TestLoadEnvBuckets(t *testing.T) {
-	t.Setenv(EnvS2ServerBuckets, "foo,bar,baz")
-	cfg := DefaultConfig()
-	require.NoError(t, cfg.LoadEnv())
-	assert.Equal(t, []string{"foo", "bar", "baz"}, cfg.Buckets)
-}
-
-func TestDefaultConfig(t *testing.T) {
-	testCases := []struct {
-		caseName string
-		field    string
-		got      any
-		want     any
-	}{
-		{caseName: "listen", field: "Listen", got: DefaultConfig().Listen, want: ":9000"},
-		{caseName: "type", field: "Type", got: string(DefaultConfig().Type), want: "osfs"},
-		{caseName: "root", field: "Root", got: DefaultConfig().Root, want: "/var/lib/s2"},
-		// MaxUploadSize is intentionally 0 in DefaultConfig; EffectiveMaxUploadSize resolves a backend-specific default.
-		{caseName: "max upload size", field: "MaxUploadSize", got: DefaultConfig().MaxUploadSize, want: int64(0)},
-		{caseName: "effective max upload size (osfs)", field: "EffectiveMaxUploadSize", got: DefaultConfig().EffectiveMaxUploadSize(), want: int64(5 << 30)},
-		{caseName: "max preview size", field: "MaxPreviewSize", got: DefaultConfig().MaxPreviewSize, want: int64(10 << 20)},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.caseName, func(t *testing.T) {
-			assert.Equal(t, tc.want, tc.got)
-		})
-	}
-}
-
-func TestEffectiveMaxUploadSize(t *testing.T) {
-	testCases := []struct {
-		caseName string
-		cfg      *Config
-		want     int64
-	}{
-		{
-			caseName: "osfs default",
-			cfg:      DefaultConfig(),
-			want:     DefaultMaxUploadSize,
-		},
-		{
-			caseName: "memfs default",
-			cfg: func() *Config {
-				c := DefaultConfig()
-				c.Type = s2.TypeMemFS
-				return c
-			}(),
-			want: DefaultMemfsMaxUploadSize,
-		},
-		{
-			caseName: "explicit override on memfs",
-			cfg: func() *Config {
-				c := DefaultConfig()
-				c.Type = s2.TypeMemFS
-				c.MaxUploadSize = 1 << 30
-				return c
-			}(),
-			want: 1 << 30,
-		},
-		{
-			caseName: "explicit override on osfs",
-			cfg: func() *Config {
-				c := DefaultConfig()
-				c.MaxUploadSize = 123
-				return c
-			}(),
-			want: 123,
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.caseName, func(t *testing.T) {
-			assert.Equal(t, tc.want, tc.cfg.EffectiveMaxUploadSize())
-		})
-	}
-}


### PR DESCRIPTION
## Summary
- Add a dedicated `memfs backend` subsection under Limitations explaining the in-memory lifetime, the 16 MiB default upload cap, and the lack of a total-memory budget.
- Cross-link from the Storage Backends table.

## Base
Stacked on mojatter/s2#26 because it documents the 16 MiB default introduced there.