### PR TITLE
chore(ci): Add Dependabot weekly update config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Enable Dependabot for `gomod` and `github-actions` on a weekly schedule.
- Group all updates per ecosystem into a single PR to reduce review overhead.

## Test plan
- [ ] Dependabot picks up the config and opens grouped PRs on the next run.