### PR TITLE
test: Add integration tests and fix bugs found by them

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -23,12 +23,8 @@ jobs:
         uses: docker/setup-buildx-action@v4
       -
         name: Run E2E tests
-        run: |
-          docker compose -f s2test/e2e/docker-compose.yml up \
-            --build \
-            --abort-on-container-exit \
-            --exit-code-from test
+        run: make test-e2e
       -
         name: Show s2 logs on failure
         if: failure()
-        run: docker compose -f s2test/e2e/docker-compose.yml logs s2
+        run: docker compose -f s2test/e2e/docker-compose.yml logs s2 s2-mem

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,11 @@ bench:
 .PHONY: test-e2e
 test-e2e:
 	docker compose -f s2test/e2e/docker-compose.yml run --build --rm test; \
-	rc=$$?; \
+	rc1=$$?; \
+	docker compose -f s2test/e2e/docker-compose.yml run --build --rm test-sdk; \
+	rc2=$$?; \
 	docker compose -f s2test/e2e/docker-compose.yml down; \
-	exit $$rc
+	[ $$rc1 -eq 0 ] && [ $$rc2 -eq 0 ]
 
 # bench-warp runs a `warp mixed` benchmark against a fresh in-process
 # s2-server. It expects the github.com/minio/warp binary on PATH; the

--- a/s2test/e2e/Dockerfile.sdk
+++ b/s2test/e2e/Dockerfile.sdk
@@ -1,0 +1,4 @@
+FROM golang:1.24-alpine
+WORKDIR /app
+RUN --mount=target=. go test -tags integtest -c -o /usr/local/bin/s3-integ-test ./s3/
+ENTRYPOINT ["s3-integ-test", "-test.v", "-test.run", "TestS3Integration"]

--- a/s2test/e2e/docker-compose.yml
+++ b/s2test/e2e/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       S2_SERVER_LISTEN: ":9000"
       S2_SERVER_USER: "testkey"
       S2_SERVER_PASSWORD: "testsecret"
+      S2_SERVER_BUCKETS: "sdk-test-bucket"
     tmpfs:
       - /var/lib/s2
 
@@ -35,3 +36,17 @@ services:
     command: ["/bin/sh", "/tests/run.sh"]
     volumes:
       - ./run.sh:/tests/run.sh:ro
+
+  test-sdk:
+    build:
+      context: ../..
+      dockerfile: s2test/e2e/Dockerfile.sdk
+    depends_on:
+      s2:
+        condition: service_started
+    environment:
+      S2_TEST_S3_BUCKET: "sdk-test-bucket"
+      S2_TEST_S3_ENDPOINT: "http://s2:9000"
+      S2_TEST_S3_REGION: "us-east-1"
+      S2_TEST_S3_ACCESS_KEY_ID: "testkey"
+      S2_TEST_S3_SECRET_ACCESS_KEY: "testsecret"

--- a/s2test/e2e/run.sh
+++ b/s2test/e2e/run.sh
@@ -157,6 +157,41 @@ run_test "ListDirAndPartialFilename" sh -c '
   [ "$out" = "images/a.png" ]
 '
 
+# Metadata operations
+run_test "PutObjectWithMetadata" sh -c '
+  EP="'"$ENDPOINT"'"
+  printf "meta body" > /tmp/meta.txt
+  aws s3api --endpoint-url "$EP" put-object \
+    --bucket test-bucket --key meta.txt --body /tmp/meta.txt \
+    --metadata key1=val1,key2=val2
+  out=$(aws s3api --endpoint-url "$EP" head-object --bucket test-bucket --key meta.txt --query "Metadata" --output json)
+  echo "$out" | grep -q "val1"
+  echo "$out" | grep -q "val2"
+'
+
+run_test "CopyObjectPreservesMetadata" sh -c '
+  EP="'"$ENDPOINT"'"
+  aws s3api --endpoint-url "$EP" copy-object \
+    --bucket test-bucket --key meta-copy.txt \
+    --copy-source test-bucket/meta.txt
+  out=$(aws s3api --endpoint-url "$EP" head-object --bucket test-bucket --key meta-copy.txt --query "Metadata" --output json)
+  echo "$out" | grep -q "val1"
+  echo "$out" | grep -q "val2"
+'
+
+run_test "CopyObjectReplaceMetadata" sh -c '
+  EP="'"$ENDPOINT"'"
+  aws s3api --endpoint-url "$EP" copy-object \
+    --bucket test-bucket --key meta-replaced.txt \
+    --copy-source test-bucket/meta.txt \
+    --metadata-directive REPLACE \
+    --metadata newkey=newval
+  out=$(aws s3api --endpoint-url "$EP" head-object --bucket test-bucket --key meta-replaced.txt --query "Metadata" --output json)
+  echo "$out" | grep -q "newval"
+  # Original metadata should NOT be present
+  ! echo "$out" | grep -q "val1"
+'
+
 # Presigned URL (query-string SigV4)
 run_test "PresignedGetObject" sh -c '
   EP="'"$ENDPOINT"'"

--- a/s3/storage.go
+++ b/s3/storage.go
@@ -1,9 +1,11 @@
 package s3
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"path"
 	"strings"
 
@@ -258,10 +260,22 @@ func (s *storage) Put(ctx context.Context, obj s2.Object) error {
 	}
 	defer func() { _ = rc.Close() }()
 
+	// The AWS SDK requires a seekable body for payload signing over HTTP
+	// and checksum calculation. If the stream is already seekable, use it
+	// as-is; otherwise buffer it into a bytes.Reader.
+	body, ok := rc.(io.ReadSeeker)
+	if !ok {
+		b, err := io.ReadAll(rc)
+		if err != nil {
+			return err
+		}
+		body = bytes.NewReader(b)
+	}
+
 	_, err = s.client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:        aws.String(s.bucket),
 		Key:           aws.String(path.Join(s.prefix, obj.Name())),
-		Body:          rc,
+		Body:          body,
 		ContentLength: aws.Int64(numconv.MustInt64(obj.Length())),
 		Metadata:      obj.Metadata(),
 	})

--- a/server/handlers/s3api/objects.go
+++ b/server/handlers/s3api/objects.go
@@ -452,6 +452,14 @@ func handleCopyObject(s *server.Server, w http.ResponseWriter, r *http.Request, 
 	}
 	defer func() { _ = rc.Close() }()
 
+	// Determine metadata for the destination object.
+	var md s2.Metadata
+	if strings.EqualFold(r.Header.Get("x-amz-metadata-directive"), "REPLACE") {
+		md = parseMetadataHeaders(r)
+	} else {
+		md = srcObj.Metadata().Clone()
+	}
+
 	// Write to destination
 	dstStrg, err := s.Buckets.Get(ctx, dstBucket)
 	if err != nil {
@@ -460,8 +468,16 @@ func handleCopyObject(s *server.Server, w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	dstObj := s2.NewObjectReader(dstKey, rc, srcObj.Length())
+	dstObj := s2.NewObjectReader(dstKey, rc, srcObj.Length(), s2.WithMetadata(md))
 	if err := dstStrg.Put(ctx, dstObj); err != nil {
+		code, msg, status := s2ErrorToS3Error(err)
+		writeError(w, r, code, msg, status)
+		return
+	}
+
+	// Persist ETag (carried from source or recomputed) alongside user metadata.
+	md[etagMetadataKey] = objectETag(srcObj)
+	if err := dstStrg.PutMetadata(ctx, dstKey, md); err != nil {
 		code, msg, status := s2ErrorToS3Error(err)
 		writeError(w, r, code, msg, status)
 		return


### PR DESCRIPTION
## Summary

Depends on #57.

- Add `//go:build integtest` integration tests for s3, gcs, and azblob backends
- Fix four bugs discovered during integration testing:
  - **s3**: `HeadObject` 404 now correctly maps to `s2.ErrNotExist` (was only handling `NoSuchKey`, not `NotFound`)
  - **s3**: Buffer `PutObject` body into `bytes.Reader` so the AWS SDK can seek for payload signing over HTTP endpoints
  - **s3api server**: Support `x-amz-metadata-directive` in `CopyObject` — `REPLACE` uses request headers, `COPY` (default) preserves source metadata
  - **azblob**: Lowercase metadata keys on read (Azure normalizes them to Title-Case)
- Fix s2test metadata keys to avoid hyphens (rejected by Azure)

## Running integration tests

```sh
# S3 (against AWS)
S2_TEST_S3_BUCKET=my-bucket go test -tags integtest ./s3/...

# S3 (against local s2-server)
S2_TEST_S3_BUCKET=my-bucket S2_TEST_S3_ENDPOINT=http://localhost:9000 \
  S2_TEST_S3_ACCESS_KEY_ID=user S2_TEST_S3_SECRET_ACCESS_KEY=pass \
  go test -tags integtest ./s3/...

# GCS
S2_TEST_GCS_BUCKET=my-bucket go test -tags integtest ./gcs/...

# Azure Blob Storage
S2_TEST_AZBLOB_CONTAINER=my-container \
  S2_TEST_AZBLOB_ACCOUNT_NAME=acct S2_TEST_AZBLOB_ACCOUNT_KEY=key \
  go test -tags integtest ./azblob/...
```

## Test plan

- [x] All unit tests pass
- [x] `golangci-lint run ./...` reports 0 issues
- [x] Integration tests pass: AWS S3, S2 server (HTTP), GCS, Azure Blob Storage