### PR TITLE
feat(server): Add build tags to enable cloud backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The bind-mounted directory is recognized as a bucket automatically — no `S2_SE
 ## Features
 
 - **Unified Storage Interface** — One API for local filesystem, in-memory, AWS S3, Google Cloud Storage, and Azure Blob Storage
-- **S3-Compatible Server** — Serve `osfs` or `memfs` backends over S3 APIs; a drop-in replacement for MinIO in local development
+- **S3-Compatible Server** — Serve any backend over S3 APIs with [build tags](#environment-variables); `osfs` and `memfs` out of the box
 - **Lightweight** — Minimal dependencies, single binary, `go install` ready
 - **Pluggable Backends** — Register storage implementations with a blank import
 - **Web Console** — Built-in browser interface for managing buckets and objects
@@ -519,7 +519,17 @@ if _, err := strg.Get(ctx, "missing.txt"); errors.Is(err, s2.ErrNotExist) {
 | `S2_SERVER_BUCKETS` | — | Comma-separated list of buckets to create on startup |
 
 Environment variables take precedence over the config file.
-The server supports `osfs` and `memfs` backends only. Cloud backends (`s3`, `gcs`, `azblob`) are available as a library but not as server backends.
+The server supports `osfs` and `memfs` backends by default. To enable cloud backends, build with the corresponding tags:
+
+```sh
+# Single backend
+go install -tags server_gcs github.com/mojatter/s2/cmd/s2-server@latest
+
+# All cloud backends
+go install -tags server_s3,server_gcs,server_azblob github.com/mojatter/s2/cmd/s2-server@latest
+```
+
+The official release binaries and Docker images include `osfs` and `memfs` only.
 
 ### Authentication
 

--- a/server/tag_azblob.go
+++ b/server/tag_azblob.go
@@ -1,0 +1,5 @@
+//go:build server_azblob
+
+package server
+
+import _ "github.com/mojatter/s2/azblob" // Register Azure Blob Storage backend for s2-server.

--- a/server/tag_gcs.go
+++ b/server/tag_gcs.go
@@ -1,0 +1,5 @@
+//go:build server_gcs
+
+package server
+
+import _ "github.com/mojatter/s2/gcs" // Register GCS backend for s2-server.

--- a/server/tag_s3.go
+++ b/server/tag_s3.go
@@ -1,0 +1,5 @@
+//go:build server_s3
+
+package server
+
+import _ "github.com/mojatter/s2/s3" // Register S3 backend for s2-server.


### PR DESCRIPTION
## Summary

- Add `server_s3`, `server_gcs`, `server_azblob` build tags that opt-in cloud backends for s2-server
- Default build remains `osfs`/`memfs` only — official release binaries and Docker images are unchanged
- Document build tag usage in README (Server Configuration section)

## Files

- `server/tag_s3.go` — `//go:build server_s3` → `_ "github.com/mojatter/s2/s3"`
- `server/tag_gcs.go` — `//go:build server_gcs` → `_ "github.com/mojatter/s2/gcs"`
- `server/tag_azblob.go` — `//go:build server_azblob` → `_ "github.com/mojatter/s2/azblob"`

## Test plan

- [x] `go build ./server/...` passes without tags
- [x] `go build -tags server_s3,server_gcs,server_azblob ./cmd/s2-server/` passes
- [x] `go test ./server/...` passes
- [x] `golangci-lint run ./server/...` — 0 issues