### PR TITLE
Memfs large-file strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ The `s2test` package provides reusable assertion helpers (e.g. `s2test.TestStora
 | Type | Import | Description |
 |------|--------|-------------|
 | `osfs` | `github.com/mojatter/s2/fs` | Local filesystem storage |
-| `memfs` | `github.com/mojatter/s2/fs` | In-memory filesystem (great for testing) |
+| `memfs` | `github.com/mojatter/s2/fs` | In-memory filesystem (great for testing; see notes below) |
 | `s3` | `github.com/mojatter/s2/s3` | AWS S3 (and any S3-compatible service) |
 
 Backends are registered via blank imports. Import only what you need:
@@ -428,6 +428,16 @@ S2 aims to cover the parts of the S3 API that matter for local development and l
 - **Replication, lifecycle rules, object lock** — Not implemented.
 
 If your use case needs any of the above, S2 is probably not the right tool — consider AWS S3, Ceph RGW, or SeaweedFS.
+
+### memfs backend
+
+The `memfs` backend holds every object body in process memory. It is designed for **tests and local development**, not production workloads:
+
+- All objects live in RAM for the lifetime of the process; nothing is persisted.
+- The default upload limit is **16 MiB** (vs. 5 GiB for `osfs`/`s3`) to protect the host from accidental OOM. Set `S2_SERVER_MAX_UPLOAD_SIZE` (or `Config.MaxUploadSize`) to raise it if you genuinely need larger uploads against memfs.
+- There is no total-memory budget or backpressure across concurrent uploads.
+
+If you need to handle large files, use the `osfs` or `s3` backend instead.
 
 ## License
 

--- a/s2test/e2e/docker-compose.yml
+++ b/s2test/e2e/docker-compose.yml
@@ -10,10 +10,22 @@ services:
     tmpfs:
       - /var/lib/s2
 
+  s2-mem:
+    build:
+      context: ../..
+      dockerfile: server/Dockerfile
+    environment:
+      S2_SERVER_LISTEN: ":9000"
+      S2_SERVER_TYPE: "memfs"
+      S2_SERVER_USER: "testkey"
+      S2_SERVER_PASSWORD: "testsecret"
+
   test:
     image: amazon/aws-cli
     depends_on:
       s2:
+        condition: service_started
+      s2-mem:
         condition: service_started
     environment:
       AWS_ACCESS_KEY_ID: "testkey"

--- a/s2test/e2e/run.sh
+++ b/s2test/e2e/run.sh
@@ -2,6 +2,7 @@
 set -eu
 
 ENDPOINT="http://s2:9000/s3api"
+ENDPOINT_MEM="http://s2-mem:9000/s3api"
 
 aws_s3() {
   aws s3 --endpoint-url "$ENDPOINT" "$@"
@@ -11,21 +12,25 @@ aws_s3api() {
   aws s3api --endpoint-url "$ENDPOINT" "$@"
 }
 
-# Wait for s2-server to be ready
-echo "==> Waiting for s2-server..."
-i=0
-while [ "$i" -lt 30 ]; do
-  if aws_s3api list-buckets >/dev/null 2>&1; then
-    break
-  fi
-  i=$((i + 1))
-  sleep 1
-done
-if [ "$i" -eq 30 ]; then
-  echo "FAIL: s2-server did not become ready"
+wait_for_server() {
+  name="$1"
+  ep="$2"
+  echo "==> Waiting for $name..."
+  i=0
+  while [ "$i" -lt 30 ]; do
+    if aws s3api --endpoint-url "$ep" list-buckets >/dev/null 2>&1; then
+      echo "    $name is ready."
+      return 0
+    fi
+    i=$((i + 1))
+    sleep 1
+  done
+  echo "FAIL: $name did not become ready"
   exit 1
-fi
-echo "    s2-server is ready."
+}
+
+wait_for_server "s2 (osfs)" "$ENDPOINT"
+wait_for_server "s2-mem" "$ENDPOINT_MEM"
 
 passed=0
 failed=0
@@ -167,6 +172,42 @@ run_test "PresignedGetObject_TamperedSignatureRejected" sh -c '
   tampered=$(echo "$url" | sed "s/X-Amz-Signature=[0-9a-f]*/X-Amz-Signature=deadbeef/")
   status=$(curl -sS -o /dev/null -w "%{http_code}" "$tampered")
   [ "$status" = "403" ]
+'
+
+# === Memfs backend ===
+# Verify that the memfs default upload cap (16 MiB) is enforced end-to-end,
+# and that the streaming CompleteMultipartUpload assembly works on the
+# in-memory backend.
+
+run_test "Memfs_CreateBucket" sh -c '
+  aws s3api --endpoint-url "'"$ENDPOINT_MEM"'" create-bucket --bucket mem-bucket
+'
+
+run_test "Memfs_SmallUploadSucceeds" sh -c '
+  dd if=/dev/zero of=/tmp/small.bin bs=1024 count=1024 2>/dev/null
+  aws s3api --endpoint-url "'"$ENDPOINT_MEM"'" put-object \
+    --bucket mem-bucket --key small.bin --body /tmp/small.bin
+'
+
+run_test "Memfs_LargeUploadRejected" sh -c '
+  dd if=/dev/zero of=/tmp/large.bin bs=1048576 count=17 2>/dev/null
+  # Expect the put-object call to fail because 17 MiB > 16 MiB default cap.
+  ! aws s3api --endpoint-url "'"$ENDPOINT_MEM"'" put-object \
+    --bucket mem-bucket --key large.bin --body /tmp/large.bin
+'
+
+run_test "Memfs_MultipartUploadStreams" sh -c '
+  EP="'"$ENDPOINT_MEM"'"
+  set -e
+  # 10 MiB stays under the 16 MiB memfs cap while still exceeding the AWS CLI
+  # multipart_threshold (8 MiB), so this exercises the streaming
+  # CompleteMultipartUpload assembly on the in-memory backend.
+  dd if=/dev/urandom of=/tmp/mp.bin bs=1048576 count=10 2>/dev/null
+  aws s3 --endpoint-url "$EP" cp /tmp/mp.bin s3://mem-bucket/mp.bin
+  aws s3 --endpoint-url "$EP" cp s3://mem-bucket/mp.bin /tmp/mp.out
+  src=$(sha256sum /tmp/mp.bin | cut -d" " -f1)
+  dst=$(sha256sum /tmp/mp.out | cut -d" " -f1)
+  [ "$src" = "$dst" ]
 '
 
 # Cleanup

--- a/server/config.go
+++ b/server/config.go
@@ -28,7 +28,11 @@ type Config struct {
 	s2.Config
 	// Listen is the address to listen on.
 	Listen string `json:"listen"`
-	// MaxUploadSize is the maximum upload size in bytes (0 = default 5GB).
+	// MaxUploadSize is the maximum upload size in bytes. When 0, a backend-specific
+	// default is used (see EffectiveMaxUploadSize): 5 GiB for osfs/s3, 16 MiB for
+	// memfs. The conservative memfs default protects the host from accidental
+	// OOM when a large upload targets the in-memory backend; set an explicit
+	// value here to override.
 	MaxUploadSize int64 `json:"max_upload_size"`
 	// MaxPreviewSize is the maximum file size for text preview in bytes (0 = default 10MB).
 	MaxPreviewSize int64 `json:"max_preview_size"`
@@ -42,9 +46,24 @@ type Config struct {
 }
 
 const (
-	DefaultMaxUploadSize  = 5 << 30  // 5GB
-	DefaultMaxPreviewSize = 10 << 20 // 10MB
+	DefaultMaxUploadSize      = 5 << 30  // 5 GiB — default for osfs/s3 backends.
+	DefaultMemfsMaxUploadSize = 16 << 20 // 16 MiB — conservative default for the in-memory backend.
+	DefaultMaxPreviewSize     = 10 << 20 // 10 MiB
 )
+
+// EffectiveMaxUploadSize returns the upload size limit to enforce for this
+// configuration. When MaxUploadSize is explicitly set (> 0) it is returned
+// as-is; otherwise a backend-specific default is chosen so that switching
+// Type to memfs does not silently inherit the 5 GiB default.
+func (cfg *Config) EffectiveMaxUploadSize() int64 {
+	if cfg.MaxUploadSize > 0 {
+		return cfg.MaxUploadSize
+	}
+	if cfg.Type == s2.TypeMemFS {
+		return DefaultMemfsMaxUploadSize
+	}
+	return DefaultMaxUploadSize
+}
 
 func DefaultConfig() *Config {
 	return &Config{
@@ -52,8 +71,9 @@ func DefaultConfig() *Config {
 			Type: s2.TypeOSFS,
 			Root: "/var/lib/s2",
 		},
-		Listen:         ":9000",
-		MaxUploadSize:  DefaultMaxUploadSize,
+		Listen: ":9000",
+		// MaxUploadSize intentionally left 0 — EffectiveMaxUploadSize resolves
+		// a backend-appropriate default at request time.
 		MaxPreviewSize: DefaultMaxPreviewSize,
 	}
 }

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -1,0 +1,86 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mojatter/s2"
+)
+
+func TestLoadEnvBuckets(t *testing.T) {
+	t.Setenv(EnvS2ServerBuckets, "foo,bar,baz")
+	cfg := DefaultConfig()
+	require.NoError(t, cfg.LoadEnv())
+	assert.Equal(t, []string{"foo", "bar", "baz"}, cfg.Buckets)
+}
+
+func TestDefaultConfig(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		field    string
+		got      any
+		want     any
+	}{
+		{caseName: "listen", field: "Listen", got: DefaultConfig().Listen, want: ":9000"},
+		{caseName: "type", field: "Type", got: string(DefaultConfig().Type), want: "osfs"},
+		{caseName: "root", field: "Root", got: DefaultConfig().Root, want: "/var/lib/s2"},
+		// MaxUploadSize is intentionally 0 in DefaultConfig; EffectiveMaxUploadSize resolves a backend-specific default.
+		{caseName: "max upload size", field: "MaxUploadSize", got: DefaultConfig().MaxUploadSize, want: int64(0)},
+		{caseName: "effective max upload size (osfs)", field: "EffectiveMaxUploadSize", got: DefaultConfig().EffectiveMaxUploadSize(), want: int64(5 << 30)},
+		{caseName: "max preview size", field: "MaxPreviewSize", got: DefaultConfig().MaxPreviewSize, want: int64(10 << 20)},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.got)
+		})
+	}
+}
+
+func TestEffectiveMaxUploadSize(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		cfg      *Config
+		want     int64
+	}{
+		{
+			caseName: "osfs default",
+			cfg:      DefaultConfig(),
+			want:     DefaultMaxUploadSize,
+		},
+		{
+			caseName: "memfs default",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.Type = s2.TypeMemFS
+				return c
+			}(),
+			want: DefaultMemfsMaxUploadSize,
+		},
+		{
+			caseName: "explicit override on memfs",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.Type = s2.TypeMemFS
+				c.MaxUploadSize = 1 << 30
+				return c
+			}(),
+			want: 1 << 30,
+		},
+		{
+			caseName: "explicit override on osfs",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.MaxUploadSize = 123
+				return c
+			}(),
+			want: 123,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.cfg.EffectiveMaxUploadSize())
+		})
+	}
+}

--- a/server/handlers/buckets/objects.go
+++ b/server/handlers/buckets/objects.go
@@ -139,7 +139,7 @@ func handleUploadFile(s *server.Server, w http.ResponseWriter, r *http.Request) 
 	prefix := r.FormValue("prefix")
 
 	// Enforce upload size limit
-	maxSize := s.Config.MaxUploadSize
+	maxSize := s.Config.EffectiveMaxUploadSize()
 	r.Body = http.MaxBytesReader(w, r.Body, maxSize)
 
 	file, header, err := r.FormFile("file")

--- a/server/handlers/s3api/multipart.go
+++ b/server/handlers/s3api/multipart.go
@@ -96,7 +96,7 @@ func handleUploadPart(s *server.Server, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	maxSize := s.Config.MaxUploadSize
+	maxSize := s.Config.EffectiveMaxUploadSize()
 	r.Body = http.MaxBytesReader(w, r.Body, maxSize)
 
 	data, err := io.ReadAll(unwrapAWSChunkedBody(r))

--- a/server/handlers/s3api/multipart.go
+++ b/server/handlers/s3api/multipart.go
@@ -1,13 +1,13 @@
 package s3api
 
 import (
-	"bytes"
 	"crypto/md5" // #nosec G501 -- MD5 is required for S3-compatible multipart ETag
 	"crypto/rand"
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/xml"
 	"fmt"
+	"hash"
 	"io"
 	"net/http"
 	"sort"
@@ -148,40 +148,37 @@ func handleCompleteMultipartUpload(s *server.Server, w http.ResponseWriter, r *h
 		return req.Parts[i].PartNumber < req.Parts[j].PartNumber
 	})
 
-	// Assemble parts into a buffer, computing the multipart ETag as we go.
-	// The multipart ETag is MD5(concat of each part's raw MD5 bytes) + "-" + partCount.
-	var buf bytes.Buffer
-	var partMD5s []byte
-	for _, p := range req.Parts {
+	// Stat each part once up front: verify existence and compute the total
+	// length required by NewObjectReader. We intentionally do NOT read part
+	// bodies here — they are streamed lazily by partsReader below.
+	partObjs := make([]s2.Object, len(req.Parts))
+	var totalLen uint64
+	for i, p := range req.Parts {
 		obj, err := strg.Get(ctx, partKey(uploadID, p.PartNumber))
 		if err != nil {
 			writeError(w, r, "InvalidPart", fmt.Sprintf("Part %d not found", p.PartNumber), http.StatusBadRequest)
 			return
 		}
-		rc, err := obj.Open()
-		if err != nil {
-			code, msg, status := s2ErrorToS3Error(err)
-			writeError(w, r, code, msg, status)
-			return
-		}
-		h := md5.New() // #nosec G401 -- MD5 is required for S3-compatible multipart ETag
-		if _, err := io.Copy(io.MultiWriter(&buf, h), rc); err != nil {
-			_ = rc.Close()
-			writeError(w, r, "InternalError", "Failed to assemble parts", http.StatusInternalServerError)
-			return
-		}
-		_ = rc.Close()
-		partMD5s = append(partMD5s, h.Sum(nil)...)
+		partObjs[i] = obj
+		totalLen += obj.Length()
 	}
 
-	finalObj := s2.NewObjectBytes(key, buf.Bytes())
+	// Stream all parts through a single reader, tee-ing each part into its own
+	// MD5 hash as it flows by. This avoids buffering the assembled object in
+	// memory — critical for the memfs backend, and a peak-memory win for all
+	// backends. The multipart ETag is MD5(concat of each part's raw MD5 bytes)
+	// + "-" + partCount; we collect the per-part MD5s after Put has drained
+	// the reader.
+	pr := &partsReader{parts: partObjs}
+	finalObj := s2.NewObjectReader(key, pr, totalLen)
 	if err := strg.Put(ctx, finalObj); err != nil {
+		_ = pr.Close()
 		code, msg, status := s2ErrorToS3Error(err)
 		writeError(w, r, code, msg, status)
 		return
 	}
 
-	combined := md5.Sum(partMD5s) // #nosec G401 -- MD5 is required for S3-compatible multipart ETag
+	combined := md5.Sum(pr.partMD5s) // #nosec G401 -- MD5 is required for S3-compatible multipart ETag
 	etag := `"` + hex.EncodeToString(combined[:]) + `-` + strconv.Itoa(len(req.Parts)) + `"`
 	_ = strg.PutMetadata(ctx, key, s2.MetadataMap{etagMetadataKey: etag})
 
@@ -217,6 +214,60 @@ func handleAbortMultipartUpload(s *server.Server, w http.ResponseWriter, r *http
 
 	_ = strg.DeleteRecursive(ctx, multipartPrefix+uploadID+"/")
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// partsReader is an io.ReadCloser that concatenates the bodies of a slice of
+// s2.Object parts, opening each one lazily. As each part's body flows through
+// Read, it is also hashed into a per-part MD5; after the reader is fully
+// drained, partMD5s holds the concatenation of those digests in part order —
+// exactly what the S3 multipart ETag formula requires.
+type partsReader struct {
+	parts    []s2.Object
+	idx      int
+	current  io.ReadCloser
+	currentH hash.Hash
+	partMD5s []byte
+}
+
+func (p *partsReader) Read(buf []byte) (int, error) {
+	for {
+		if p.current == nil {
+			if p.idx >= len(p.parts) {
+				return 0, io.EOF
+			}
+			rc, err := p.parts[p.idx].Open()
+			if err != nil {
+				return 0, err
+			}
+			p.current = rc
+			p.currentH = md5.New() // #nosec G401 -- MD5 is required for S3-compatible multipart ETag
+		}
+		n, err := p.current.Read(buf)
+		if n > 0 {
+			_, _ = p.currentH.Write(buf[:n])
+		}
+		if err == io.EOF {
+			p.partMD5s = append(p.partMD5s, p.currentH.Sum(nil)...)
+			_ = p.current.Close()
+			p.current = nil
+			p.currentH = nil
+			p.idx++
+			if n > 0 {
+				return n, nil
+			}
+			continue
+		}
+		return n, err
+	}
+}
+
+func (p *partsReader) Close() error {
+	if p.current != nil {
+		err := p.current.Close()
+		p.current = nil
+		return err
+	}
+	return nil
 }
 
 func handleObjectPOST(s *server.Server, w http.ResponseWriter, r *http.Request) {

--- a/server/handlers/s3api/multipart_test.go
+++ b/server/handlers/s3api/multipart_test.go
@@ -1,0 +1,67 @@
+package s3api
+
+import (
+	"crypto/md5" // #nosec G501 -- MD5 is used here only to mirror S3 multipart ETag semantics under test.
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mojatter/s2"
+)
+
+func TestPartsReader(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		bodies   []string
+	}{
+		{caseName: "single part", bodies: []string{"hello"}},
+		{caseName: "two parts", bodies: []string{"foo", "barbaz"}},
+		{caseName: "empty part in middle", bodies: []string{"a", "", "b"}},
+		{caseName: "many parts", bodies: []string{"1", "22", "333", "4444", "55555"}},
+		{caseName: "no parts", bodies: nil},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			parts := make([]s2.Object, len(tc.bodies))
+			var want string
+			var wantMD5s []byte
+			for i, body := range tc.bodies {
+				parts[i] = s2.NewObjectBytes("part", []byte(body))
+				want += body
+				h := md5.Sum([]byte(body)) // #nosec G401
+				wantMD5s = append(wantMD5s, h[:]...)
+			}
+
+			pr := &partsReader{parts: parts}
+			got, err := io.ReadAll(pr)
+			require.NoError(t, err)
+			assert.Equal(t, want, string(got))
+			assert.Equal(t, wantMD5s, pr.partMD5s)
+			assert.NoError(t, pr.Close())
+		})
+	}
+}
+
+func TestPartsReader_SmallBuffer(t *testing.T) {
+	// Read byte-by-byte to exercise the "part exhausted mid-buffer" path.
+	parts := []s2.Object{
+		s2.NewObjectBytes("a", []byte("abc")),
+		s2.NewObjectBytes("b", []byte("de")),
+	}
+	pr := &partsReader{parts: parts}
+
+	var got []byte
+	buf := make([]byte, 1)
+	for {
+		n, err := pr.Read(buf)
+		got = append(got, buf[:n]...)
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+	}
+	assert.Equal(t, "abcde", string(got))
+	assert.Len(t, pr.partMD5s, 2*md5.Size)
+}

--- a/server/handlers/s3api/objects.go
+++ b/server/handlers/s3api/objects.go
@@ -321,7 +321,7 @@ func handlePutObject(s *server.Server, w http.ResponseWriter, r *http.Request) {
 	key := r.PathValue("key")
 
 	// Enforce upload size limit
-	maxSize := s.Config.MaxUploadSize
+	maxSize := s.Config.EffectiveMaxUploadSize()
 	if r.ContentLength > maxSize {
 		writeError(w, r, "EntityTooLarge", fmt.Sprintf("Your proposed upload exceeds the maximum allowed size (%d bytes)", maxSize), http.StatusBadRequest)
 		return

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -222,29 +222,3 @@ func TestInitBuckets(t *testing.T) {
 	})
 }
 
-func TestLoadEnvBuckets(t *testing.T) {
-	t.Setenv(EnvS2ServerBuckets, "foo,bar,baz")
-	cfg := DefaultConfig()
-	require.NoError(t, cfg.LoadEnv())
-	assert.Equal(t, []string{"foo", "bar", "baz"}, cfg.Buckets)
-}
-
-func TestDefaultConfig(t *testing.T) {
-	testCases := []struct {
-		caseName string
-		field    string
-		got      any
-		want     any
-	}{
-		{caseName: "listen", field: "Listen", got: DefaultConfig().Listen, want: ":9000"},
-		{caseName: "type", field: "Type", got: string(DefaultConfig().Type), want: "osfs"},
-		{caseName: "root", field: "Root", got: DefaultConfig().Root, want: "/var/lib/s2"},
-		{caseName: "max upload size", field: "MaxUploadSize", got: DefaultConfig().MaxUploadSize, want: int64(5 << 30)},
-		{caseName: "max preview size", field: "MaxPreviewSize", got: DefaultConfig().MaxPreviewSize, want: int64(10 << 20)},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.caseName, func(t *testing.T) {
-			assert.Equal(t, tc.want, tc.got)
-		})
-	}
-}


### PR DESCRIPTION
Integration PR rolling up the four merged sub-PRs into `main`:

- mojatter/s2#25 — `refactor(s3api): stream CompleteMultipartUpload assembly`
- mojatter/s2#26 — `feat(server): conservative default upload limit for memfs (16 MiB)`
- mojatter/s2#27 — `docs: document memfs limitations and upload cap`
- mojatter/s2#28 — `test(e2e): add s2-mem service to verify memfs upload limits`

## Summary
Make the in-memory backend safe by default while removing the worst peak-memory waste from multipart upload assembly.

- **Stream multipart assembly** — `CompleteMultipartUpload` no longer buffers every part into a `bytes.Buffer` before writing the final object. A new internal `partsReader` lazily opens parts and tees their bytes into per-part MD5 hashes as it streams. Peak memory drops by ~half across all backends, and crucially memfs no longer holds two full copies of the assembled object.
- **Conservative memfs default upload cap** — `Config.MaxUploadSize == 0` now resolves via `EffectiveMaxUploadSize`: 16 MiB for memfs, 5 GiB for everything else. The 5 GiB default is no longer silently inherited when a user flips `S2_SERVER_TYPE=memfs`. Users who genuinely need larger uploads against memfs can still set `S2_SERVER_MAX_UPLOAD_SIZE` explicitly.
- **Docs** — README has a dedicated `memfs backend` subsection under Limitations explaining the in-memory lifetime, the 16 MiB cap, and the lack of total-memory budget.
- **e2e coverage** — A new `s2-mem` service in the docker-compose stack runs three memfs-targeted cases: small upload succeeds, 17 MiB upload is rejected by the cap, 10 MiB multipart `aws s3 cp` round-trip exercises the streaming assembly on the in-memory backend.

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] `docker compose up` in `s2test/e2e` → 23/23 PASS