### PR TITLE
refactor: Extract shared config helpers

### DIFF
--- a/azblob/client.go
+++ b/azblob/client.go
@@ -240,7 +240,7 @@ func derefTime(p *time.Time) time.Time {
 	return *p
 }
 
-func toAzureMetadata(md map[string]string) map[string]*string {
+func toPtrMetadata(md map[string]string) map[string]*string {
 	if md == nil {
 		return nil
 	}
@@ -252,7 +252,7 @@ func toAzureMetadata(md map[string]string) map[string]*string {
 	return out
 }
 
-func fromAzureMetadata(md map[string]*string) map[string]string {
+func fromPtrMetadata(md map[string]*string) map[string]string {
 	if md == nil {
 		return nil
 	}

--- a/azblob/storage.go
+++ b/azblob/storage.go
@@ -16,8 +16,11 @@ import (
 	"github.com/mojatter/s2/internal/numconv"
 )
 
+// ErrRequiredConfigRoot is kept for backwards compatibility.
+// Deprecated: Use s2.ErrRequiredConfigRoot instead.
+var ErrRequiredConfigRoot = s2.ErrRequiredConfigRoot
+
 var (
-	ErrRequiredConfigRoot         = errors.New("required config.root")
 	ErrRequiredAccountName        = errors.New("azblob: account_name or connection_string is required")
 	ErrSignedURLRequiresSharedKey = errors.New("azblob: signed URL requires account_name and account_key")
 )
@@ -32,7 +35,7 @@ func init() {
 	s2.RegisterNewStorageFunc(s2.TypeAzblob, NewStorage)
 }
 
-// NewStorage creates a new Azure Blob Storage backend.
+// NewStorage creates a new Azure Blob Storage backend (azblob).
 // cfg.Root must be set to "<container>" or "<container>/<prefix>".
 func NewStorage(ctx context.Context, cfg s2.Config) (s2.Storage, error) {
 	if cfg.Root == "" {
@@ -44,12 +47,7 @@ func NewStorage(ctx context.Context, cfg s2.Config) (s2.Storage, error) {
 		return nil, err
 	}
 
-	roots := strings.SplitN(strings.Trim(cfg.Root, "/"), "/", 2)
-	ctr := roots[0]
-	prefix := ""
-	if len(roots) > 1 {
-		prefix = roots[1]
-	}
+	ctr, prefix := s2.ParseRoot(cfg.Root)
 
 	return &azblobStorage{
 		client:    client,
@@ -160,7 +158,7 @@ func (s *azblobStorage) List(ctx context.Context, opts s2.ListOptions) (s2.ListR
 			name:      name,
 			length:    numconv.MustUint64(item.contentLength),
 			modified:  item.lastModified,
-			metadata:  s2.Metadata(fromAzureMetadata(item.metadata)),
+			metadata:  s2.Metadata(fromPtrMetadata(item.metadata)),
 		})
 	}
 
@@ -184,7 +182,7 @@ func (s *azblobStorage) Get(ctx context.Context, name string) (s2.Object, error)
 		name:      name,
 		length:    numconv.MustUint64(props.contentLength),
 		modified:  props.lastModified,
-		metadata:  s2.Metadata(fromAzureMetadata(props.metadata)),
+		metadata:  s2.Metadata(fromPtrMetadata(props.metadata)),
 	}, nil
 }
 
@@ -216,11 +214,11 @@ func (s *azblobStorage) Put(ctx context.Context, obj s2.Object) error {
 	}
 	defer func() { _ = rc.Close() }()
 
-	return s.client.upload(ctx, s.container, s.key(obj.Name()), rc, toAzureMetadata(obj.Metadata()))
+	return s.client.upload(ctx, s.container, s.key(obj.Name()), rc, toPtrMetadata(obj.Metadata()))
 }
 
 func (s *azblobStorage) PutMetadata(ctx context.Context, name string, metadata s2.Metadata) error {
-	return s.client.setMetadata(ctx, s.container, s.key(name), toAzureMetadata(metadata))
+	return s.client.setMetadata(ctx, s.container, s.key(name), toPtrMetadata(metadata))
 }
 
 func (s *azblobStorage) Copy(ctx context.Context, src, dst string) error {

--- a/config.go
+++ b/config.go
@@ -1,5 +1,19 @@
 package s2
 
+import "strings"
+
+// ParseRoot splits a Root string like "bucket/some/prefix" into the
+// top-level name (bucket, container, or directory) and an optional
+// key prefix. Leading and trailing slashes are trimmed.
+func ParseRoot(root string) (name, prefix string) {
+	parts := strings.SplitN(strings.Trim(root, "/"), "/", 2)
+	name = parts[0]
+	if len(parts) > 1 {
+		prefix = parts[1]
+	}
+	return
+}
+
 type Type string
 
 const (

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,57 @@
+package s2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type ConfigTestSuite struct {
+	suite.Suite
+}
+
+func TestConfigTestSuite(t *testing.T) {
+	suite.Run(t, &ConfigTestSuite{})
+}
+
+func (s *ConfigTestSuite) TestParseRoot() {
+	testCases := []struct {
+		caseName   string
+		root       string
+		wantName   string
+		wantPrefix string
+	}{
+		{
+			caseName:   "name only",
+			root:       "my-bucket",
+			wantName:   "my-bucket",
+			wantPrefix: "",
+		},
+		{
+			caseName:   "name with prefix",
+			root:       "my-bucket/some/prefix",
+			wantName:   "my-bucket",
+			wantPrefix: "some/prefix",
+		},
+		{
+			caseName:   "slashes trimmed",
+			root:       "/my-bucket/pfx/",
+			wantName:   "my-bucket",
+			wantPrefix: "pfx",
+		},
+		{
+			caseName:   "single prefix segment",
+			root:       "my-bucket/data",
+			wantName:   "my-bucket",
+			wantPrefix: "data",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			name, prefix := ParseRoot(tc.root)
+			s.Equal(tc.wantName, name)
+			s.Equal(tc.wantPrefix, prefix)
+		})
+	}
+}

--- a/error.go
+++ b/error.go
@@ -11,6 +11,11 @@ import "errors"
 //	}
 var ErrNotExist = errors.New("s2: object not exist")
 
+// ErrRequiredConfigRoot is returned by NewStorage implementations when
+// Config.Root is empty. Root identifies the bucket, container, or directory
+// that the storage operates on and is always required.
+var ErrRequiredConfigRoot = errors.New("s2: required config.root")
+
 // ErrUnknownType is returned by NewStorage when no plugin is registered for
 // the requested Type. Detect with errors.Is:
 //

--- a/fs/storage.go
+++ b/fs/storage.go
@@ -24,6 +24,9 @@ func NewStorage(_ context.Context, cfg s2.Config) (s2.Storage, error) {
 	if cfg.Type == s2.TypeMemFS {
 		return NewStorageMem(cfg), nil
 	}
+	if cfg.Root == "" {
+		return nil, s2.ErrRequiredConfigRoot
+	}
 	return NewStorageFS(cfg, osfs.DirFS(cfg.Root)), nil
 }
 
@@ -217,7 +220,6 @@ func (s *storage) Exists(ctx context.Context, name string) (bool, error) {
 	return true, nil
 }
 
-
 func (s *storage) Put(ctx context.Context, obj s2.Object) error {
 	rc, err := obj.Open()
 	if err != nil {
@@ -281,7 +283,6 @@ func (s *storage) Move(ctx context.Context, src, dst string) error {
 	}
 	return s.Delete(ctx, src)
 }
-
 
 func (s *storage) Delete(ctx context.Context, name string) error {
 	// Ignore metadata deletion errors (file may not have metadata)

--- a/fs/storage_test.go
+++ b/fs/storage_test.go
@@ -51,7 +51,7 @@ func (s *StorageTestSuite) TestNewStorage() {
 	}{
 		{
 			caseName: "osfs",
-			cfg:      s2.Config{Type: s2.TypeOSFS},
+			cfg:      s2.Config{Type: s2.TypeOSFS, Root: s.T().TempDir()},
 			wantType: &storage{},
 		},
 		{
@@ -67,6 +67,11 @@ func (s *StorageTestSuite) TestNewStorage() {
 			s.IsType(tc.wantType, got)
 		})
 	}
+}
+
+func (s *StorageTestSuite) TestNewStorageOSFSEmptyRoot() {
+	_, err := NewStorage(context.Background(), s2.Config{Type: s2.TypeOSFS})
+	s.Require().ErrorIs(err, s2.ErrRequiredConfigRoot)
 }
 
 func (s *StorageTestSuite) TestNewStorageDir() {

--- a/gcs/storage.go
+++ b/gcs/storage.go
@@ -17,7 +17,9 @@ import (
 	"github.com/mojatter/s2/internal/numconv"
 )
 
-var ErrRequiredConfigRoot = errors.New("required config.root")
+// ErrRequiredConfigRoot is kept for backwards compatibility.
+// Deprecated: Use s2.ErrRequiredConfigRoot instead.
+var ErrRequiredConfigRoot = s2.ErrRequiredConfigRoot
 
 type gcsStorage struct {
 	client gcsClient
@@ -49,7 +51,7 @@ func NewStorage(ctx context.Context, cfg s2.Config) (s2.Storage, error) {
 		return nil, fmt.Errorf("gcs: failed to create client: %w", err)
 	}
 
-	bucket, prefix := parseRoot(cfg.Root)
+	bucket, prefix := s2.ParseRoot(cfg.Root)
 
 	return &gcsStorage{
 		client: &sdkClient{c: client},
@@ -258,15 +260,6 @@ func (s *gcsStorage) SignedURL(_ context.Context, opts s2.SignedURLOptions) (str
 }
 
 // --- helpers ---
-
-func parseRoot(root string) (bucket, prefix string) {
-	roots := strings.SplitN(strings.Trim(root, "/"), "/", 2)
-	bucket = roots[0]
-	if len(roots) > 1 {
-		prefix = roots[1]
-	}
-	return
-}
 
 func (s *gcsStorage) key(name string) string {
 	if s.prefix == "" {

--- a/gcs/storage_test.go
+++ b/gcs/storage_test.go
@@ -319,48 +319,6 @@ func (s *StorageTestSuite) TestNewStorageError() {
 	})
 }
 
-func (s *StorageTestSuite) TestParseRoot() {
-	testCases := []struct {
-		caseName   string
-		root       string
-		wantBucket string
-		wantPrefix string
-	}{
-		{
-			caseName:   "bucket only",
-			root:       "my-bucket",
-			wantBucket: "my-bucket",
-			wantPrefix: "",
-		},
-		{
-			caseName:   "bucket with prefix",
-			root:       "my-bucket/some/prefix",
-			wantBucket: "my-bucket",
-			wantPrefix: "some/prefix",
-		},
-		{
-			caseName:   "root with slashes trimmed",
-			root:       "/my-bucket/pfx/",
-			wantBucket: "my-bucket",
-			wantPrefix: "pfx",
-		},
-		{
-			caseName:   "bucket with single prefix",
-			root:       "my-bucket/data",
-			wantBucket: "my-bucket",
-			wantPrefix: "data",
-		},
-	}
-
-	for _, tc := range testCases {
-		s.Run(tc.caseName, func() {
-			bucket, prefix := parseRoot(tc.root)
-			s.Equal(tc.wantBucket, bucket)
-			s.Equal(tc.wantPrefix, prefix)
-		})
-	}
-}
-
 func (s *StorageTestSuite) TestS2TestList() {
 	_, strg := s.testMockStorage()
 	ctx := context.Background()

--- a/s3/storage.go
+++ b/s3/storage.go
@@ -16,9 +16,9 @@ import (
 	"github.com/mojatter/s2/internal/numconv"
 )
 
-var (
-	ErrRequiredConfigRoot = errors.New("required config.root")
-)
+// ErrRequiredConfigRoot is kept for backwards compatibility.
+// Deprecated: Use s2.ErrRequiredConfigRoot instead.
+var ErrRequiredConfigRoot = s2.ErrRequiredConfigRoot
 
 type clientAPI interface {
 	s3.ListObjectsV2APIClient
@@ -84,12 +84,7 @@ func NewStorage(ctx context.Context, cfg s2.Config) (s2.Storage, error) {
 		})
 	}
 
-	roots := strings.SplitN(strings.Trim(cfg.Root, "/"), "/", 2)
-	bucket := roots[0]
-	prefix := ""
-	if len(roots) > 1 {
-		prefix = roots[1]
-	}
+	bucket, prefix := s2.ParseRoot(cfg.Root)
 	return &storage{
 		client: s3.NewFromConfig(awsCfg, s3Opts...),
 		bucket: bucket,


### PR DESCRIPTION
## Summary

- Move `ErrRequiredConfigRoot` to the `s2` package as the single source of truth
- Add `s2.ParseRoot` to replace duplicated root-parsing logic in `s3`, `gcs`, and `azblob`
- Add `cfg.Root` validation to `fs.NewStorage` for `osfs` (previously allowed empty root, which silently used the current directory)
- Backend packages retain deprecated aliases for backwards compatibility

## Test plan

- [x] All existing tests pass
- [x] New `TestParseRoot` in `config_test.go`
- [x] New `TestNewStorageOSFSEmptyRoot` in `fs/storage_test.go`
- [x] `golangci-lint run ./...` reports 0 issues