### PR TITLE
ci: replace staticcheck/gosec with golangci-lint

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,4 @@
-name: Go
+name: Tests
 
 on:
   push:
@@ -29,12 +29,7 @@ jobs:
           go mod tidy
           go test -v ./...
       -
-        name: Run staticcheck
-        run: |
-          go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
-          staticcheck ./...
-      -
-        name: Run gosec
-        run: |
-          go install github.com/securego/gosec/v2/cmd/gosec@v2.24.7
-          gosec ./...
+        name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.11.4


### PR DESCRIPTION
## Summary
- Consolidate the separate staticcheck and gosec steps into a single `golangci-lint` step using `golangci/golangci-lint-action@v7` (v2.11.4).
- Unblocks #19: lowering go.mod to go1.24 in c62e08d removed the version mismatch that originally forced the revert.

## Test plan
- [x] `golangci-lint run ./...` locally → 0 issues
- [x] CI green on this PR

Closes #19