### PR TITLE
bench: Add Go-native microbenchmarks and make bench target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,17 @@ test:
 test-integration:
 	go test -v -count=1 ./server/handlers/s3api/ -run Integration
 
+# bench runs Go-native microbenchmarks against the storage backend and the
+# HTTP handler. Shorter than bench-warp and requires no external binaries,
+# so it's the right knob for in-loop regression checks.
+BENCH_GO_PACKAGES ?= ./fs/ ./server/handlers/s3api/
+BENCH_GO_RE       ?= BenchmarkPutObject|BenchmarkGetObject|BenchmarkHTTPPutObject|BenchmarkHTTPGetObject
+BENCH_GO_TIME     ?= 2s
+
+.PHONY: bench
+bench:
+	go test $(BENCH_GO_PACKAGES) -run='^$$' -bench='$(BENCH_GO_RE)' -benchmem -benchtime=$(BENCH_GO_TIME)
+
 .PHONY: test-e2e
 test-e2e:
 	docker compose -f s2test/e2e/docker-compose.yml run --build --rm test; \

--- a/README.md
+++ b/README.md
@@ -456,13 +456,35 @@ Custom metadata is supported via `x-amz-meta-*` headers on PutObject/CopyObject 
 
 ## Benchmarks
 
-S2 ships a `make bench-warp` target that drives a fresh in-process s2-server with [`minio/warp`](https://github.com/minio/warp). Install warp first with `go install github.com/minio/warp@latest`, then:
+Two complementary benchmark harnesses ship with S2:
 
-```sh
-make bench-warp
-```
+- **`make bench`** runs Go-native `testing.B` benchmarks against the storage layer (`fs` package) and the HTTP handler (`server/handlers/s3api` package). Good for catching regressions in a unit-test-style loop — no external binary needed.
+- **`make bench-warp`** drives a fresh in-process s2-server end-to-end with [`minio/warp`](https://github.com/minio/warp). Good for SDK-level throughput numbers that exercise the whole stack (connection pooling, SigV4 streaming, chunked bodies, real wire HTTP). Install warp first with `go install github.com/minio/warp@latest`.
 
-The numbers below are from a local run on an Apple Silicon laptop (`darwin/arm64`, `osfs` backend, single-process server), captured with the default `make bench-warp` settings (1 MiB objects, 8 concurrent clients, 30 seconds, `warp mixed`). They are intended as a sanity check, not a competitive ranking — the most useful number is the one you get on your own hardware.
+Numbers below are local runs on an Apple M4 (`darwin/arm64`, single process). Treat them as sanity checks, not competitive rankings — the most useful number is the one you get on your own hardware.
+
+### Go-native microbenchmarks
+
+1 KiB payload, `osfs` backend rooted at `b.TempDir()`, 2-second bench time. `make bench` runs the full set.
+
+| Benchmark | ns/op | B/op | allocs/op |
+|---|---:|---:|---:|
+| `BenchmarkPutObject` (osfs) | 4,255,653 | 2,856 | 31 |
+| `BenchmarkGetObject` (osfs) | 38,011 | 1,051 | 12 |
+| `BenchmarkPutObjectMemFS` | 2,363 | 4,072 | 78 |
+| `BenchmarkGetObjectMemFS` | 337 | 416 | 14 |
+| `BenchmarkHTTPPutObject` (osfs) | 9,330,348 | 50,591 | 181 |
+| `BenchmarkHTTPGetObject` (osfs) | 168,535 | 11,923 | 138 |
+| `BenchmarkHTTPPutObjectMemFS` | 166,138 | 46,665 | 196 |
+| `BenchmarkHTTPGetObjectMemFS` | 35,402 | 43,067 | 120 |
+
+The `osfs` PUT path always fsyncs before rename — that durability guarantee is roughly **4 ms of the 4.2 ms per storage-layer PUT** on this machine. For apples-to-apples comparisons against benchmarks from other S3-compatible servers, make sure they are running with fsync enabled as well; many default to write-through-page-cache and will look proportionally faster until you flip the fsync switch on.
+
+The `memfs` columns exist because S2 ships an in-memory backend specifically for tests; skipping the disk barrier makes `GetObject` over **100x faster** and `PutObject` over **1800x faster** than `osfs` on the same hardware, which is what makes `memfs` worth reaching for in unit tests that need an S3-compatible target without Docker or a temp directory.
+
+### End-to-end benchmark with warp
+
+Captured with the default `make bench-warp` settings (1 MiB objects, 8 concurrent clients, 30 seconds, `warp mixed`), `osfs` backend.
 
 | Operation | Throughput | p50 latency | p99 latency |
 |---|---|---|---|
@@ -471,8 +493,6 @@ The numbers below are from a local run on an Apple Silicon laptop (`darwin/arm64
 | **STAT** | 265.58 obj/s | 0.4 ms | 3.3 ms |
 | **DELETE** | 88.70 obj/s | 4.5 ms | 12.8 ms |
 | **Total** | **531.30 MiB/s, 885.58 obj/s** | — | — |
-
-PUT throughput is bounded by `osfs`'s atomic write (rename after `Sync`); switching to `memfs` removes the disk barrier when you only need a fast in-process target for tests.
 
 You can run any other warp workload by overriding the Makefile variables, e.g. larger objects:
 

--- a/fs/storage_test.go
+++ b/fs/storage_test.go
@@ -1,10 +1,12 @@
 package fs
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"io/fs"
+	"path"
 	"testing"
 	"time"
 
@@ -693,3 +695,83 @@ func (s *StorageTestSuite) TestSignedURL() {
 		})
 	}
 }
+
+// --- Benchmarks ---
+//
+// Storage-layer benchmarks against the osfs and memfs backends with a
+// 1 KiB payload. PUT rotates the key across a small alphabet so each
+// iteration writes to a distinct path (stressing directory creation
+// and rename); GET repeatedly reads a single pre-populated key
+// (stressing open/stat/read). Note that s2's atomicWrite always fsyncs
+// the payload before rename, so PUT here pays the durability cost on
+// every iteration — when comparing against benchmarks from other S3
+// implementations, verify that they are also running with fsync on
+// before drawing conclusions.
+
+// newBenchStorage creates an empty Storage for the given backend type.
+// osfs is rooted at b.TempDir() so iteration state is isolated from
+// other tests/benches in the package; memfs is a pristine in-memory
+// filesystem. Used to share the bench bodies between osfs and memfs
+// variants.
+func newBenchStorage(b *testing.B, typ s2.Type) s2.Storage {
+	b.Helper()
+	cfg := s2.Config{Type: typ}
+	if typ == s2.TypeOSFS {
+		cfg.Root = b.TempDir()
+	}
+	strg, err := s2.NewStorage(context.Background(), cfg)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return strg
+}
+
+func benchPutObject(b *testing.B, typ s2.Type) {
+	ctx := context.Background()
+	strg := newBenchStorage(b, typ)
+	content := bytes.Repeat([]byte("a"), 1024) // 1 KiB
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		key := path.Join("test", string(rune(i%26+97)), "file.txt")
+		if err := strg.Put(ctx, s2.NewObjectBytes(key, content)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func benchGetObject(b *testing.B, typ s2.Type) {
+	ctx := context.Background()
+	strg := newBenchStorage(b, typ)
+	content := bytes.Repeat([]byte("a"), 1024) // 1 KiB
+	if err := strg.Put(ctx, s2.NewObjectBytes("test.txt", content)); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		obj, err := strg.Get(ctx, "test.txt")
+		if err != nil {
+			b.Fatal(err)
+		}
+		rc, err := obj.Open()
+		if err != nil {
+			b.Fatal(err)
+		}
+		if _, err := io.Copy(io.Discard, rc); err != nil {
+			b.Fatal(err)
+		}
+		_ = rc.Close()
+	}
+}
+
+// BenchmarkPutObject covers the osfs backend with a 1 KiB payload and
+// rotating-key writes. s2's atomicWrite always fsyncs before rename;
+// see BenchmarkPutObjectMemFS for numbers that exclude the durability
+// cost.
+func BenchmarkPutObject(b *testing.B)    { benchPutObject(b, s2.TypeOSFS) }
+func BenchmarkGetObject(b *testing.B)    { benchGetObject(b, s2.TypeOSFS) }
+func BenchmarkPutObjectMemFS(b *testing.B) { benchPutObject(b, s2.TypeMemFS) }
+func BenchmarkGetObjectMemFS(b *testing.B) { benchGetObject(b, s2.TypeMemFS) }

--- a/server/handlers/s3api/objects_test.go
+++ b/server/handlers/s3api/objects_test.go
@@ -1,10 +1,12 @@
 package s3api
 
 import (
+	"bytes"
 	"context"
 	"crypto/md5"
 	"encoding/hex"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +15,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+
+	"github.com/mojatter/s2"
+	_ "github.com/mojatter/s2/fs"
+	"github.com/mojatter/s2/server"
 )
 
 type ObjectsTestSuite struct{ s3apiSuite }
@@ -1312,3 +1318,104 @@ func (s *ObjectsTestSuite) TestXMLResponseFormat() {
 	s.Contains(w.Body.String(), `<?xml version="1.0" encoding="UTF-8"?>`)
 	s.Contains(w.Body.String(), `xmlns="http://s3.amazonaws.com/doc/2006-03-01/"`)
 }
+
+// --- HTTP Benchmarks ---
+//
+// End-to-end HTTP-layer benchmarks against the S3 handler with a 1 KiB
+// payload. PUT rotates the object key each iteration (so no caching
+// hides work); GET repeatedly reads a single pre-populated object. The
+// server runs with authentication disabled (cfg.User == "") so the
+// benchmark measures transport + handler + storage cost without
+// SigV4 signature verification noise.
+
+// setupBenchServer brings up an in-process S3 listener for benchmarks.
+// The backend is selected by the caller; osfs is rooted at b.TempDir()
+// while memfs is a pristine in-process filesystem. The "benchbucket"
+// bucket is pre-created.
+func setupBenchServer(b *testing.B, typ s2.Type) *httptest.Server {
+	b.Helper()
+	cfg := server.DefaultConfig()
+	cfg.Type = typ
+	if typ == s2.TypeOSFS {
+		cfg.Root = b.TempDir()
+	}
+	cfg.User = ""
+	cfg.HealthPath = ""
+	cfg.ConsoleListen = ""
+	srv, err := server.NewServer(context.Background(), cfg)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := srv.Buckets.Create(context.Background(), "benchbucket"); err != nil {
+		b.Fatal(err)
+	}
+	ts := httptest.NewServer(srv.S3Handler())
+	b.Cleanup(ts.Close)
+	return ts
+}
+
+func benchHTTPPutObject(b *testing.B, typ s2.Type) {
+	srv := setupBenchServer(b, typ)
+	payload := bytes.Repeat([]byte("a"), 1024) // 1 KiB
+	client := srv.Client()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		key := fmt.Sprintf("file-%d.txt", i)
+		req, err := http.NewRequest(http.MethodPut, srv.URL+"/benchbucket/"+key, bytes.NewReader(payload))
+		if err != nil {
+			b.Fatal(err)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			b.Fatalf("PUT status %d", resp.StatusCode)
+		}
+	}
+}
+
+func benchHTTPGetObject(b *testing.B, typ s2.Type) {
+	srv := setupBenchServer(b, typ)
+
+	// Pre-populate one object that every iteration reads.
+	payload := bytes.Repeat([]byte("a"), 1024)
+	req, err := http.NewRequest(http.MethodPut, srv.URL+"/benchbucket/read.txt", bytes.NewReader(payload))
+	if err != nil {
+		b.Fatal(err)
+	}
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		b.Fatal(err)
+	}
+	_ = resp.Body.Close()
+
+	client := srv.Client()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		req, err := http.NewRequest(http.MethodGet, srv.URL+"/benchbucket/read.txt", nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			b.Fatalf("GET status %d", resp.StatusCode)
+		}
+	}
+}
+
+func BenchmarkHTTPPutObject(b *testing.B)      { benchHTTPPutObject(b, s2.TypeOSFS) }
+func BenchmarkHTTPGetObject(b *testing.B)      { benchHTTPGetObject(b, s2.TypeOSFS) }
+func BenchmarkHTTPPutObjectMemFS(b *testing.B) { benchHTTPPutObject(b, s2.TypeMemFS) }
+func BenchmarkHTTPGetObjectMemFS(b *testing.B) { benchHTTPGetObject(b, s2.TypeMemFS) }


### PR DESCRIPTION
## Summary

- Add Go-native `testing.B` benchmarks at two layers: the storage interface (`fs` package) and the S3 HTTP handler (`server/handlers/s3api` package). Each ships in an `osfs` and a `memfs` variant so the disk vs in-process cost split is obvious.
- Add a `make bench` target that runs the full set with `-benchmem` at a 2-second bench time (override via `BENCH_GO_TIME`). The existing `make bench-warp` stays as the end-to-end driver; this new target is the in-loop regression knob.
- Expand the README Benchmarks section with the microbenchmark results alongside the existing `warp mixed` table and a fsync-comparison caveat.

## Why it's worth landing

Microbenchmarks live in the repo, so they're something you can run during a refactor to catch regressions without standing up a full warp harness. They also split the "storage cost" from the "HTTP layer cost" cleanly: on this machine the storage-layer `GetObject` is 38 µs while the HTTP-layer version is 168 µs, so about **130 µs of the HTTP GET is pure handler/middleware overhead**. That's a useful number to have in the repo before touching the handler path.

The `memfs` variants exist because s2's in-memory backend is one of its differentiators: tests can use it to replace Docker-backed MinIO in CI. Having benchmarks that quantify "how much disk cost are you skipping" (100x on GET, 1800x on PUT on this machine) makes the pitch concrete.

## fsync caveat

The `osfs` PUT path always fsyncs before rename — that durability guarantee is roughly **4 ms of the 4.2 ms per storage-layer PUT** on this machine. Microbenchmarks from other S3 implementations often default to write-through-page-cache; make sure both sides are running with fsync enabled before drawing "X is faster than Y" conclusions from PUT numbers.

## Test plan

- [x] `make bench` — full run, numbers stable across re-runs
- [x] `go test -count=1 ./...`
- [x] `golangci-lint run ./...`