### PR TITLE
refactor: Move s2env logic to root package and promote internal/numconv

### DIFF
--- a/azblob/object.go
+++ b/azblob/object.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/mojatter/s2"
-	"github.com/mojatter/s2/internal/numconv"
 )
 
 type object struct {
@@ -33,7 +32,7 @@ func (o *object) Open() (io.ReadCloser, error) {
 }
 
 func (o *object) OpenRange(offset, length uint64) (io.ReadCloser, error) {
-	rc, err := o.client.downloadStream(context.Background(), o.container, o.key(), numconv.MustInt64(offset), numconv.MustInt64(length))
+	rc, err := o.client.downloadStream(context.Background(), o.container, o.key(), s2.MustInt64(offset), s2.MustInt64(length))
 	if err != nil {
 		return nil, mapNotExist(err, o.name)
 	}

--- a/azblob/storage.go
+++ b/azblob/storage.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 
 	"github.com/mojatter/s2"
-	"github.com/mojatter/s2/internal/numconv"
 )
 
 // ErrRequiredConfigRoot is kept for backwards compatibility.
@@ -156,7 +155,7 @@ func (s *azblobStorage) List(ctx context.Context, opts s2.ListOptions) (s2.ListR
 			container: s.container,
 			prefix:    s.prefix,
 			name:      name,
-			length:    numconv.MustUint64(item.contentLength),
+			length:    s2.MustUint64(item.contentLength),
 			modified:  item.lastModified,
 			metadata:  s2.Metadata(fromPtrMetadata(item.metadata)),
 		})
@@ -180,7 +179,7 @@ func (s *azblobStorage) Get(ctx context.Context, name string) (s2.Object, error)
 		container: s.container,
 		prefix:    s.prefix,
 		name:      name,
-		length:    numconv.MustUint64(props.contentLength),
+		length:    s2.MustUint64(props.contentLength),
 		modified:  props.lastModified,
 		metadata:  s2.Metadata(fromPtrMetadata(props.metadata)),
 	}, nil

--- a/configs.go
+++ b/configs.go
@@ -1,0 +1,61 @@
+package s2
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// Configs is a map of logical names to Config objects.
+type Configs map[string]Config
+
+// Storages is a map of logical names to Storage instances.
+type Storages map[string]Storage
+
+// LoadConfigs parses JSON formatted data from the specified io.Reader into Configs.
+func LoadConfigs(r io.Reader) (Configs, error) {
+	var c Configs
+	if err := json.NewDecoder(r).Decode(&c); err != nil {
+		return nil, fmt.Errorf("decode configs: %w", err)
+	}
+	return c, nil
+}
+
+// LoadConfigsFile reads the file at the given path and parses it as a JSON format
+// into Configs.
+func LoadConfigsFile(filename string) (Configs, error) {
+	f, err := os.Open(filepath.Clean(filename))
+	if err != nil {
+		return nil, fmt.Errorf("open config file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	return LoadConfigs(f)
+}
+
+// Storages iterates over the parsed configs, invokes NewStorage for each,
+// and returns a new Storages map representing the initialized storage environments.
+func (c Configs) Storages(ctx context.Context) (Storages, error) {
+	storages := make(Storages, len(c))
+	for name, cfg := range c {
+		strg, err := NewStorage(ctx, cfg)
+		if err != nil {
+			return nil, err
+		}
+		storages[name] = strg
+	}
+	return storages, nil
+}
+
+// Load helps to simplify loading the Configs from a specific JSON file and
+// fully initializing all nested Storage instances into the resulting Storages structure.
+func Load(ctx context.Context, filename string) (Storages, error) {
+	c, err := LoadConfigsFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	return c.Storages(ctx)
+}

--- a/configs_test.go
+++ b/configs_test.go
@@ -1,0 +1,79 @@
+package s2_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mojatter/s2"
+	_ "github.com/mojatter/s2/fs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfigs(t *testing.T) {
+	jsonData := `{
+		"local-dev": {
+			"type": "memfs",
+			"root": ""
+		},
+		"public-assets": {
+			"type": "osfs",
+			"root": "/tmp/assets",
+			"signed_url": "http://localhost:8080/assets"
+		}
+	}`
+
+	configs, err := s2.LoadConfigs(strings.NewReader(jsonData))
+	require.NoError(t, err)
+
+	require.Len(t, configs, 2)
+	assert.Equal(t, s2.TypeMemFS, configs["local-dev"].Type)
+	assert.Equal(t, s2.TypeOSFS, configs["public-assets"].Type)
+	assert.Equal(t, "/tmp/assets", configs["public-assets"].Root)
+	assert.Equal(t, "http://localhost:8080/assets", configs["public-assets"].SignedURL)
+}
+
+func TestLoadConfigsFileError(t *testing.T) {
+	_, err := s2.LoadConfigsFile("non-existent-file.json")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "open config file")
+}
+
+func TestConfigsStorages(t *testing.T) {
+	configs := s2.Configs{
+		"local": s2.Config{
+			Type: s2.TypeMemFS,
+		},
+	}
+
+	storages, err := configs.Storages(context.Background())
+	require.NoError(t, err)
+	require.Len(t, storages, 1)
+
+	strg, ok := storages["local"]
+	require.True(t, ok)
+	assert.NotNil(t, strg)
+	assert.Equal(t, s2.TypeMemFS, strg.Type())
+}
+
+func TestLoad(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "configs.json")
+
+	jsonData := `{
+		"mem": {
+			"type": "memfs"
+		}
+	}`
+	err := os.WriteFile(configFile, []byte(jsonData), 0644)
+	require.NoError(t, err)
+
+	storages, err := s2.Load(context.Background(), configFile)
+	require.NoError(t, err)
+
+	require.Len(t, storages, 1)
+	assert.Equal(t, s2.TypeMemFS, storages["mem"].Type())
+}

--- a/fs/object.go
+++ b/fs/object.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/mojatter/s2"
-	"github.com/mojatter/s2/internal/numconv"
 	"github.com/mojatter/wfs"
 )
 
@@ -27,7 +26,7 @@ func newObjectFileInfo(fsys fs.FS, name string, info fs.FileInfo) *object {
 	return &object{
 		fsys:         fsys,
 		name:         name,
-		length:       numconv.MustUint64(info.Size()),
+		length:       s2.MustUint64(info.Size()),
 		lastModified: info.ModTime(),
 	}
 }
@@ -73,22 +72,22 @@ func (o *object) OpenRange(offset, length uint64) (io.ReadCloser, error) {
 		return rc, nil
 	}
 	if seeker, ok := rc.(io.ReadSeeker); ok {
-		if _, err := seeker.Seek(numconv.MustInt64(offset), io.SeekStart); err != nil {
+		if _, err := seeker.Seek(s2.MustInt64(offset), io.SeekStart); err != nil {
 			_ = rc.Close()
 			return nil, err
 		}
 		return &limitReadCloser{
-			Reader: io.LimitReader(seeker, numconv.MustInt64(length)),
+			Reader: io.LimitReader(seeker, s2.MustInt64(length)),
 			Closer: rc,
 		}, nil
 	}
 	// Fallback for non-seeker
-	if _, err := io.CopyN(io.Discard, rc, numconv.MustInt64(offset)); err != nil {
+	if _, err := io.CopyN(io.Discard, rc, s2.MustInt64(offset)); err != nil {
 		_ = rc.Close()
 		return nil, err
 	}
 	return &limitReadCloser{
-		Reader: io.LimitReader(rc, numconv.MustInt64(length)),
+		Reader: io.LimitReader(rc, s2.MustInt64(length)),
 		Closer: rc,
 	}, nil
 }

--- a/gcs/object.go
+++ b/gcs/object.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/mojatter/s2"
-	"github.com/mojatter/s2/internal/numconv"
 )
 
 type object struct {
@@ -35,7 +34,7 @@ func (o *object) Open() (io.ReadCloser, error) {
 
 func (o *object) OpenRange(offset, length uint64) (io.ReadCloser, error) {
 	obj := o.client.bucket(o.bucket).object(o.key())
-	rc, err := obj.newRangeReader(context.Background(), numconv.MustInt64(offset), numconv.MustInt64(length))
+	rc, err := obj.newRangeReader(context.Background(), s2.MustInt64(offset), s2.MustInt64(length))
 	if err != nil {
 		return nil, mapNotExist(err, o.name)
 	}

--- a/gcs/storage.go
+++ b/gcs/storage.go
@@ -14,7 +14,6 @@ import (
 	"google.golang.org/api/option"
 
 	"github.com/mojatter/s2"
-	"github.com/mojatter/s2/internal/numconv"
 )
 
 // ErrRequiredConfigRoot is kept for backwards compatibility.
@@ -131,7 +130,7 @@ func (s *gcsStorage) List(ctx context.Context, opts s2.ListOptions) (s2.ListResu
 			bucket:       s.bucket,
 			prefix:       s.prefix,
 			name:         name,
-			length:       numconv.MustUint64(attrs.Size),
+			length:       s2.MustUint64(attrs.Size),
 			lastModified: attrs.Updated,
 			metadata:     s2.Metadata(attrs.Metadata),
 		})
@@ -150,7 +149,7 @@ func (s *gcsStorage) Get(ctx context.Context, name string) (s2.Object, error) {
 		bucket:       s.bucket,
 		prefix:       s.prefix,
 		name:         name,
-		length:       numconv.MustUint64(attrs.Size),
+		length:       s2.MustUint64(attrs.Size),
 		lastModified: attrs.Updated,
 		metadata:     s2.Metadata(attrs.Metadata),
 	}, nil

--- a/object.go
+++ b/object.go
@@ -8,8 +8,6 @@ import (
 	"io"
 	"os"
 	"time"
-
-	"github.com/mojatter/s2/internal/numconv"
 )
 
 // Object is an interface that represents an object in a storage.
@@ -73,7 +71,7 @@ func NewObjectFromFile(ctx context.Context, name string, opts ...ObjectOption) (
 	}
 	o := &object{
 		name:         name,
-		length:       numconv.MustUint64(info.Size()),
+		length:       MustUint64(info.Size()),
 		lastModified: info.ModTime(),
 	}
 	for _, opt := range opts {
@@ -129,22 +127,22 @@ func (o *object) OpenRange(offset, length uint64) (io.ReadCloser, error) {
 		return rc, nil
 	}
 	if seeker, ok := rc.(io.ReadSeeker); ok {
-		if _, err := seeker.Seek(numconv.MustInt64(offset), io.SeekStart); err != nil {
+		if _, err := seeker.Seek(MustInt64(offset), io.SeekStart); err != nil {
 			_ = rc.Close()
 			return nil, err
 		}
 		return &limitReadCloser{
-			Reader: io.LimitReader(seeker, numconv.MustInt64(length)),
+			Reader: io.LimitReader(seeker, MustInt64(length)),
 			Closer: rc,
 		}, nil
 	}
 	// Fallback for non-seeker
-	if _, err := io.CopyN(io.Discard, rc, numconv.MustInt64(offset)); err != nil {
+	if _, err := io.CopyN(io.Discard, rc, MustInt64(offset)); err != nil {
 		_ = rc.Close()
 		return nil, err
 	}
 	return &limitReadCloser{
-		Reader: io.LimitReader(rc, numconv.MustInt64(length)),
+		Reader: io.LimitReader(rc, MustInt64(length)),
 		Closer: rc,
 	}, nil
 }

--- a/s2env/s2env.go
+++ b/s2env/s2env.go
@@ -1,12 +1,14 @@
+// Package s2env loads JSON configuration files and initializes all storage
+// backends. Importing this package registers every built-in backend via
+// side-effect imports.
+//
+// The core types and functions now live in the parent s2 package.
+// This package re-exports them for backward compatibility.
 package s2env
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 
 	"github.com/mojatter/s2"
 	_ "github.com/mojatter/s2/azblob"
@@ -15,52 +17,31 @@ import (
 	_ "github.com/mojatter/s2/s3"
 )
 
-// Configs is a map of logical names to s2.Config objects.
-type Configs map[string]s2.Config
+// Configs is an alias for [s2.Configs].
+type Configs = s2.Configs
 
-// Storages is a map of logical names to s2.Storage instances.
-type Storages map[string]s2.Storage
+// Storages is an alias for [s2.Storages].
+type Storages = s2.Storages
 
 // LoadConfigs parses JSON formatted data from the specified io.Reader into Configs.
+//
+// Deprecated: Use [s2.LoadConfigs] instead.
 func LoadConfigs(r io.Reader) (Configs, error) {
-	var c Configs
-	if err := json.NewDecoder(r).Decode(&c); err != nil {
-		return nil, fmt.Errorf("decode configs: %w", err)
-	}
-	return c, nil
+	return s2.LoadConfigs(r)
 }
 
 // LoadConfigsFile reads the file at the given path and parses it as a JSON format
 // into Configs.
+//
+// Deprecated: Use [s2.LoadConfigsFile] instead.
 func LoadConfigsFile(filename string) (Configs, error) {
-	f, err := os.Open(filepath.Clean(filename))
-	if err != nil {
-		return nil, fmt.Errorf("open config file: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-	return LoadConfigs(f)
-}
-
-// Storages iterates over the parsed configs, invokes s2.NewStorage for each,
-// and returns a new Configs map representing the initialized storage environments.
-func (c Configs) Storages(ctx context.Context) (Storages, error) {
-	storages := make(Storages, len(c))
-	for name, cfg := range c {
-		strg, err := s2.NewStorage(ctx, cfg)
-		if err != nil {
-			return nil, err
-		}
-		storages[name] = strg
-	}
-	return storages, nil
+	return s2.LoadConfigsFile(filename)
 }
 
 // Load helps to simplify loading the Configs from a specific JSON file and
 // fully initializing all nested Storage instances into the resulting Storages structure.
+//
+// Deprecated: Use [s2.Load] instead.
 func Load(ctx context.Context, filename string) (Storages, error) {
-	c, err := LoadConfigsFile(filename)
-	if err != nil {
-		return nil, err
-	}
-	return c.Storages(ctx)
+	return s2.Load(ctx, filename)
 }

--- a/s3/storage.go
+++ b/s3/storage.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/mojatter/s2"
-	"github.com/mojatter/s2/internal/numconv"
 )
 
 // ErrRequiredConfigRoot is kept for backwards compatibility.
@@ -160,7 +159,7 @@ func (s *storage) List(ctx context.Context, opts s2.ListOptions) (s2.ListResult,
 			bucket:       s.bucket,
 			prefix:       s.prefix,
 			name:         key,
-			length:       numconv.MustUint64(aws.ToInt64(c.Size)),
+			length:       s2.MustUint64(aws.ToInt64(c.Size)),
 			lastModified: aws.ToTime(c.LastModified),
 		})
 	}
@@ -186,7 +185,7 @@ func (s *storage) Get(ctx context.Context, name string) (s2.Object, error) {
 		bucket:       s.bucket,
 		prefix:       s.prefix,
 		name:         name,
-		length:       numconv.MustUint64(aws.ToInt64(params.ContentLength)),
+		length:       s2.MustUint64(aws.ToInt64(params.ContentLength)),
 		lastModified: aws.ToTime(params.LastModified),
 		metadata:     s2.Metadata(params.Metadata),
 	}, nil
@@ -276,7 +275,7 @@ func (s *storage) Put(ctx context.Context, obj s2.Object) error {
 		Bucket:        aws.String(s.bucket),
 		Key:           aws.String(path.Join(s.prefix, obj.Name())),
 		Body:          body,
-		ContentLength: aws.Int64(numconv.MustInt64(obj.Length())),
+		ContentLength: aws.Int64(s2.MustInt64(obj.Length())),
 		Metadata:      obj.Metadata(),
 	})
 	return err

--- a/server/handlers/console/buckets/objects.go
+++ b/server/handlers/console/buckets/objects.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/mojatter/s2"
-	"github.com/mojatter/s2/internal/numconv"
 	"github.com/mojatter/s2/server"
 	"github.com/mojatter/s2/server/middleware"
 )
@@ -149,7 +148,7 @@ func handleUploadFile(s *server.Server, w http.ResponseWriter, r *http.Request) 
 	}
 
 	key := path.Join(prefix, header.Filename)
-	obj := s2.NewObjectReader(key, file, numconv.MustUint64(header.Size))
+	obj := s2.NewObjectReader(key, file, s2.MustUint64(header.Size))
 	if err := strg.Put(ctx, obj); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/server/handlers/s3api/objects.go
+++ b/server/handlers/s3api/objects.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/mojatter/s2"
-	"github.com/mojatter/s2/internal/numconv"
 	"github.com/mojatter/s2/server"
 	"github.com/mojatter/s2/server/middleware"
 )
@@ -366,7 +365,7 @@ func handlePutObject(s *server.Server, w http.ResponseWriter, r *http.Request) {
 			contentLength = n
 		}
 	}
-	obj := s2.NewObjectReader(key, io.NopCloser(body), numconv.MustUint64(contentLength))
+	obj := s2.NewObjectReader(key, io.NopCloser(body), s2.MustUint64(contentLength))
 
 	if err := strg.Put(ctx, obj); err != nil {
 		code, msg, status := s2ErrorToS3Error(err)

--- a/server/templates.go
+++ b/server/templates.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mojatter/s2/internal/numconv"
+	"github.com/mojatter/s2"
 )
 
 //go:embed templates/*
@@ -150,7 +150,7 @@ func templateFuncs(cfg *Config) template.FuncMap {
 			if !previewableExts[ext] {
 				return false
 			}
-			if textPreviewExts[ext] && numconv.MustInt64(size) > cfg.MaxPreviewSize {
+			if textPreviewExts[ext] && s2.MustInt64(size) > cfg.MaxPreviewSize {
 				return false
 			}
 			return true

--- a/utils.go
+++ b/utils.go
@@ -1,11 +1,4 @@
-// Package numconv contains internal helpers for converting between Go's
-// signed and unsigned integer types when dealing with stdlib APIs that
-// disagree on signedness (notably os.FileInfo.Size and io.Seeker offsets).
-//
-// These helpers panic on overflow rather than silently truncating; they
-// are intended for paths where the input cannot legitimately exceed the
-// destination range, so a panic indicates a programmer error.
-package numconv
+package s2
 
 import (
 	"fmt"

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,4 +1,4 @@
-package numconv
+package s2
 
 import (
 	"math"
@@ -40,6 +40,7 @@ func TestMustInt64Panic(t *testing.T) {
 					t.Errorf("MustInt64(%d) did not panic", tc.input)
 				}
 			}()
+
 			MustInt64(tc.input)
 		})
 	}
@@ -80,6 +81,7 @@ func TestMustUint64Panic(t *testing.T) {
 					t.Errorf("MustUint64(%d) did not panic", tc.input)
 				}
 			}()
+
 			MustUint64(tc.input)
 		})
 	}


### PR DESCRIPTION
## Summary

- Move `Configs`, `Storages`, `LoadConfigs`, `LoadConfigsFile`, and `Load` from `s2env` into the root `s2` package
- Convert `s2env` to a thin backward-compatible shim (type aliases + delegating wrappers with deprecation notices)
- Promote `internal/numconv` (`MustInt64`/`MustUint64`) to `utils.go` in the root package so future submodules can access them

Both changes are prerequisites for the multi-module split planned in #63 (v0.8.0).

## Test plan

- [x] `go test ./...` passes (including existing `s2env` tests via type alias compatibility)
- [x] `golangci-lint run ./...` — 0 issues