### PR TITLE
docs: update README and stale comments for v0.2 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,11 +143,11 @@ func main() {
 	}
 
 	// List objects
-	objects, _, err := assets.List(ctx, "", 100)
+	res, err := assets.List(ctx, s2.ListOptions{Limit: 100})
 	if err != nil {
 		panic(err)
 	}
-	for _, o := range objects {
+	for _, o := range res.Objects {
 		fmt.Println(o.Name())
 	}
 }
@@ -192,11 +192,11 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	objects, _, err := strg.List(ctx, "", 1000)
+	res, err := strg.List(ctx, s2.ListOptions{Limit: 1000})
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("%v\n", objects)
+	fmt.Printf("%v\n", res.Objects)
 }
 ```
 
@@ -310,19 +310,51 @@ When `S3Config` is nil or all fields are empty, the standard AWS SDK credential 
 type Storage interface {
 	Type() Type
 	Sub(ctx context.Context, prefix string) (Storage, error)
-	List(ctx context.Context, prefix string, limit int) ([]Object, []string, error)
-	ListAfter(ctx context.Context, prefix string, limit int, after string) ([]Object, []string, error)
-	ListRecursive(ctx context.Context, prefix string, limit int) ([]Object, error)
-	ListRecursiveAfter(ctx context.Context, prefix string, limit int, after string) ([]Object, error)
+	List(ctx context.Context, opts ListOptions) (ListResult, error)
 	Get(ctx context.Context, name string) (Object, error)
 	Exists(ctx context.Context, name string) (bool, error)
 	Put(ctx context.Context, obj Object) error
 	PutMetadata(ctx context.Context, name string, metadata Metadata) error
 	Copy(ctx context.Context, src, dst string) error
-	Move(ctx context.Context, src, dst string) error
 	Delete(ctx context.Context, name string) error
 	DeleteRecursive(ctx context.Context, prefix string) error
-	SignedURL(ctx context.Context, name string, ttl time.Duration) (string, error)
+	SignedURL(ctx context.Context, opts SignedURLOptions) (string, error)
+}
+
+// One List method covers flat and recursive listings, with explicit
+// pagination via continuation token.
+type ListOptions struct {
+	Prefix    string
+	After     string // continuation token; empty = first page
+	Limit     int    // 0 = backend default
+	Recursive bool
+}
+
+type ListResult struct {
+	Objects        []Object
+	CommonPrefixes []string // empty when Recursive == true
+	NextAfter      string   // empty when exhausted
+}
+
+// SignedURL is method-aware so backends can issue both download and upload URLs.
+type SignedURLOptions struct {
+	Name   string
+	Method SignedURLMethod // SignedURLGet (default) or SignedURLPut
+	TTL    time.Duration
+}
+```
+
+Move is a free function rather than a method so backends do not have to implement two near-identical operations. Backends that can do better than `Copy + Delete` (e.g. `osfs` via filesystem rename) satisfy the optional `s2.Mover` interface, which `s2.Move` discovers via type assertion:
+
+```go
+err := s2.Move(ctx, strg, "src.txt", "dst.txt")
+```
+
+Errors that report a missing object wrap [`s2.ErrNotExist`](https://pkg.go.dev/github.com/mojatter/s2#pkg-variables); detect them with `errors.Is`:
+
+```go
+if _, err := strg.Get(ctx, "missing.txt"); errors.Is(err, s2.ErrNotExist) {
+	// handle not found
 }
 ```
 

--- a/fs/atomic.go
+++ b/fs/atomic.go
@@ -15,7 +15,7 @@ import (
 
 // tmpPrefix is the basename prefix used for in-flight atomic-write files.
 // Entries with this prefix are hidden from listings so partial writes are
-// never observable through List/ListRecursive.
+// never observable through Storage.List (in either flat or recursive mode).
 const tmpPrefix = ".s2tmp-"
 
 // atomicWrite writes src into name using a temp-file + Sync + Rename pattern

--- a/s2test/s2test.go
+++ b/s2test/s2test.go
@@ -12,8 +12,9 @@ import (
 )
 
 // TestStorageList is a test helper for validating s2.Storage list operations.
-// It tests the List and ListAfter methods of an s2.Storage implementation
-// for a particular prefix against the expected direct object names.
+// It exercises the flat-listing path of Storage.List (Recursive: false) for a
+// particular prefix against the expected direct object names, including a
+// pagination round-trip via the After continuation token.
 // The expected array should only contain names of objects immediately beneath the prefix.
 // expectedPrefixes is an optional list of expected common prefixes (subdirectories).
 func TestStorageList(ctx context.Context, strg s2.Storage, prefix string, expected ...string) error {
@@ -93,8 +94,9 @@ func TestStorageListWithPrefixes(ctx context.Context, strg s2.Storage, prefix st
 }
 
 // TestStorageListRecursive is a test helper for validating s2.Storage recursive list operations.
-// It tests the ListRecursive and ListRecursiveAfter methods
-// of an s2.Storage implementation against the expected object names.
+// It exercises the recursive path of Storage.List (Recursive: true) — including
+// a prefix-filter case and a pagination round-trip via the After continuation
+// token — against the expected object names.
 // The provided expected array must be the comprehensive list of object names in the storage.
 func TestStorageListRecursive(ctx context.Context, strg s2.Storage, expected ...string) error {
 	sort.Strings(expected)


### PR DESCRIPTION
## Summary
Pre-tag fixup for v0.2.0. The Storage Interface block in \`README.md\` was carried over verbatim from v0.1 and still listed the four removed List methods, the removed \`Storage.Move\`, and the old \`SignedURL\` signature. Two Quick Start snippets also called the old three-return \`List\` form (\`objects, prefixes, err\`).

This PR brings the README and a couple of leftover internal comments in sync with the v0.2 public surface.

### README
- **Storage Interface block** — replaced with the single \`List(opts)\` signature plus the new \`ListOptions\` / \`ListResult\` / \`SignedURLOptions\` types, a short note about \`s2.Move\` and the optional \`Mover\` interface, and an \`errors.Is(err, s2.ErrNotExist)\` example.
- **Quick Start snippets** — switched to \`res, err := strg.List(ctx, s2.ListOptions{...})\` and \`res.Objects\`.

### Internal comments
- \`s2test/s2test.go\` godoc on \`TestStorageList\` and \`TestStorageListRecursive\` — no longer mention the deleted \`ListAfter\` / \`ListRecursive\` / \`ListRecursiveAfter\` method names.
- \`fs/atomic.go\` — \`tmpPrefix\` comment no longer references the deleted \`ListRecursive\` method.

## Why now
This is a release blocker for **v0.2.0**: a new user landing on pkg.go.dev or the README would copy code that no longer compiles. Worth a small targeted PR rather than rolling into a future commit.

## Test plan
- [x] \`go test ./...\`
- [x] \`golangci-lint run ./...\`
- [x] Visually inspected the rendered README block on the PR diff page