### PR TITLE
ci: Add govulncheck workflow

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -1,0 +1,24 @@
+name: govulncheck
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'  # Every Monday 03:00 UTC
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/govulncheck.yaml'
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Run govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          go-version-file: go.mod


### PR DESCRIPTION
## Summary
- Run `govulncheck` weekly (Mon 03:00 UTC), on demand, and on PRs touching `go.mod`/`go.sum` or the workflow itself.
- Catches known vulnerabilities in Go dependencies early — relevant given s2 exposes an S3-compatible HTTP API.

## Test plan
- [ ] Workflow runs successfully on this PR.