### PR TITLE
test(console): Add handler tests for the entire Web Console

### DIFF
--- a/server/handlers/console/buckets/objects/view_test.go
+++ b/server/handlers/console/buckets/objects/view_test.go
@@ -1,0 +1,233 @@
+package objects
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mojatter/s2"
+	"github.com/mojatter/s2/server"
+	"github.com/stretchr/testify/suite"
+)
+
+type viewSuite struct {
+	suite.Suite
+	server *server.Server
+}
+
+func (s *viewSuite) SetupTest() {
+	cfg := server.DefaultConfig()
+	cfg.Root = s.T().TempDir()
+	srv, err := server.NewServer(context.Background(), cfg)
+	s.Require().NoError(err)
+	s.server = srv
+}
+
+func (s *viewSuite) createBucket(name string) {
+	s.T().Helper()
+	s.Require().NoError(s.server.Buckets.Create(context.Background(), name))
+}
+
+func (s *viewSuite) putObject(bucket, key string, content []byte, opts ...s2.ObjectOption) {
+	s.T().Helper()
+	ctx := context.Background()
+	strg, err := s.server.Buckets.Get(ctx, bucket)
+	s.Require().NoError(err)
+	s.Require().NoError(strg.Put(ctx, s2.NewObjectBytes(key, content, opts...)))
+}
+
+type ViewTestSuite struct{ viewSuite }
+
+func TestViewTestSuite(t *testing.T) {
+	suite.Run(t, &ViewTestSuite{})
+}
+
+// --- GET /buckets/{name}/view/{object...} ---
+
+func (s *ViewTestSuite) TestHandleView() {
+	s.Run("text file", func() {
+		s.createBucket("view")
+		s.putObject("view", "hello.txt", []byte("Hello, World!"))
+
+		req := httptest.NewRequest("GET", "/buckets/view/view/hello.txt", nil)
+		req.SetPathValue("name", "view")
+		req.SetPathValue("object", "hello.txt")
+		w := httptest.NewRecorder()
+		handleView(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		s.Contains(w.Header().Get("Content-Type"), "text/plain")
+		s.Contains(w.Header().Get("Content-Disposition"), "hello.txt")
+		s.Equal("Hello, World!", w.Body.String())
+	})
+
+	s.Run("image file", func() {
+		s.createBucket("view-img")
+		s.putObject("view-img", "pic.png", []byte("fake-png"))
+
+		req := httptest.NewRequest("GET", "/buckets/view-img/view/pic.png", nil)
+		req.SetPathValue("name", "view-img")
+		req.SetPathValue("object", "pic.png")
+		w := httptest.NewRecorder()
+		handleView(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		s.Equal("image/png", w.Header().Get("Content-Type"))
+	})
+
+	s.Run("nested path", func() {
+		s.createBucket("view-nest")
+		s.server.Buckets.CreateFolder(context.Background(), "view-nest", "a/b")
+		s.putObject("view-nest", "a/b/deep.txt", []byte("deep"))
+
+		req := httptest.NewRequest("GET", "/buckets/view-nest/view/a/b/deep.txt", nil)
+		req.SetPathValue("name", "view-nest")
+		req.SetPathValue("object", "a/b/deep.txt")
+		w := httptest.NewRecorder()
+		handleView(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		s.Equal("deep", w.Body.String())
+	})
+
+	s.Run("nonexistent bucket", func() {
+		req := httptest.NewRequest("GET", "/buckets/nope/view/x.txt", nil)
+		req.SetPathValue("name", "nope")
+		req.SetPathValue("object", "x.txt")
+		w := httptest.NewRecorder()
+		handleView(s.server, w, req)
+
+		s.Equal(http.StatusNotFound, w.Code)
+	})
+
+	s.Run("nonexistent object", func() {
+		s.createBucket("view-miss")
+
+		req := httptest.NewRequest("GET", "/buckets/view-miss/view/missing.txt", nil)
+		req.SetPathValue("name", "view-miss")
+		req.SetPathValue("object", "missing.txt")
+		w := httptest.NewRecorder()
+		handleView(s.server, w, req)
+
+		s.Equal(http.StatusNotFound, w.Code)
+	})
+}
+
+// --- contentTypeByExt ---
+
+func (s *ViewTestSuite) TestContentTypeByExt() {
+	// contentTypeByExt tries mime.TypeByExtension first, then falls
+	// back to a built-in switch. The OS MIME database differs between
+	// macOS and Linux, so we only assert on properties that hold
+	// regardless of the platform.
+	testCases := []struct {
+		caseName      string
+		ext           string
+		wantNonEmpty  bool   // result must not be empty
+		wantContains  string // result must contain this substring (if non-empty)
+	}{
+		{caseName: "Go source returns text", ext: ".go", wantNonEmpty: true, wantContains: "text/"},
+		{caseName: "JSON", ext: ".json", wantNonEmpty: true, wantContains: "json"},
+		{caseName: "CSS", ext: ".css", wantNonEmpty: true, wantContains: "css"},
+		{caseName: "PNG image", ext: ".png", wantNonEmpty: true, wantContains: "image/png"},
+		{caseName: "WebP image", ext: ".webp", wantNonEmpty: true, wantContains: "image/webp"},
+		{caseName: "Wasm binary", ext: ".wasm", wantNonEmpty: true, wantContains: "wasm"},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			got := contentTypeByExt(tc.ext)
+			if tc.wantNonEmpty {
+				s.NotEmpty(got)
+			}
+			if tc.wantContains != "" {
+				s.Contains(got, tc.wantContains)
+			}
+		})
+	}
+}
+
+// --- GET /buckets/{name}/meta/{object...} ---
+
+func (s *ViewTestSuite) TestHandleMeta() {
+	s.Run("basic metadata", func() {
+		s.createBucket("meta")
+		s.putObject("meta", "doc.txt", []byte("content"))
+
+		req := httptest.NewRequest("GET", "/buckets/meta/meta/doc.txt", nil)
+		req.SetPathValue("name", "meta")
+		req.SetPathValue("object", "doc.txt")
+		w := httptest.NewRecorder()
+		handleMeta(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		s.Equal("application/json", w.Header().Get("Content-Type"))
+
+		var resp map[string]any
+		s.Require().NoError(json.Unmarshal(w.Body.Bytes(), &resp))
+		s.Equal("doc.txt", resp["name"])
+		s.Contains(resp["contentType"], "text/plain")
+		s.Equal(float64(7), resp["size"])
+		s.NotEmpty(resp["lastModified"])
+	})
+
+	s.Run("with custom metadata", func() {
+		s.createBucket("meta-custom")
+		md := s2.Metadata{"author": "test", "version": "1"}
+		s.putObject("meta-custom", "with-meta.txt", []byte("x"), s2.WithMetadata(md))
+
+		req := httptest.NewRequest("GET", "/buckets/meta-custom/meta/with-meta.txt", nil)
+		req.SetPathValue("name", "meta-custom")
+		req.SetPathValue("object", "with-meta.txt")
+		w := httptest.NewRecorder()
+		handleMeta(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+
+		var resp map[string]any
+		s.Require().NoError(json.Unmarshal(w.Body.Bytes(), &resp))
+		metadata, ok := resp["metadata"].(map[string]any)
+		s.True(ok)
+		s.Equal("test", metadata["author"])
+		s.Equal("1", metadata["version"])
+	})
+
+	s.Run("no custom metadata omits field", func() {
+		s.createBucket("meta-none")
+		s.putObject("meta-none", "plain.txt", []byte("x"))
+
+		req := httptest.NewRequest("GET", "/buckets/meta-none/meta/plain.txt", nil)
+		req.SetPathValue("name", "meta-none")
+		req.SetPathValue("object", "plain.txt")
+		w := httptest.NewRecorder()
+		handleMeta(s.server, w, req)
+
+		var resp map[string]any
+		s.Require().NoError(json.Unmarshal(w.Body.Bytes(), &resp))
+		_, hasMetadata := resp["metadata"]
+		s.False(hasMetadata)
+	})
+
+	s.Run("nonexistent bucket", func() {
+		req := httptest.NewRequest("GET", "/buckets/nope/meta/x.txt", nil)
+		req.SetPathValue("name", "nope")
+		req.SetPathValue("object", "x.txt")
+		w := httptest.NewRecorder()
+		handleMeta(s.server, w, req)
+
+		s.Equal(http.StatusNotFound, w.Code)
+	})
+
+	s.Run("nonexistent object", func() {
+		s.createBucket("meta-miss")
+
+		req := httptest.NewRequest("GET", "/buckets/meta-miss/meta/missing.txt", nil)
+		req.SetPathValue("name", "meta-miss")
+		req.SetPathValue("object", "missing.txt")
+		w := httptest.NewRecorder()
+		handleMeta(s.server, w, req)
+
+		s.Equal(http.StatusNotFound, w.Code)
+	})
+}

--- a/server/handlers/console/buckets/objects_test.go
+++ b/server/handlers/console/buckets/objects_test.go
@@ -1,0 +1,196 @@
+package buckets
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/mojatter/s2"
+	"github.com/mojatter/s2/server"
+	"github.com/stretchr/testify/suite"
+)
+
+type objectsSuite struct {
+	suite.Suite
+	server *server.Server
+}
+
+func (s *objectsSuite) SetupTest() {
+	cfg := server.DefaultConfig()
+	cfg.Root = s.T().TempDir()
+	srv, err := server.NewServer(context.Background(), cfg)
+	s.Require().NoError(err)
+	s.server = srv
+}
+
+func (s *objectsSuite) createBucket(name string) {
+	s.T().Helper()
+	s.Require().NoError(s.server.Buckets.Create(context.Background(), name))
+}
+
+func (s *objectsSuite) putObject(bucket, key, content string) {
+	s.T().Helper()
+	ctx := context.Background()
+	strg, err := s.server.Buckets.Get(ctx, bucket)
+	s.Require().NoError(err)
+	s.Require().NoError(strg.Put(ctx, s2.NewObjectBytes(key, []byte(content))))
+}
+
+type ObjectsTestSuite struct{ objectsSuite }
+
+func TestObjectsTestSuite(t *testing.T) {
+	suite.Run(t, &ObjectsTestSuite{})
+}
+
+// --- GET /buckets/{name} ---
+
+func (s *ObjectsTestSuite) TestHandleObjects() {
+	s.Run("empty bucket", func() {
+		s.createBucket("empty")
+
+		req := httptest.NewRequest("GET", "/buckets/empty", nil)
+		req.SetPathValue("name", "empty")
+		req.Header.Set("HX-Request", "true")
+		w := httptest.NewRecorder()
+		handleObjects(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		s.Contains(w.Body.String(), "This folder is empty")
+	})
+
+	s.Run("with objects", func() {
+		s.createBucket("files")
+		s.putObject("files", "readme.txt", "hello")
+
+		req := httptest.NewRequest("GET", "/buckets/files", nil)
+		req.SetPathValue("name", "files")
+		req.Header.Set("HX-Request", "true")
+		w := httptest.NewRecorder()
+		handleObjects(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		s.Contains(w.Body.String(), "readme.txt")
+	})
+
+	s.Run("with prefix", func() {
+		s.createBucket("nested")
+		s.server.Buckets.CreateFolder(context.Background(), "nested", "sub")
+		s.putObject("nested", "sub/file.txt", "data")
+
+		req := httptest.NewRequest("GET", "/buckets/nested?prefix=sub", nil)
+		req.SetPathValue("name", "nested")
+		req.Header.Set("HX-Request", "true")
+		w := httptest.NewRecorder()
+		handleObjects(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		body := w.Body.String()
+		s.Contains(body, "file.txt")
+		s.Contains(body, "Parent Directory")
+	})
+
+	s.Run("nonexistent bucket", func() {
+		req := httptest.NewRequest("GET", "/buckets/nope", nil)
+		req.SetPathValue("name", "nope")
+		w := httptest.NewRecorder()
+		handleObjects(s.server, w, req)
+
+		s.Equal(http.StatusNotFound, w.Code)
+	})
+
+	s.Run("full page without HX-Request", func() {
+		s.createBucket("full")
+
+		req := httptest.NewRequest("GET", "/buckets/full", nil)
+		req.SetPathValue("name", "full")
+		w := httptest.NewRecorder()
+		handleObjects(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		s.Contains(w.Body.String(), "<!DOCTYPE html>")
+	})
+}
+
+// --- POST /buckets/{name}/folders ---
+
+func (s *ObjectsTestSuite) TestHandleCreateFolder() {
+	s.Run("success", func() {
+		s.createBucket("fld")
+
+		form := url.Values{"prefix": {""}, "folder_name": {"photos"}}
+		req := httptest.NewRequest("POST", "/buckets/fld/folders", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("HX-Request", "true")
+		req.SetPathValue("name", "fld")
+		w := httptest.NewRecorder()
+		handleCreateFolder(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		s.Contains(w.Body.String(), "photos")
+	})
+
+	s.Run("empty name", func() {
+		s.createBucket("fld2")
+
+		form := url.Values{"prefix": {""}, "folder_name": {""}}
+		req := httptest.NewRequest("POST", "/buckets/fld2/folders", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.SetPathValue("name", "fld2")
+		w := httptest.NewRecorder()
+		handleCreateFolder(s.server, w, req)
+
+		s.Equal(http.StatusBadRequest, w.Code)
+	})
+}
+
+// --- DELETE /buckets/{name}/objects ---
+
+func (s *ObjectsTestSuite) TestHandleDeleteObject() {
+	s.Run("delete file", func() {
+		s.createBucket("del")
+		s.putObject("del", "a.txt", "data")
+
+		req := httptest.NewRequest("DELETE", "/buckets/del/objects?key=a.txt&prefix=", nil)
+		req.SetPathValue("name", "del")
+		req.Header.Set("HX-Request", "true")
+		w := httptest.NewRecorder()
+		handleDeleteObject(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		s.NotContains(w.Body.String(), "a.txt")
+	})
+
+	s.Run("delete folder recursively", func() {
+		s.createBucket("delr")
+		s.server.Buckets.CreateFolder(context.Background(), "delr", "dir")
+		s.putObject("delr", "dir/b.txt", "data")
+
+		req := httptest.NewRequest("DELETE", "/buckets/delr/objects?key=dir/&prefix=", nil)
+		req.SetPathValue("name", "delr")
+		req.Header.Set("HX-Request", "true")
+		w := httptest.NewRecorder()
+		handleDeleteObject(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+
+		strg, err := s.server.Buckets.Get(context.Background(), "delr")
+		s.Require().NoError(err)
+		exists, err := strg.Exists(context.Background(), "dir/b.txt")
+		s.Require().NoError(err)
+		s.False(exists)
+	})
+
+	s.Run("missing key", func() {
+		s.createBucket("delm")
+
+		req := httptest.NewRequest("DELETE", "/buckets/delm/objects", nil)
+		req.SetPathValue("name", "delm")
+		w := httptest.NewRecorder()
+		handleDeleteObject(s.server, w, req)
+
+		s.Equal(http.StatusBadRequest, w.Code)
+	})
+}

--- a/server/handlers/console/console_test.go
+++ b/server/handlers/console/console_test.go
@@ -1,0 +1,120 @@
+package console
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/mojatter/s2/server"
+	"github.com/stretchr/testify/suite"
+)
+
+type consoleSuite struct {
+	suite.Suite
+	server *server.Server
+}
+
+func (s *consoleSuite) SetupTest() {
+	cfg := server.DefaultConfig()
+	cfg.Root = s.T().TempDir()
+	srv, err := server.NewServer(context.Background(), cfg)
+	s.Require().NoError(err)
+	s.server = srv
+}
+
+func (s *consoleSuite) createBucket(name string) {
+	s.T().Helper()
+	s.Require().NoError(s.server.Buckets.Create(context.Background(), name))
+}
+
+type IndexTestSuite struct{ consoleSuite }
+
+func TestIndexTestSuite(t *testing.T) {
+	suite.Run(t, &IndexTestSuite{})
+}
+
+// --- GET / ---
+
+func (s *IndexTestSuite) TestHandleIndex() {
+	s.Run("empty", func() {
+		req := httptest.NewRequest("GET", "/", nil)
+		w := httptest.NewRecorder()
+		handleIndex(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		s.Contains(w.Body.String(), "Storage Overview")
+	})
+
+	s.Run("with buckets", func() {
+		s.createBucket("alpha")
+		s.createBucket("beta")
+
+		req := httptest.NewRequest("GET", "/", nil)
+		w := httptest.NewRecorder()
+		handleIndex(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		body := w.Body.String()
+		s.Contains(body, "alpha")
+		s.Contains(body, "beta")
+	})
+}
+
+// --- POST /buckets ---
+
+func (s *IndexTestSuite) TestHandleCreateBucket() {
+	s.Run("success", func() {
+		form := url.Values{"name": {"new-bucket"}}
+		req := httptest.NewRequest("POST", "/buckets", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		w := httptest.NewRecorder()
+		handleCreateBucket(s.server, w, req)
+
+		s.Equal(http.StatusFound, w.Code)
+		exists, err := s.server.Buckets.Exists("new-bucket")
+		s.Require().NoError(err)
+		s.True(exists)
+	})
+
+	s.Run("empty name", func() {
+		form := url.Values{"name": {""}}
+		req := httptest.NewRequest("POST", "/buckets", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		w := httptest.NewRecorder()
+		handleCreateBucket(s.server, w, req)
+
+		s.Equal(http.StatusBadRequest, w.Code)
+	})
+}
+
+// --- DELETE /buckets/{name} ---
+
+func (s *IndexTestSuite) TestHandleDeleteBucket() {
+	s.Run("success", func() {
+		s.createBucket("to-delete")
+
+		req := httptest.NewRequest("DELETE", "/buckets/to-delete", nil)
+		req.SetPathValue("name", "to-delete")
+		w := httptest.NewRecorder()
+		handleDeleteBucket(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		s.Equal("/", w.Header().Get("HX-Redirect"))
+
+		exists, err := s.server.Buckets.Exists("to-delete")
+		s.Require().NoError(err)
+		s.False(exists)
+	})
+
+	s.Run("empty name", func() {
+		req := httptest.NewRequest("DELETE", "/buckets/", nil)
+		req.SetPathValue("name", "")
+		w := httptest.NewRecorder()
+		handleDeleteBucket(s.server, w, req)
+
+		s.Equal(http.StatusBadRequest, w.Code)
+	})
+}

--- a/server/handlers/console/static_test.go
+++ b/server/handlers/console/static_test.go
@@ -1,0 +1,60 @@
+package console
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type StaticTestSuite struct{ consoleSuite }
+
+func TestStaticTestSuite(t *testing.T) {
+	suite.Run(t, &StaticTestSuite{})
+}
+
+func (s *StaticTestSuite) TestHandleStatic() {
+	testCases := []struct {
+		caseName    string
+		path        string
+		wantStatus  int
+		wantType    string
+		wantContain string
+	}{
+		{
+			caseName:    "CSS file",
+			path:        "style.css",
+			wantStatus:  http.StatusOK,
+			wantType:    "text/css",
+			wantContain: ":root",
+		},
+		{
+			caseName:   "JS file",
+			path:       "htmx.min.js",
+			wantStatus: http.StatusOK,
+			wantType:   "application/javascript",
+		},
+		{
+			caseName:   "not found",
+			path:       "nonexistent.css",
+			wantStatus: http.StatusNotFound,
+		},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			req := httptest.NewRequest("GET", "/static/"+tc.path, nil)
+			req.SetPathValue("filepath", tc.path)
+			w := httptest.NewRecorder()
+			handleStatic(s.server, w, req)
+
+			s.Equal(tc.wantStatus, w.Code)
+			if tc.wantType != "" {
+				s.Equal(tc.wantType, w.Header().Get("Content-Type"))
+			}
+			if tc.wantContain != "" {
+				s.Contains(w.Body.String(), tc.wantContain)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add test suites for all Web Console handlers that previously had zero coverage:
  - **index** — GET / (list buckets), POST /buckets (create), DELETE /buckets/{name}
  - **static** — GET /static/{filepath} (CSS, JS, 404)
  - **objects** — GET /buckets/{name} (list, prefix, HTMX partial vs full page), POST folders, DELETE objects/folders
  - **view/meta** — GET view (text, image, nested path, 404), GET meta (JSON response, custom metadata, omit empty), contentTypeByExt

## Test plan

- [x] `go test -short ./server/handlers/console/...` passes
- [x] `golangci-lint run ./...` reports 0 issues