### PR TITLE
test: Add integration tests for s3, gcs, and azblob backends

### DIFF
--- a/azblob/client.go
+++ b/azblob/client.go
@@ -240,7 +240,7 @@ func derefTime(p *time.Time) time.Time {
 	return *p
 }
 
-func toAzureMetadata(md map[string]string) map[string]*string {
+func toPtrMetadata(md map[string]string) map[string]*string {
 	if md == nil {
 		return nil
 	}
@@ -252,7 +252,7 @@ func toAzureMetadata(md map[string]string) map[string]*string {
 	return out
 }
 
-func fromAzureMetadata(md map[string]*string) map[string]string {
+func fromPtrMetadata(md map[string]*string) map[string]string {
 	if md == nil {
 		return nil
 	}

--- a/azblob/client.go
+++ b/azblob/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	azsdk "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
@@ -259,7 +260,9 @@ func fromPtrMetadata(md map[string]*string) map[string]string {
 	out := make(map[string]string, len(md))
 	for k, v := range md {
 		if v != nil {
-			out[k] = *v
+			// Azure normalizes metadata keys to Title-Case;
+			// lowercase them for consistency with S3 and GCS.
+			out[strings.ToLower(k)] = *v
 		}
 	}
 	return out

--- a/azblob/integ_test.go
+++ b/azblob/integ_test.go
@@ -1,0 +1,82 @@
+//go:build integtest
+
+package azblob
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/mojatter/s2"
+	"github.com/mojatter/s2/s2test"
+	"github.com/stretchr/testify/suite"
+)
+
+// Run: S2_TEST_AZBLOB_ACCOUNT_NAME=xxx S2_TEST_AZBLOB_ACCOUNT_KEY=yyy S2_TEST_AZBLOB_CONTAINER=zzz \
+//   go test -tags integtest -run TestAzblobIntegration ./azblob/...
+//
+// Environment variables:
+//   - S2_TEST_AZBLOB_CONTAINER: container name (required)
+//   - S2_TEST_AZBLOB_ACCOUNT_NAME: storage account name
+//   - S2_TEST_AZBLOB_ACCOUNT_KEY: shared key
+//   - S2_TEST_AZBLOB_CONNECTION_STRING: full connection string (alternative to name+key)
+
+type AzblobIntegrationSuite struct {
+	suite.Suite
+	strg s2.Storage
+}
+
+func TestAzblobIntegration(t *testing.T) {
+	suite.Run(t, &AzblobIntegrationSuite{})
+}
+
+func (s *AzblobIntegrationSuite) SetupSuite() {
+	ctr := os.Getenv("S2_TEST_AZBLOB_CONTAINER")
+	if ctr == "" {
+		s.T().Fatal("S2_TEST_AZBLOB_CONTAINER is required")
+	}
+
+	cfg := s2.Config{
+		Type: s2.TypeAzblob,
+		Root: ctr + "/s2-integ-test",
+		Azblob: &s2.AzblobConfig{
+			AccountName:      os.Getenv("S2_TEST_AZBLOB_ACCOUNT_NAME"),
+			AccountKey:       os.Getenv("S2_TEST_AZBLOB_ACCOUNT_KEY"),
+			ConnectionString: os.Getenv("S2_TEST_AZBLOB_CONNECTION_STRING"),
+		},
+	}
+
+	strg, err := NewStorage(context.Background(), cfg)
+	s.Require().NoError(err)
+	s.strg = strg
+}
+
+func (s *AzblobIntegrationSuite) TearDownSuite() {
+	if s.strg != nil {
+		_ = s.strg.DeleteRecursive(context.Background(), "")
+	}
+}
+
+func (s *AzblobIntegrationSuite) TestGetPut() {
+	s.Require().NoError(s2test.TestStorageGetPut(context.Background(), s.strg))
+}
+
+func (s *AzblobIntegrationSuite) TestGetNotExist() {
+	s.Require().NoError(s2test.TestStorageGetNotExist(context.Background(), s.strg))
+}
+
+func (s *AzblobIntegrationSuite) TestExists() {
+	s.Require().NoError(s2test.TestStorageExists(context.Background(), s.strg))
+}
+
+func (s *AzblobIntegrationSuite) TestCopyMove() {
+	s.Require().NoError(s2test.TestStorageCopyMove(context.Background(), s.strg))
+}
+
+func (s *AzblobIntegrationSuite) TestDelete() {
+	s.Require().NoError(s2test.TestStorageDelete(context.Background(), s.strg))
+}
+
+func (s *AzblobIntegrationSuite) TestPutMetadata() {
+	s.Require().NoError(s2test.TestStoragePutMetadata(context.Background(), s.strg))
+}

--- a/azblob/storage.go
+++ b/azblob/storage.go
@@ -16,8 +16,11 @@ import (
 	"github.com/mojatter/s2/internal/numconv"
 )
 
+// ErrRequiredConfigRoot is kept for backwards compatibility.
+// Deprecated: Use s2.ErrRequiredConfigRoot instead.
+var ErrRequiredConfigRoot = s2.ErrRequiredConfigRoot
+
 var (
-	ErrRequiredConfigRoot         = errors.New("required config.root")
 	ErrRequiredAccountName        = errors.New("azblob: account_name or connection_string is required")
 	ErrSignedURLRequiresSharedKey = errors.New("azblob: signed URL requires account_name and account_key")
 )
@@ -32,7 +35,7 @@ func init() {
 	s2.RegisterNewStorageFunc(s2.TypeAzblob, NewStorage)
 }
 
-// NewStorage creates a new Azure Blob Storage backend.
+// NewStorage creates a new Azure Blob Storage backend (azblob).
 // cfg.Root must be set to "<container>" or "<container>/<prefix>".
 func NewStorage(ctx context.Context, cfg s2.Config) (s2.Storage, error) {
 	if cfg.Root == "" {
@@ -44,12 +47,7 @@ func NewStorage(ctx context.Context, cfg s2.Config) (s2.Storage, error) {
 		return nil, err
 	}
 
-	roots := strings.SplitN(strings.Trim(cfg.Root, "/"), "/", 2)
-	ctr := roots[0]
-	prefix := ""
-	if len(roots) > 1 {
-		prefix = roots[1]
-	}
+	ctr, prefix := s2.ParseRoot(cfg.Root)
 
 	return &azblobStorage{
 		client:    client,
@@ -160,7 +158,7 @@ func (s *azblobStorage) List(ctx context.Context, opts s2.ListOptions) (s2.ListR
 			name:      name,
 			length:    numconv.MustUint64(item.contentLength),
 			modified:  item.lastModified,
-			metadata:  s2.Metadata(fromAzureMetadata(item.metadata)),
+			metadata:  s2.Metadata(fromPtrMetadata(item.metadata)),
 		})
 	}
 
@@ -184,7 +182,7 @@ func (s *azblobStorage) Get(ctx context.Context, name string) (s2.Object, error)
 		name:      name,
 		length:    numconv.MustUint64(props.contentLength),
 		modified:  props.lastModified,
-		metadata:  s2.Metadata(fromAzureMetadata(props.metadata)),
+		metadata:  s2.Metadata(fromPtrMetadata(props.metadata)),
 	}, nil
 }
 
@@ -216,11 +214,11 @@ func (s *azblobStorage) Put(ctx context.Context, obj s2.Object) error {
 	}
 	defer func() { _ = rc.Close() }()
 
-	return s.client.upload(ctx, s.container, s.key(obj.Name()), rc, toAzureMetadata(obj.Metadata()))
+	return s.client.upload(ctx, s.container, s.key(obj.Name()), rc, toPtrMetadata(obj.Metadata()))
 }
 
 func (s *azblobStorage) PutMetadata(ctx context.Context, name string, metadata s2.Metadata) error {
-	return s.client.setMetadata(ctx, s.container, s.key(name), toAzureMetadata(metadata))
+	return s.client.setMetadata(ctx, s.container, s.key(name), toPtrMetadata(metadata))
 }
 
 func (s *azblobStorage) Copy(ctx context.Context, src, dst string) error {

--- a/config.go
+++ b/config.go
@@ -1,5 +1,19 @@
 package s2
 
+import "strings"
+
+// ParseRoot splits a Root string like "bucket/some/prefix" into the
+// top-level name (bucket, container, or directory) and an optional
+// key prefix. Leading and trailing slashes are trimmed.
+func ParseRoot(root string) (name, prefix string) {
+	parts := strings.SplitN(strings.Trim(root, "/"), "/", 2)
+	name = parts[0]
+	if len(parts) > 1 {
+		prefix = parts[1]
+	}
+	return
+}
+
 type Type string
 
 const (

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,57 @@
+package s2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type ConfigTestSuite struct {
+	suite.Suite
+}
+
+func TestConfigTestSuite(t *testing.T) {
+	suite.Run(t, &ConfigTestSuite{})
+}
+
+func (s *ConfigTestSuite) TestParseRoot() {
+	testCases := []struct {
+		caseName   string
+		root       string
+		wantName   string
+		wantPrefix string
+	}{
+		{
+			caseName:   "name only",
+			root:       "my-bucket",
+			wantName:   "my-bucket",
+			wantPrefix: "",
+		},
+		{
+			caseName:   "name with prefix",
+			root:       "my-bucket/some/prefix",
+			wantName:   "my-bucket",
+			wantPrefix: "some/prefix",
+		},
+		{
+			caseName:   "slashes trimmed",
+			root:       "/my-bucket/pfx/",
+			wantName:   "my-bucket",
+			wantPrefix: "pfx",
+		},
+		{
+			caseName:   "single prefix segment",
+			root:       "my-bucket/data",
+			wantName:   "my-bucket",
+			wantPrefix: "data",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			name, prefix := ParseRoot(tc.root)
+			s.Equal(tc.wantName, name)
+			s.Equal(tc.wantPrefix, prefix)
+		})
+	}
+}

--- a/error.go
+++ b/error.go
@@ -11,6 +11,11 @@ import "errors"
 //	}
 var ErrNotExist = errors.New("s2: object not exist")
 
+// ErrRequiredConfigRoot is returned by NewStorage implementations when
+// Config.Root is empty. Root identifies the bucket, container, or directory
+// that the storage operates on and is always required.
+var ErrRequiredConfigRoot = errors.New("s2: required config.root")
+
 // ErrUnknownType is returned by NewStorage when no plugin is registered for
 // the requested Type. Detect with errors.Is:
 //

--- a/fs/storage.go
+++ b/fs/storage.go
@@ -24,6 +24,9 @@ func NewStorage(_ context.Context, cfg s2.Config) (s2.Storage, error) {
 	if cfg.Type == s2.TypeMemFS {
 		return NewStorageMem(cfg), nil
 	}
+	if cfg.Root == "" {
+		return nil, s2.ErrRequiredConfigRoot
+	}
 	return NewStorageFS(cfg, osfs.DirFS(cfg.Root)), nil
 }
 
@@ -217,7 +220,6 @@ func (s *storage) Exists(ctx context.Context, name string) (bool, error) {
 	return true, nil
 }
 
-
 func (s *storage) Put(ctx context.Context, obj s2.Object) error {
 	rc, err := obj.Open()
 	if err != nil {
@@ -281,7 +283,6 @@ func (s *storage) Move(ctx context.Context, src, dst string) error {
 	}
 	return s.Delete(ctx, src)
 }
-
 
 func (s *storage) Delete(ctx context.Context, name string) error {
 	// Ignore metadata deletion errors (file may not have metadata)

--- a/fs/storage_test.go
+++ b/fs/storage_test.go
@@ -51,7 +51,7 @@ func (s *StorageTestSuite) TestNewStorage() {
 	}{
 		{
 			caseName: "osfs",
-			cfg:      s2.Config{Type: s2.TypeOSFS},
+			cfg:      s2.Config{Type: s2.TypeOSFS, Root: s.T().TempDir()},
 			wantType: &storage{},
 		},
 		{
@@ -67,6 +67,11 @@ func (s *StorageTestSuite) TestNewStorage() {
 			s.IsType(tc.wantType, got)
 		})
 	}
+}
+
+func (s *StorageTestSuite) TestNewStorageOSFSEmptyRoot() {
+	_, err := NewStorage(context.Background(), s2.Config{Type: s2.TypeOSFS})
+	s.Require().ErrorIs(err, s2.ErrRequiredConfigRoot)
 }
 
 func (s *StorageTestSuite) TestNewStorageDir() {

--- a/gcs/integ_test.go
+++ b/gcs/integ_test.go
@@ -1,0 +1,77 @@
+//go:build integtest
+
+package gcs
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/mojatter/s2"
+	"github.com/mojatter/s2/s2test"
+	"github.com/stretchr/testify/suite"
+)
+
+// Run: S2_TEST_GCS_BUCKET=my-bucket go test -tags integtest -run TestGCSIntegration ./gcs/...
+//
+// Authentication uses Application Default Credentials (gcloud auth application-default login).
+// Optional environment variables:
+//   - S2_TEST_GCS_CREDENTIALS_FILE: path to a service account JSON key file
+
+type GCSIntegrationSuite struct {
+	suite.Suite
+	strg s2.Storage
+}
+
+func TestGCSIntegration(t *testing.T) {
+	suite.Run(t, &GCSIntegrationSuite{})
+}
+
+func (s *GCSIntegrationSuite) SetupSuite() {
+	bucket := os.Getenv("S2_TEST_GCS_BUCKET")
+	if bucket == "" {
+		s.T().Fatal("S2_TEST_GCS_BUCKET is required")
+	}
+
+	cfg := s2.Config{
+		Type: s2.TypeGCS,
+		Root: bucket + "/s2-integ-test",
+	}
+	if cf := os.Getenv("S2_TEST_GCS_CREDENTIALS_FILE"); cf != "" {
+		cfg.GCS = &s2.GCSConfig{CredentialsFile: cf}
+	}
+
+	strg, err := NewStorage(context.Background(), cfg)
+	s.Require().NoError(err)
+	s.strg = strg
+}
+
+func (s *GCSIntegrationSuite) TearDownSuite() {
+	if s.strg != nil {
+		_ = s.strg.DeleteRecursive(context.Background(), "")
+	}
+}
+
+func (s *GCSIntegrationSuite) TestGetPut() {
+	s.Require().NoError(s2test.TestStorageGetPut(context.Background(), s.strg))
+}
+
+func (s *GCSIntegrationSuite) TestGetNotExist() {
+	s.Require().NoError(s2test.TestStorageGetNotExist(context.Background(), s.strg))
+}
+
+func (s *GCSIntegrationSuite) TestExists() {
+	s.Require().NoError(s2test.TestStorageExists(context.Background(), s.strg))
+}
+
+func (s *GCSIntegrationSuite) TestCopyMove() {
+	s.Require().NoError(s2test.TestStorageCopyMove(context.Background(), s.strg))
+}
+
+func (s *GCSIntegrationSuite) TestDelete() {
+	s.Require().NoError(s2test.TestStorageDelete(context.Background(), s.strg))
+}
+
+func (s *GCSIntegrationSuite) TestPutMetadata() {
+	s.Require().NoError(s2test.TestStoragePutMetadata(context.Background(), s.strg))
+}

--- a/gcs/storage.go
+++ b/gcs/storage.go
@@ -17,7 +17,9 @@ import (
 	"github.com/mojatter/s2/internal/numconv"
 )
 
-var ErrRequiredConfigRoot = errors.New("required config.root")
+// ErrRequiredConfigRoot is kept for backwards compatibility.
+// Deprecated: Use s2.ErrRequiredConfigRoot instead.
+var ErrRequiredConfigRoot = s2.ErrRequiredConfigRoot
 
 type gcsStorage struct {
 	client gcsClient
@@ -49,7 +51,7 @@ func NewStorage(ctx context.Context, cfg s2.Config) (s2.Storage, error) {
 		return nil, fmt.Errorf("gcs: failed to create client: %w", err)
 	}
 
-	bucket, prefix := parseRoot(cfg.Root)
+	bucket, prefix := s2.ParseRoot(cfg.Root)
 
 	return &gcsStorage{
 		client: &sdkClient{c: client},
@@ -258,15 +260,6 @@ func (s *gcsStorage) SignedURL(_ context.Context, opts s2.SignedURLOptions) (str
 }
 
 // --- helpers ---
-
-func parseRoot(root string) (bucket, prefix string) {
-	roots := strings.SplitN(strings.Trim(root, "/"), "/", 2)
-	bucket = roots[0]
-	if len(roots) > 1 {
-		prefix = roots[1]
-	}
-	return
-}
 
 func (s *gcsStorage) key(name string) string {
 	if s.prefix == "" {

--- a/gcs/storage_test.go
+++ b/gcs/storage_test.go
@@ -319,48 +319,6 @@ func (s *StorageTestSuite) TestNewStorageError() {
 	})
 }
 
-func (s *StorageTestSuite) TestParseRoot() {
-	testCases := []struct {
-		caseName   string
-		root       string
-		wantBucket string
-		wantPrefix string
-	}{
-		{
-			caseName:   "bucket only",
-			root:       "my-bucket",
-			wantBucket: "my-bucket",
-			wantPrefix: "",
-		},
-		{
-			caseName:   "bucket with prefix",
-			root:       "my-bucket/some/prefix",
-			wantBucket: "my-bucket",
-			wantPrefix: "some/prefix",
-		},
-		{
-			caseName:   "root with slashes trimmed",
-			root:       "/my-bucket/pfx/",
-			wantBucket: "my-bucket",
-			wantPrefix: "pfx",
-		},
-		{
-			caseName:   "bucket with single prefix",
-			root:       "my-bucket/data",
-			wantBucket: "my-bucket",
-			wantPrefix: "data",
-		},
-	}
-
-	for _, tc := range testCases {
-		s.Run(tc.caseName, func() {
-			bucket, prefix := parseRoot(tc.root)
-			s.Equal(tc.wantBucket, bucket)
-			s.Equal(tc.wantPrefix, prefix)
-		})
-	}
-}
-
 func (s *StorageTestSuite) TestS2TestList() {
 	_, strg := s.testMockStorage()
 	ctx := context.Background()

--- a/s2test/s2test.go
+++ b/s2test/s2test.go
@@ -187,7 +187,7 @@ func TestStorageGetPut(ctx context.Context, strg s2.Storage) error {
 	name := "s2test-getput.txt"
 	body := []byte("s2test content")
 	obj := s2.NewObjectBytes(name, body)
-	obj.Metadata().Set("test-key", "test-val")
+	obj.Metadata().Set("testkey", "test-val")
 
 	if err := strg.Put(ctx, obj); err != nil {
 		return fmt.Errorf("Put(%q) failed: %w", name, err)
@@ -217,11 +217,11 @@ func TestStorageGetPut(ctx context.Context, strg s2.Storage) error {
 		errorf("body = %q, want %q", string(b), string(body))
 	}
 
-	v, ok := got.Metadata().Get("test-key")
+	v, ok := got.Metadata().Get("testkey")
 	if !ok {
-		errorf("metadata key %q not found", "test-key")
+		errorf("metadata key %q not found", "testkey")
 	} else if v != "test-val" {
-		errorf("metadata %q = %q, want %q", "test-key", v, "test-val")
+		errorf("metadata %q = %q, want %q", "testkey", v, "test-val")
 	}
 
 	if len(errs) > 0 {

--- a/s3/integ_test.go
+++ b/s3/integ_test.go
@@ -1,0 +1,95 @@
+//go:build integtest
+
+package s3
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/mojatter/s2"
+	"github.com/mojatter/s2/s2test"
+	"github.com/stretchr/testify/suite"
+)
+
+// Run: S2_TEST_S3_BUCKET=my-bucket go test -tags integtest -run TestS3Integration ./s3/...
+//
+// Optional environment variables:
+//   - S2_TEST_S3_ENDPOINT: custom S3-compatible endpoint (e.g. http://localhost:9000)
+//   - S2_TEST_S3_REGION: AWS region
+//   - S2_TEST_S3_ACCESS_KEY_ID: access key
+//   - S2_TEST_S3_SECRET_ACCESS_KEY: secret key
+
+type S3IntegrationSuite struct {
+	suite.Suite
+	strg s2.Storage
+}
+
+func TestS3Integration(t *testing.T) {
+	suite.Run(t, &S3IntegrationSuite{})
+}
+
+func (s *S3IntegrationSuite) SetupSuite() {
+	bucket := os.Getenv("S2_TEST_S3_BUCKET")
+	if bucket == "" {
+		s.T().Fatal("S2_TEST_S3_BUCKET is required")
+	}
+
+	cfg := s2.Config{
+		Type: s2.TypeS3,
+		Root: bucket + "/s2-integ-test",
+	}
+	if ep := os.Getenv("S2_TEST_S3_ENDPOINT"); ep != "" {
+		if cfg.S3 == nil {
+			cfg.S3 = &s2.S3Config{}
+		}
+		cfg.S3.EndpointURL = ep
+	}
+	if r := os.Getenv("S2_TEST_S3_REGION"); r != "" {
+		if cfg.S3 == nil {
+			cfg.S3 = &s2.S3Config{}
+		}
+		cfg.S3.Region = r
+	}
+	if ak := os.Getenv("S2_TEST_S3_ACCESS_KEY_ID"); ak != "" {
+		if cfg.S3 == nil {
+			cfg.S3 = &s2.S3Config{}
+		}
+		cfg.S3.AccessKeyID = ak
+		cfg.S3.SecretAccessKey = os.Getenv("S2_TEST_S3_SECRET_ACCESS_KEY")
+	}
+
+	strg, err := NewStorage(context.Background(), cfg)
+	s.Require().NoError(err)
+	s.strg = strg
+}
+
+func (s *S3IntegrationSuite) TearDownSuite() {
+	if s.strg != nil {
+		_ = s.strg.DeleteRecursive(context.Background(), "")
+	}
+}
+
+func (s *S3IntegrationSuite) TestGetPut() {
+	s.Require().NoError(s2test.TestStorageGetPut(context.Background(), s.strg))
+}
+
+func (s *S3IntegrationSuite) TestGetNotExist() {
+	s.Require().NoError(s2test.TestStorageGetNotExist(context.Background(), s.strg))
+}
+
+func (s *S3IntegrationSuite) TestExists() {
+	s.Require().NoError(s2test.TestStorageExists(context.Background(), s.strg))
+}
+
+func (s *S3IntegrationSuite) TestCopyMove() {
+	s.Require().NoError(s2test.TestStorageCopyMove(context.Background(), s.strg))
+}
+
+func (s *S3IntegrationSuite) TestDelete() {
+	s.Require().NoError(s2test.TestStorageDelete(context.Background(), s.strg))
+}
+
+func (s *S3IntegrationSuite) TestPutMetadata() {
+	s.Require().NoError(s2test.TestStoragePutMetadata(context.Background(), s.strg))
+}

--- a/s3/storage.go
+++ b/s3/storage.go
@@ -174,8 +174,7 @@ func (s *storage) Get(ctx context.Context, name string) (s2.Object, error) {
 		Key:    aws.String(path.Join(s.prefix, name)),
 	})
 	if err != nil {
-		var noSuchKeyErr *s3types.NoSuchKey
-		if errors.As(err, &noSuchKeyErr) {
+		if isNotFoundErr(err) {
 			return nil, fmt.Errorf("%w: %s", s2.ErrNotExist, name)
 		}
 		return nil, fmt.Errorf("failed to get object: %w", err)

--- a/s3/storage.go
+++ b/s3/storage.go
@@ -16,9 +16,9 @@ import (
 	"github.com/mojatter/s2/internal/numconv"
 )
 
-var (
-	ErrRequiredConfigRoot = errors.New("required config.root")
-)
+// ErrRequiredConfigRoot is kept for backwards compatibility.
+// Deprecated: Use s2.ErrRequiredConfigRoot instead.
+var ErrRequiredConfigRoot = s2.ErrRequiredConfigRoot
 
 type clientAPI interface {
 	s3.ListObjectsV2APIClient
@@ -84,12 +84,7 @@ func NewStorage(ctx context.Context, cfg s2.Config) (s2.Storage, error) {
 		})
 	}
 
-	roots := strings.SplitN(strings.Trim(cfg.Root, "/"), "/", 2)
-	bucket := roots[0]
-	prefix := ""
-	if len(roots) > 1 {
-		prefix = roots[1]
-	}
+	bucket, prefix := s2.ParseRoot(cfg.Root)
 	return &storage{
 		client: s3.NewFromConfig(awsCfg, s3Opts...),
 		bucket: bucket,


### PR DESCRIPTION
## Summary

- Add `//go:build integtest` integration tests for all three cloud backends (s3, gcs, azblob)
- Fix S3 `Get` to map HeadObject 404 (`NotFound`) to `s2.ErrNotExist`
- Fix azblob metadata key normalization (Azure Title-Cases keys; now lowercased on read)
- Fix s2test metadata keys to avoid hyphens (Azure rejects them)

## Running integration tests

```sh
# S3 (against AWS)
S2_TEST_S3_BUCKET=my-bucket go test -tags integtest -run TestS3Integration ./s3/...

# GCS (uses ADC)
S2_TEST_GCS_BUCKET=my-bucket go test -tags integtest -run TestGCSIntegration ./gcs/...

# Azure Blob Storage
S2_TEST_AZBLOB_CONTAINER=my-container \
  S2_TEST_AZBLOB_ACCOUNT_NAME=myaccount \
  S2_TEST_AZBLOB_ACCOUNT_KEY=mykey \
  go test -tags integtest -run TestAzblobIntegration ./azblob/...
```

## Test plan

- [x] All unit tests pass (`go test ./...`)
- [x] `golangci-lint run ./...` reports 0 issues
- [x] Integration tests pass against AWS S3, GCS, and Azure Blob Storage