### PR TITLE
docs: add S3 Compatibility section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,18 @@ s2-server -f config.json
 
 Custom metadata is supported via `x-amz-meta-*` headers on PutObject/CopyObject and returned on GetObject/HeadObject.
 
+## S3 Compatibility
+
+S2 Server is designed to drop-in replace MinIO for:
+
+- ✅ Local development against `aws-sdk-go`, `boto3`, `@aws-sdk/client-s3`, and other S3 SDKs
+- ✅ CI/test environments using S3 via testcontainers or docker-compose
+- ✅ Small-scale production for static assets, uploads, and backups
+- ✅ Presigned URL workflows (browser uploads/downloads)
+- ✅ Multipart uploads for large objects
+
+It is **not** a replacement for AWS S3 in scenarios requiring versioning, server-side encryption, IAM policies, lifecycle management, or multi-node replication. See [Limitations](#limitations) for details.
+
 ## Limitations
 
 S2 aims to cover the parts of the S3 API that matter for local development and lightweight production use. Some features are intentionally **not** implemented:


### PR DESCRIPTION
## Summary
- Add a new `## S3 Compatibility` section to the README, clarifying the use cases where S2 Server works as a drop-in replacement for MinIO
- Keep the existing `## Limitations` section for honesty and cross-link to it

## Test plan
- [x] Verified rendering in Markdown preview