### PR TITLE
feat(cmd): s2-server CLI flags, "data" default, -help examples

### DIFF
--- a/docs/api-audit.md
+++ b/docs/api-audit.md
@@ -274,10 +274,106 @@ Non-breaking improvements bundled in the same release:
 
 ---
 
+## Server CLI (`cmd/s2-server`)
+
+**Scope note.** The rest of this document audits the library import
+surface. This section is a deliberate scope expansion to record the
+`s2-server` CLI UX decisions that also ship in v0.2.0.
+
+### Precedence
+
+Configuration sources are applied in this order, each overriding the
+previous one:
+
+```
+default  <  -f config file  <  env var  <  flag
+```
+
+- **default**: built into the binary (see `DefaultRoot` below).
+- **-f config file**: JSON file loaded via `-f` or `S2_SERVER_CONFIG`.
+- **env var**: `S2_SERVER_*` variables read on startup.
+- **flag**: explicit command-line flags; the most recent, most
+  explicit intent wins, matching kubectl / Viper / Terraform /
+  AWS CLI.
+
+Rejected alternative: `env < file`. Today's code already loads file
+first and env second, and `env > file` means a single
+`S2_SERVER_ROOT=...` in a shell rc can override a committed config
+without the user editing the file — the usual 12-factor expectation.
+
+### Command-line flags
+
+Three new flags cover the settings users most often want to tweak for
+a one-off run:
+
+| Flag | Equivalent env / file field |
+|---|---|
+| `-listen <addr>` | `S2_SERVER_LISTEN` / `listen` |
+| `-root <path>` | `S2_SERVER_ROOT` / `root` |
+| `-buckets <a,b,c>` | `S2_SERVER_BUCKETS` / `buckets` |
+
+Only flags the user actually passed override the underlying layer
+(tracked as pointer-typed fields in `server.Flags`). Omitting a flag
+leaves the value from file/env/default untouched — the flags are
+additive, not a reset.
+
+### DefaultRoot
+
+`server.DefaultConfig().Root` previously hardcoded `/var/lib/s2`,
+which made sense inside the Docker image but broke the
+"`go install && s2-server`" first-run experience: new users had no
+write access to `/var/lib/s2` and had to discover `S2_SERVER_ROOT` or
+`-f` before anything worked.
+
+The default is now `"data"` (relative to the current working
+directory, same idiom as Prometheus / etcd). The Docker image keeps
+`/var/lib/s2` via a linker flag:
+
+```sh
+go build \
+    -ldflags "-X github.com/mojatter/s2/server.DefaultRoot=/var/lib/s2" \
+    ./cmd/s2-server
+```
+
+This uses the same ldflags-injection idiom already in place for
+`server.version`. No runtime branching, no new env var, no special
+Docker-detection heuristics.
+
+Rejected alternatives:
+
+- **Interactive prompt on first run.** Server tools rarely prompt;
+  they break under non-interactive contexts (CI, systemd, Docker,
+  k8s) and conflict with daemon use cases. Neither Prometheus, etcd,
+  MinIO, InfluxDB, MongoDB, Redis, nor Docker prompt for their data
+  directory. `aws configure`-style prompting belongs to one-shot
+  clients, not long-running servers.
+- **`S2_SERVER_ROOT_DEFAULT` env var.** Adds a new precedence layer
+  and a new env var whose only purpose is to differ from
+  `S2_SERVER_ROOT`. ldflags injection accomplishes the same goal with
+  zero runtime surface.
+- **Runtime Docker detection (`/.dockerenv`).** Fragile and
+  surprising.
+
+### `-help` output
+
+`-help` now prints an Examples section after the flag list, covering:
+
+1. Bare defaults run.
+2. One-off override of `-listen` and `-root`.
+3. Initial bucket creation via flag and via env var.
+4. Layering a config file under a single one-off flag.
+5. Printing the version.
+
+This is the cheapest available nudge toward correct usage for new
+users and documents the precedence chain implicitly ("here is `-f`
+and `-listen` together, and the flag wins").
+
+---
+
 ## Out of scope for v0.2 audit
 
 - Server packages (`server/`, `server/handlers/`, `server/middleware/`) —
-  these are not part of the library import surface.
-- CLI flag/env names — covered by separate user-facing compatibility.
+  these are not part of the library import surface, except for the
+  CLI UX decisions captured above.
 - Web console templates and assets.
 - v1.0.0 release planning (deferred until v0.2 has lived in use).

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,7 +1,12 @@
 FROM golang:1.26-alpine AS builder
 WORKDIR /app
+# DefaultRoot is overridden via -ldflags so the Docker image defaults to
+# /var/lib/s2 while a bare "go install" binary keeps the friendlier
+# relative "data" default (see server/config.go).
 RUN --mount=target=. GOOS=linux CGO_ENABLED=0 \
-    go build -o /s2-server ./cmd/s2-server
+    go build \
+      -ldflags "-s -w -X github.com/mojatter/s2/server.DefaultRoot=/var/lib/s2" \
+      -o /s2-server ./cmd/s2-server
 
 FROM busybox AS init
 RUN mkdir -p /var/lib/s2

--- a/server/config.go
+++ b/server/config.go
@@ -11,6 +11,24 @@ import (
 	"github.com/mojatter/s2"
 )
 
+// splitBucketList parses a comma-separated bucket list (used by both the
+// S2_SERVER_BUCKETS env var and the -buckets flag). Whitespace around each
+// entry is trimmed; empty entries are dropped so "a,,b" becomes ["a","b"]
+// and the zero-value "" becomes a nil slice rather than [""].
+func splitBucketList(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := parts[:0]
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
 const (
 	EnvS2ServerConfig         = "S2_SERVER_CONFIG"
 	EnvS2ServerListen         = "S2_SERVER_LISTEN"
@@ -120,7 +138,7 @@ func (cfg *Config) LoadEnv() error {
 		cfg.Password = v
 	}
 	if v := os.Getenv(EnvS2ServerBuckets); v != "" {
-		cfg.Buckets = strings.Split(v, ",")
+		cfg.Buckets = splitBucketList(v)
 	}
 	return nil
 }

--- a/server/config.go
+++ b/server/config.go
@@ -69,6 +69,21 @@ const (
 	DefaultMaxPreviewSize     = 10 << 20 // 10 MiB
 )
 
+// DefaultRoot is the default storage root path used by DefaultConfig when
+// the user does not supply one via -root, -f, or S2_SERVER_ROOT.
+//
+// It is intentionally a var (not a const) so that binaries can be built with
+// a different default via linker flags, matching the same idiom used for
+// version injection:
+//
+//	go build -ldflags "-X github.com/mojatter/s2/server.DefaultRoot=/var/lib/s2" ./cmd/s2-server
+//
+// This lets the stock "go install" binary default to a relative "data"
+// directory (so a new user can run s2-server in any directory and
+// immediately see where data lands) while the Docker image is built with
+// /var/lib/s2 baked in.
+var DefaultRoot = "data"
+
 // EffectiveMaxUploadSize returns the upload size limit to enforce for this
 // configuration. When MaxUploadSize is explicitly set (> 0) it is returned
 // as-is; otherwise a backend-specific default is chosen so that switching
@@ -87,7 +102,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		Config: s2.Config{
 			Type: s2.TypeOSFS,
-			Root: "/var/lib/s2",
+			Root: DefaultRoot,
 		},
 		Listen: ":9000",
 		// MaxUploadSize intentionally left 0 — EffectiveMaxUploadSize resolves

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -28,7 +28,7 @@ func TestDefaultConfig(t *testing.T) {
 	}{
 		{caseName: "listen", field: "Listen", got: DefaultConfig().Listen, want: ":9000"},
 		{caseName: "type", field: "Type", got: string(DefaultConfig().Type), want: "osfs"},
-		{caseName: "root", field: "Root", got: DefaultConfig().Root, want: "/var/lib/s2"},
+		{caseName: "root", field: "Root", got: DefaultConfig().Root, want: DefaultRoot},
 		// MaxUploadSize is intentionally 0 in DefaultConfig; EffectiveMaxUploadSize resolves a backend-specific default.
 		{caseName: "max upload size", field: "MaxUploadSize", got: DefaultConfig().MaxUploadSize, want: int64(0)},
 		{caseName: "effective max upload size (osfs)", field: "EffectiveMaxUploadSize", got: DefaultConfig().EffectiveMaxUploadSize(), want: int64(5 << 30)},

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -1,6 +1,9 @@
 package server
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -81,6 +84,77 @@ func TestEffectiveMaxUploadSize(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.caseName, func(t *testing.T) {
 			assert.Equal(t, tc.want, tc.cfg.EffectiveMaxUploadSize())
+		})
+	}
+}
+
+// TestConfigPrecedence verifies that configuration sources are applied in
+// the documented order: default < file < env < flag. The test exercises the
+// same load sequence Run uses (DefaultConfig -> LoadFile -> LoadEnv -> flag
+// override) without actually starting an HTTP server.
+func TestConfigPrecedence(t *testing.T) {
+	// Write a small config file with a root value we can later see being
+	// overridden.
+	dir := t.TempDir()
+	fileRoot := filepath.Join(dir, "from-file")
+	cfgPath := filepath.Join(dir, "config.json")
+	body, err := json.Marshal(map[string]any{
+		"root":   fileRoot,
+		"listen": ":7001",
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(cfgPath, body, 0o600))
+
+	testCases := []struct {
+		caseName string
+		envRoot  string
+		flagRoot *string
+		wantRoot string
+	}{
+		{
+			caseName: "default only (no file, no env, no flag)",
+			wantRoot: DefaultConfig().Root,
+		},
+		{
+			caseName: "file beats default",
+			wantRoot: fileRoot,
+		},
+		{
+			caseName: "env beats file",
+			envRoot:  "/from-env",
+			wantRoot: "/from-env",
+		},
+		{
+			caseName: "flag beats env",
+			envRoot:  "/from-env",
+			flagRoot: strPtr("/from-flag"),
+			wantRoot: "/from-flag",
+		},
+		{
+			caseName: "flag beats file (no env)",
+			flagRoot: strPtr("/from-flag"),
+			wantRoot: "/from-flag",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			if tc.envRoot != "" {
+				t.Setenv(EnvS2ServerRoot, tc.envRoot)
+			} else {
+				t.Setenv(EnvS2ServerRoot, "")
+			}
+
+			cfg := DefaultConfig()
+			// "default only" uses no file; every other case loads the file.
+			if tc.caseName != "default only (no file, no env, no flag)" {
+				require.NoError(t, cfg.LoadFile(cfgPath))
+			}
+			require.NoError(t, cfg.LoadEnv())
+			if tc.flagRoot != nil {
+				cfg.Root = *tc.flagRoot
+			}
+
+			assert.Equal(t, tc.wantRoot, cfg.Root)
 		})
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -21,6 +21,27 @@ const (
 	usage = cmd + " [flags]"
 )
 
+// helpExamples is appended verbatim to the -help output so new users can see
+// a few complete command lines instead of having to synthesize one from the
+// flag list alone.
+const helpExamples = `Examples:
+  # Run with defaults: stores data in ./data, listens on :9000.
+  s2-server
+
+  # Override the listen address and storage root for a one-off run.
+  s2-server -listen :8080 -root /tmp/s2
+
+  # Create initial buckets on startup (both flag and env var work).
+  s2-server -buckets assets,uploads
+  S2_SERVER_BUCKETS=assets,uploads s2-server
+
+  # Load persistent settings from a config file, then override one field.
+  s2-server -f ./s2.json -listen :9001
+
+  # Print the version and exit.
+  s2-server -v
+`
+
 // version is set at build time via -ldflags.
 // Falls back to the module version embedded by go install.
 var version = "dev"
@@ -86,6 +107,7 @@ func initFlags(args []string) (*Flags, error) {
 		fmt.Fprintf(os.Stderr, "%s\n\nUsage:\n  %s\n\n", desc, usage)
 		fmt.Fprintln(os.Stderr, "Flags:")
 		fs.PrintDefaults()
+		fmt.Fprint(os.Stderr, "\n", helpExamples)
 	}
 	return &f, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -38,21 +38,47 @@ var (
 	handlers    = map[string]HandlerFunc{}
 )
 
+// Flags holds the parsed command-line arguments for s2-server. Pointer-typed
+// fields distinguish "explicitly set" from "left at default"; only explicitly
+// set flags override values loaded from file/env.
 type Flags struct {
 	isVersion  bool
 	isHelp     bool
 	configFile string
+	listen     *string
+	root       *string
+	buckets    *string
 }
 
 func initFlags(args []string) (*Flags, error) {
-	var f Flags
+	var (
+		f       Flags
+		listen  string
+		root    string
+		buckets string
+	)
 	fs := flag.NewFlagSet(cmd, flag.ExitOnError)
 	fs.BoolVar(&f.isVersion, "v", false, "print version")
 	fs.BoolVar(&f.isHelp, "h", false, "help for "+cmd)
-	fs.StringVar(&f.configFile, "f", os.Getenv(EnvS2ServerConfig), "configuration file")
+	fs.StringVar(&f.configFile, "f", os.Getenv(EnvS2ServerConfig), "configuration file (also "+EnvS2ServerConfig+")")
+	fs.StringVar(&listen, "listen", "", "listen address, e.g. :9000 (overrides config file and "+EnvS2ServerListen+")")
+	fs.StringVar(&root, "root", "", "storage root path (overrides config file and "+EnvS2ServerRoot+")")
+	fs.StringVar(&buckets, "buckets", "", "comma-separated list of buckets to create on startup (overrides config file and "+EnvS2ServerBuckets+")")
 	if err := fs.Parse(args[1:]); err != nil {
 		return nil, fmt.Errorf("failed to parse flags: %w", err)
 	}
+	// Record only flags that were explicitly set so Run can apply them with
+	// the correct precedence (default < file < env < flag).
+	fs.Visit(func(fl *flag.Flag) {
+		switch fl.Name {
+		case "listen":
+			f.listen = &listen
+		case "root":
+			f.root = &root
+		case "buckets":
+			f.buckets = &buckets
+		}
+	})
 	if f.isVersion {
 		fmt.Println(version)
 	}
@@ -81,6 +107,16 @@ func Run(args []string) error {
 	}
 	if err := cfg.LoadEnv(); err != nil {
 		return err
+	}
+	// Flags have the highest precedence: default < file < env < flag.
+	if f.listen != nil {
+		cfg.Listen = *f.listen
+	}
+	if f.root != nil {
+		cfg.Root = *f.root
+	}
+	if f.buckets != nil {
+		cfg.Buckets = splitBucketList(*f.buckets)
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -13,33 +13,55 @@ import (
 
 func TestInitFlags(t *testing.T) {
 	testCases := []struct {
-		caseName   string
-		args       []string
+		caseName    string
+		args        []string
 		wantVersion bool
 		wantHelp    bool
 		wantConfig  string
+		wantListen  *string
+		wantRoot    *string
+		wantBuckets *string
 	}{
 		{
-			caseName:   "no flags",
-			args:       []string{"s2-server"},
-			wantVersion: false,
-			wantHelp:    false,
-			wantConfig:  "",
+			caseName: "no flags",
+			args:     []string{"s2-server"},
 		},
 		{
-			caseName:   "version flag",
-			args:       []string{"s2-server", "-v"},
+			caseName:    "version flag",
+			args:        []string{"s2-server", "-v"},
 			wantVersion: true,
 		},
 		{
-			caseName:   "help flag",
-			args:       []string{"s2-server", "-h"},
-			wantHelp:   true,
+			caseName: "help flag",
+			args:     []string{"s2-server", "-h"},
+			wantHelp: true,
 		},
 		{
 			caseName:   "config file flag",
 			args:       []string{"s2-server", "-f", "config.json"},
 			wantConfig: "config.json",
+		},
+		{
+			caseName:   "listen flag",
+			args:       []string{"s2-server", "-listen", ":8080"},
+			wantListen: strPtr(":8080"),
+		},
+		{
+			caseName: "root flag",
+			args:     []string{"s2-server", "-root", "/tmp/s2"},
+			wantRoot: strPtr("/tmp/s2"),
+		},
+		{
+			caseName:    "buckets flag",
+			args:        []string{"s2-server", "-buckets", "a,b,c"},
+			wantBuckets: strPtr("a,b,c"),
+		},
+		{
+			caseName:    "all config flags at once",
+			args:        []string{"s2-server", "-listen", ":1", "-root", "r", "-buckets", "x"},
+			wantListen:  strPtr(":1"),
+			wantRoot:    strPtr("r"),
+			wantBuckets: strPtr("x"),
 		},
 	}
 	for _, tc := range testCases {
@@ -49,9 +71,14 @@ func TestInitFlags(t *testing.T) {
 			assert.Equal(t, tc.wantVersion, f.isVersion)
 			assert.Equal(t, tc.wantHelp, f.isHelp)
 			assert.Equal(t, tc.wantConfig, f.configFile)
+			assert.Equal(t, tc.wantListen, f.listen)
+			assert.Equal(t, tc.wantRoot, f.root)
+			assert.Equal(t, tc.wantBuckets, f.buckets)
 		})
 	}
 }
+
+func strPtr(s string) *string { return &s }
 
 func TestNewServer(t *testing.T) {
 	t.Run("sets StartedAt", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Four small cmd/s2-server improvements for v0.2.0, each as its own commit for review.

1. **Add `-listen` / `-root` / `-buckets` flags** — explicit overrides for the settings users most often tweak for a one-off run. Tracked as pointer-typed fields so "unset" vs "empty string" remain distinguishable; only explicitly passed flags override file/env. Refactors the comma-splitting logic used by `S2_SERVER_BUCKETS` into a single `splitBucketList` helper, incidentally fixing whitespace handling.
2. **Default `Root` to `"data"` (ldflags-overridable)** — `DefaultConfig().Root` previously hardcoded `/var/lib/s2`, which broke the "`go install && s2-server`" first-run experience. The new default is `"data"` (cwd-relative, same idiom as Prometheus / etcd), and the Docker image keeps `/var/lib/s2` via `-ldflags "-X github.com/mojatter/s2/server.DefaultRoot=/var/lib/s2"` — the same pattern already in use for `version` injection.
3. **Add Examples section to `-help`** — covers the bare-defaults run, one-off `-listen`/`-root` override, initial bucket creation via flag and via env var, layering a config file under a one-off flag, and `-v`. Implicitly documents the precedence chain.
4. **Document the CLI decisions in `docs/api-audit.md`** — scope-expand the audit from "library import surface only" to include the CLI UX changes that also ship in v0.2, with rejected alternatives recorded inline.

### Precedence

```
default < -f config file < env var < flag
```

Matches kubectl / Viper / Terraform / AWS CLI. Only flags the user actually passed override the underlying layer — the flags are additive, not a reset.

## Base

Stacked on mojatter/s2#30 (the audit doc PR) because commit 4 amends the audit document. Once #30 merges, this PR's base retargets automatically.

## Test plan
- [x] `go test ./...` — new `TestInitFlags` table cases for the three flags, new `TestRunConfigPrecedence` covering every layer of the default/file/env/flag chain.
- [x] `golangci-lint run ./...`
- [x] Manual `go run ./cmd/s2-server -h` — verified Examples section renders correctly.