### PR TITLE
docs: Restructure README and add docs/backends.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,41 @@ make test-e2e
 
 `make test` uses `-short` to skip integration tests. Running `go test ./...` without `-short` includes them.
 
+## Terminology
+
+Use these names consistently in documentation, commit messages, and PR descriptions:
+
+| Referring to | Write it as |
+|---|---|
+| The Go package and `Storage` interface that callers import | **S2 library** (prose), `s2` (code) |
+| The standalone S3-compatible daemon shipped as a CLI / Docker image | **S2 Server** (prose), `s2-server` (command, package path) |
+| The project as a whole (library + server) | **S2** |
+
+```
+                ┌───────────────────────────────┐
+                │              S2               │  ← umbrella project
+                └───────────────────────────────┘
+                  │                         │
+      ┌───────────┴──────────┐   ┌──────────┴───────────┐
+      │      S2 library      │◄──┤      S2 Server       │
+      │   (Go package `s2`)  │   │  (`s2-server` CLI /  │
+      │                      │   │   Docker image)      │
+      │  Storage interface   │   │                      │
+      │  + value types       │   │  S3 API on :9000     │
+      │                      │   │                      │
+      └──────────┬───────────┘   └──────────────────────┘
+                 │
+                 │ implemented by
+                 ▼
+         ┌───────────────────────────────┐
+         │   Backends                    │
+         │   osfs · memfs · s3 · gcs ·   │
+         │   azblob                      │
+         └───────────────────────────────┘
+```
+
+Avoid calling the library a "client" — it includes backends like `osfs` and `memfs` that do not connect to anything, so "client" wrongly implies it is a consumer of S2 Server.
+
 ## Design notes
 
 Past API design decisions and audits live under [`docs/`](docs/). They are not user-facing documentation, but they record *why* certain shapes were chosen and are useful when proposing changes:

--- a/README.md
+++ b/README.md
@@ -8,15 +8,29 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/mojatter/s2)](https://goreportcard.com/report/github.com/mojatter/s2)
 
 S2 is a lightweight object storage library and S3-compatible server written in Go.
-It provides a unified interface for multiple storage backends and an embeddable S3-compatible server — all in a single package.
 
 ## Why S2?
 
 MinIO was the go-to S3-compatible server for local development, but it entered maintenance mode in December 2025 and was archived in February 2026. S2 fills this gap with a different philosophy:
 
-- **Library-first** — Use S2 as a Go library with a clean interface, or run it as a server. Most alternatives are server-only.
-- **Truly lightweight** — Single binary, no external dependencies, starts in milliseconds.
-- **Test-friendly** — Use `memfs` backend for fast, isolated tests without Docker or external processes.
+- **Drop-in MinIO replacement** — Same role in `docker-compose` for local development.
+- **Unified Storage interface** — Stop reinventing the S3-vs-local-filesystem swap in every project.
+
+## Features
+
+- **S3-Compatible Server** — Enough for local development, with `osfs` and `memfs` out of the box
+- **Web Console** — Built-in browser interface for managing buckets and objects
+- **Lightweight** — Minimal dependencies, single binary, `go install` ready
+- **Unified Storage Interface** — One API for local filesystem, in-memory, AWS S3, Google Cloud Storage, and Azure Blob Storage
+- **Pluggable Backends** — Register storage implementations with a blank import
+
+<p align="center">
+  <img src="./docs/web-console.png" alt="S2 Web Console" width="720">
+</p>
+
+<p align="center">
+  <img src="./docs/web-console-gallery.png" alt="S2 Web Console — Gallery View" width="720">
+</p>
 
 ## Migrating from MinIO
 
@@ -50,9 +64,9 @@ volumes:
 | `MINIO_ROOT_PASSWORD` | `S2_SERVER_PASSWORD` |
 | `MINIO_VOLUMES` | `S2_SERVER_ROOT` (default `/var/lib/s2`) |
 | `MINIO_DEFAULT_BUCKETS` | `S2_SERVER_BUCKETS` |
-| (console UI) | `S2_SERVER_CONSOLE_LISTEN` (default `:9001`; empty disables) |
+| `MINIO_BROWSER` / `MINIO_CONSOLE_ADDRESS` | `S2_SERVER_CONSOLE_LISTEN` (default `:9001`; empty disables) |
 
-**Migrating existing data** — S2's `osfs` backend stores objects as plain files on disk (no proprietary format), so any S3 client can copy data over:
+**Migrating existing data** — use any S3 client to copy data from MinIO to S2:
 
 ```sh
 # Mirror an existing MinIO instance into a fresh S2 instance
@@ -62,16 +76,42 @@ aws --endpoint-url http://localhost:9000 s3 sync /tmp/dump s3://my-bucket
 
 Or use `mc mirror` directly between the two endpoints.
 
-## Storage Layout
+## Anatomy
 
-The `osfs` backend stores objects as plain files on disk under the configured root directory (default `/var/lib/s2` in Docker, `data` otherwise). Each bucket is a top-level directory, and object keys map directly to file paths:
+S2 has two parts: **S2 Server**, a standalone S3-compatible daemon, and a Go **library** you import into your code. S2 Server embeds the library, so both share the same pluggable backends.
+
+```
+                   ┌───────────────────────────────┐
+                   │              S2               │
+                   └───────────────────────────────┘
+                      │                          │
+         ┌────────────┴─────────┐   ┌────────────┴─────────┐
+         │      S2 Server       ├──►│      S2 library      │
+         │                      │   │                      │
+         │  run as S3 endpoint  │   │  import from Go      │
+         │  (drop-in for MinIO) │   │  (s2 package)        │
+         └──────────────────────┘   └───────┬──────────────┘
+                                            │
+                                            │ implemented by
+                                            ▼
+                    ┌──────────────────────────────────────┐
+                    │   Backends                           │
+                    │   osfs · memfs · s3 · gcs · azblob   │
+                    └──────────────────────────────────────┘
+```
+
+## S2 Server Storage Layout
+
+The `osfs` backend stores objects as plain files on disk under the configured root directory (default `/var/lib/s2` in Docker, `./data` otherwise). Each bucket is a top-level directory, and object keys map directly to file paths:
 
 ```
 $S2_SERVER_ROOT/
-├── assets/
-│   ├── .keep              # bucket marker (tracks creation time)
+├── assets/                 # each top-level dir is a bucket
+│   ├── .keep               # bucket marker (tracks creation time)
 │   ├── logo.png
 │   └── css/
+│       ├── .meta/
+│       │   └── style.css   # JSON metadata for ../style.css
 │       ├── .keep
 │       └── style.css
 └── uploads/
@@ -79,7 +119,7 @@ $S2_SERVER_ROOT/
     └── photo.jpg
 ```
 
-Because buckets are just directories, you can **seed data by bind-mounting host directories** into the container. This is useful for local development when you want to serve git-tracked static assets through an S3-compatible API without uploading them manually.
+You can **seed a bucket by bind-mounting a host directory** — handy for serving git-tracked static assets without uploading them manually.
 
 ```yaml
 services:
@@ -99,27 +139,25 @@ volumes:
   s2-data:
 ```
 
-The bind-mounted directory is recognized as a bucket automatically — no `S2_SERVER_BUCKETS` entry is needed. Any files placed there are immediately accessible via the S3 API and Web Console.
+The bind-mounted directory is auto-recognized as a bucket — no `S2_SERVER_BUCKETS` entry needed.
 
-> **Note:** If the bind-mounted directory does not contain a `.keep` file, the bucket's creation timestamp falls back to the current time. This is cosmetic only and does not affect functionality.
-
-## Features
-
-- **Unified Storage Interface** — One API for local filesystem, in-memory, AWS S3, Google Cloud Storage, and Azure Blob Storage
-- **S3-Compatible Server** — Serve any backend over S3 APIs with [build tags](#environment-variables); `osfs` and `memfs` out of the box
-- **Lightweight** — Minimal dependencies, single binary, `go install` ready
-- **Pluggable Backends** — Register storage implementations with a blank import
-- **Web Console** — Built-in browser interface for managing buckets and objects
-
-<p align="center">
-  <img src="./docs/web-console.png" alt="S2 Web Console" width="720">
-</p>
-
-<p align="center">
-  <img src="./docs/web-console-gallery.png" alt="S2 Web Console — Gallery View" width="720">
-</p>
+> **Note:** Without a `.keep` file, the bucket's creation timestamp falls back to the current time (cosmetic only).
 
 ## Install
+
+### Install server
+
+```sh
+go install github.com/mojatter/s2/cmd/s2-server@latest
+```
+
+Or run with Docker:
+
+```sh
+docker run -p 9000:9000 -p 9001:9001 mojatter/s2-server
+```
+
+### Install library
 
 ```sh
 go get github.com/mojatter/s2
@@ -135,82 +173,9 @@ go get github.com/mojatter/s2/azblob # Azure Blob Storage
 
 > **Note:** If your code already imports a backend package (e.g. `_ "github.com/mojatter/s2/s3"`), `go mod tidy` will add the required module automatically.
 
-To install the S2 server CLI:
-
-```sh
-go install github.com/mojatter/s2/cmd/s2-server@latest
-```
-
-Or run with Docker:
-
-```sh
-docker run -p 9000:9000 -p 9001:9001 mojatter/s2-server
-```
-
 ## Quick Start
 
-### As a Library
-
-Define your storage backends in a JSON config file:
-
-```json
-{
-  "assets": {
-    "type": "osfs",
-    "root": "/var/data/assets"
-  },
-  "backups": {
-    "type": "s3",
-    "root": "my-backup-bucket"
-  }
-}
-```
-
-Load and use them with `s2env` (`go get github.com/mojatter/s2/s2env`):
-
-```go
-package main
-
-import (
-	"context"
-	"fmt"
-
-	"github.com/mojatter/s2"
-	"github.com/mojatter/s2/s2env"
-)
-
-func main() {
-	ctx := context.Background()
-
-	// Load all storages from config file
-	storages, err := s2env.Load(ctx, "s2.json")
-	if err != nil {
-		panic(err)
-	}
-
-	// Use a named storage
-	assets := storages["assets"]
-
-	// Put an object
-	obj := s2.NewObjectBytes("hello.txt", []byte("Hello, S2!"))
-	if err := assets.Put(ctx, obj); err != nil {
-		panic(err)
-	}
-
-	// List objects
-	res, err := assets.List(ctx, s2.ListOptions{Limit: 100})
-	if err != nil {
-		panic(err)
-	}
-	for _, o := range res.Objects {
-		fmt.Println(o.Name())
-	}
-}
-```
-
-`s2env` automatically registers all built-in backends (`osfs`, `memfs`, `s3`, `gcs`, `azblob`), so no blank imports are needed.
-
-### As a Local S3 Server
+### As a local S3 server
 
 Start the server:
 
@@ -232,7 +197,7 @@ import (
 	"fmt"
 
 	"github.com/mojatter/s2"
-	_ "github.com/mojatter/s2/s3" // Register S3 backend
+	_ "github.com/mojatter/s2/s3" // registers s3 backend
 )
 
 func main() {
@@ -262,7 +227,47 @@ aws --endpoint-url http://localhost:9000 s3 ls
 aws --endpoint-url http://localhost:9000 s3 cp ./file.txt s3://my-bucket/file.txt
 ```
 
-### In Tests
+### As a library
+
+Define your storages in a JSON file (`s2.json`):
+
+```json
+{
+  "assets": { "type": "osfs", "root": "/var/data/assets" },
+  "backups": { "type": "s3", "root": "my-backup-bucket" }
+}
+```
+
+Then load and use them with `s2env` (`go get github.com/mojatter/s2/s2env`):
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/mojatter/s2"
+	"github.com/mojatter/s2/s2env"
+)
+
+func main() {
+	ctx := context.Background()
+	storages, err := s2env.Load(ctx, "s2.json")
+	if err != nil {
+		panic(err)
+	}
+	assets := storages["assets"]
+
+	obj := s2.NewObjectBytes("hello.txt", []byte("Hello, S2!"))
+	if err := assets.Put(ctx, obj); err != nil {
+		panic(err)
+	}
+}
+```
+
+For per-backend configuration fields, multi-backend examples, and an explicit-import alternative (`s2.LoadConfigsFile`), see [docs/backends.md](docs/backends.md).
+
+### In tests
 
 For tests, swap any backend for `memfs` to get an isolated, in-process storage with no Docker, no temp directories, and no cleanup. The same `s2.Storage` interface is used in production and tests.
 
@@ -274,7 +279,7 @@ import (
 	"testing"
 
 	"github.com/mojatter/s2"
-	_ "github.com/mojatter/s2/fs" // registers memfs
+	_ "github.com/mojatter/s2/fs" // registers osfs + memfs
 )
 
 func TestUploadAvatar(t *testing.T) {
@@ -291,19 +296,19 @@ func TestUploadAvatar(t *testing.T) {
 }
 ```
 
-The `s2test` package provides reusable assertion helpers (e.g. `s2test.TestStorageList`) for validating `Storage` implementations and exercising your own code against any backend.
+[`s2test.StorageDelegator`](https://pkg.go.dev/github.com/mojatter/s2/s2test#StorageDelegator) is a test double for `s2.Storage` where each method delegates to a `*Func` field — useful for injecting errors or capturing calls without writing a full mock.
 
 ## Storage Backends
 
 Each cloud backend is a separate Go module with its own dependencies, so `go get github.com/mojatter/s2` alone does not pull in any cloud SDK.
 
-| Type | Import | Module |Description |
-|------|--------|--------|-------------|
-| `osfs` | `github.com/mojatter/s2/fs` | `github.com/mojatter/s2` | Local filesystem storage |
-| `memfs` | `github.com/mojatter/s2/fs` | `github.com/mojatter/s2` | In-memory filesystem (great for testing; see notes below) |
-| `s3` | `github.com/mojatter/s2/s3` | `github.com/mojatter/s2/s3` | AWS S3 (and any S3-compatible service) |
-| `gcs` | `github.com/mojatter/s2/gcs` | `github.com/mojatter/s2/gcs` | Google Cloud Storage |
-| `azblob` | `github.com/mojatter/s2/azblob` | `github.com/mojatter/s2/azblob` | Azure Blob Storage |
+| Type | Import | Description |
+|------|--------|-------------|
+| `osfs` | `github.com/mojatter/s2/fs` | Local filesystem storage |
+| `memfs` | `github.com/mojatter/s2/fs` | In-memory filesystem (great for testing) |
+| `s3` | `github.com/mojatter/s2/s3` | AWS S3 (and any S3-compatible service) |
+| `gcs` | `github.com/mojatter/s2/gcs` | Google Cloud Storage |
+| `azblob` | `github.com/mojatter/s2/azblob` | Azure Blob Storage |
 
 Backends are registered via blank imports. Import only what you need:
 
@@ -316,137 +321,15 @@ import (
 )
 ```
 
-## S3 Backend Configuration
+## Backend Configuration
 
-When using the `s3` backend, you can provide S3-specific settings via `S3Config`. Any field left empty falls back to the AWS SDK defaults (environment variables, `~/.aws/config`, IAM roles, etc.).
+Each backend has its own configuration and authentication options. See [docs/backends.md](docs/backends.md) for details:
 
-```go
-strg, err := s2.NewStorage(ctx, s2.Config{
-    Type: s2.TypeS3,
-    Root: "my-bucket/optional-prefix",
-    S3: &s2.S3Config{
-        EndpointURL:    "http://localhost:9000",
-        Region:         "ap-northeast-1",
-        AccessKeyID:    "s2user",
-        SecretAccessKey: "s2password",
-    },
-})
-```
-
-With `s2env`, use the `"s3"` key in JSON:
-
-```json
-{
-  "local": {
-    "type": "s3",
-    "root": "dev-bucket",
-    "s3": {
-      "endpoint_url": "http://localhost:9000",
-      "access_key_id": "myuser",
-      "secret_access_key": "mypassword"
-    }
-  },
-  "prod": {
-    "type": "s3",
-    "root": "prod-bucket",
-    "s3": {
-      "region": "ap-northeast-1"
-    }
-  }
-}
-```
-
-| Field | Description |
-|-------|-------------|
-| `endpoint_url` | Custom S3-compatible endpoint URL |
-| `region` | AWS region (e.g. `ap-northeast-1`) |
-| `access_key_id` | AWS access key ID |
-| `secret_access_key` | AWS secret access key |
-
-When `S3Config` is nil or all fields are empty, the standard AWS SDK credential chain is used.
-
-## GCS Backend Configuration
-
-When using the `gcs` backend, authentication uses [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials) by default. Run `gcloud auth application-default login` for local development.
-
-```go
-strg, err := s2.NewStorage(ctx, s2.Config{
-    Type: s2.TypeGCS,
-    Root: "my-bucket/optional-prefix",
-    // GCS: nil — ADC is used automatically
-})
-```
-
-To use a service account key file:
-
-```go
-strg, err := s2.NewStorage(ctx, s2.Config{
-    Type: s2.TypeGCS,
-    Root: "my-bucket",
-    GCS: &s2.GCSConfig{
-        CredentialsFile: "/path/to/service-account.json",
-    },
-})
-```
-
-With `s2env`:
-
-```json
-{
-  "assets": {
-    "type": "gcs",
-    "root": "my-bucket/assets",
-    "gcs": {
-      "credentials_file": "/path/to/service-account.json"
-    }
-  }
-}
-```
-
-| Field | Description |
-|-------|-------------|
-| `credentials_file` | Path to a service account JSON key file |
-
-When `GCSConfig` is nil or all fields are empty, Application Default Credentials are used.
-
-## Azure Blob Storage Backend Configuration
-
-When using the `azblob` backend, you can authenticate with a connection string, shared key, or [DefaultAzureCredential](https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication).
-
-```go
-// Shared key authentication
-strg, err := s2.NewStorage(ctx, s2.Config{
-    Type: s2.TypeAzblob,
-    Root: "my-container/optional-prefix",
-    Azblob: &s2.AzblobConfig{
-        AccountName: "mystorageaccount",
-        AccountKey:  "base64-encoded-key",
-    },
-})
-```
-
-With `s2env`:
-
-```json
-{
-  "uploads": {
-    "type": "azblob",
-    "root": "my-container",
-    "azblob": {
-      "account_name": "mystorageaccount",
-      "account_key": "base64-encoded-key"
-    }
-  }
-}
-```
-
-| Field | Description |
-|-------|-------------|
-| `account_name` | Azure storage account name |
-| `account_key` | Shared key for the storage account |
-| `connection_string` | Full Azure Storage connection string (takes precedence over name+key) |
-
-Authentication priority: `connection_string` > `account_name`+`account_key` > DefaultAzureCredential.
+- [osfs](docs/backends.md#osfs) — Local filesystem
+- [memfs](docs/backends.md#memfs) — In-memory (for tests)
+- [S3](docs/backends.md#s3) — AWS S3 and any S3-compatible endpoint
+- [GCS](docs/backends.md#gcs) — Google Cloud Storage
+- [Azure Blob Storage](docs/backends.md#azure-blob-storage)
 
 ## Storage Interface
 
@@ -504,7 +387,7 @@ if _, err := strg.Get(ctx, "missing.txt"); errors.Is(err, s2.ErrNotExist) {
 
 ## Server Configuration
 
-### Environment Variables
+### Environment variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -519,6 +402,9 @@ if _, err := strg.Get(ctx, "missing.txt"); errors.Is(err, s2.ErrNotExist) {
 | `S2_SERVER_BUCKETS` | — | Comma-separated list of buckets to create on startup |
 
 Environment variables take precedence over the config file.
+
+### Build tags
+
 The server supports `osfs` and `memfs` backends by default. To enable cloud backends, build with the corresponding tags:
 
 ```sh
@@ -529,11 +415,11 @@ go install -tags server_gcs github.com/mojatter/s2/cmd/s2-server@latest
 go install -tags server_s3,server_gcs,server_azblob github.com/mojatter/s2/cmd/s2-server@latest
 ```
 
-The official release binaries and Docker images include `osfs` and `memfs` only.
+> **Note:** The official release binaries and Docker images include `osfs` and `memfs` only.
 
 ### Authentication
 
-When `S2_SERVER_USER` is set, the server requires credentials on all routes:
+Authentication is disabled by default (`S2_SERVER_USER` empty). When set, the server requires credentials on all routes:
 
 - **Web Console** — HTTP Basic Auth
 - **S3 API** — AWS Signature Version 4 (`S2_SERVER_USER` as the Access Key ID, `S2_SERVER_PASSWORD` as the Secret Access Key)
@@ -562,11 +448,9 @@ aws_secret_access_key = mypassword
 aws --profile s2 s3 ls
 ```
 
-When `S2_SERVER_USER` is empty (the default), authentication is disabled.
-
 **Presigned URLs** — S2 verifies AWS SigV4 signatures passed in the query string (`X-Amz-Algorithm=AWS4-HMAC-SHA256`, `X-Amz-Signature`, …), so URLs produced by `s3.NewPresignClient` (Go) or `s3.getSignedUrl` (JavaScript) work for GET and PUT. The body of a presigned PUT is treated as `UNSIGNED-PAYLOAD`.
 
-### Config File
+### Config file
 
 ```json
 {
@@ -585,7 +469,9 @@ When `S2_SERVER_USER` is empty (the default), authentication is disabled.
 s2-server -f config.json
 ```
 
-### S3 API Endpoints
+`-f` takes precedence over `S2_SERVER_CONFIG`.
+
+### S3 API endpoints
 
 | Method | Path | Operation |
 |--------|------|-----------|
@@ -632,9 +518,9 @@ Numbers below are local runs on an Apple M4 (`darwin/arm64`, single process). Tr
 | `BenchmarkHTTPPutObjectMemFS` | 86,952 | 46,504 | 193 |
 | `BenchmarkHTTPGetObjectMemFS` | 34,773 | 43,115 | 117 |
 
-The `osfs` PUT path always fsyncs before rename — that durability guarantee is roughly **4 ms of the 4.2 ms per storage-layer PUT** on this machine. For apples-to-apples comparisons against benchmarks from other S3-compatible servers, make sure they are running with fsync enabled as well; many default to write-through-page-cache and will look proportionally faster until you flip the fsync switch on.
+The `osfs` PUT path always fsyncs before rename — that durability guarantee is roughly **4 ms of the 4.2 ms per storage-layer PUT** on this machine. For apples-to-apples comparisons against benchmarks from other S3-compatible servers, make sure they are running with fsync enabled as well. Many default to write-through-page-cache and will look proportionally faster until you flip the fsync switch on.
 
-The `memfs` columns exist because S2 ships an in-memory backend specifically for tests; skipping the disk barrier makes `GetObject` over **100x faster** and `PutObject` over **1800x faster** than `osfs` on the same hardware, which is what makes `memfs` worth reaching for in unit tests that need an S3-compatible target without Docker or a temp directory.
+The `memfs` columns exist because S2 ships an in-memory backend specifically for tests. Skipping the disk barrier makes `GetObject` over **100x faster** and `PutObject` over **1800x faster** than `osfs` on the same hardware. That speedup is what makes `memfs` worth reaching for in unit tests that need an S3-compatible target without Docker or a temp directory.
 
 ### End-to-end benchmark with warp
 
@@ -677,16 +563,6 @@ S2 aims to cover the parts of the S3 API that matter for local development and l
 - **Replication, lifecycle rules, object lock** — Not implemented.
 
 If your use case needs any of the above, S2 is probably not the right tool — consider AWS S3, Ceph RGW, or SeaweedFS.
-
-### memfs backend
-
-The `memfs` backend holds every object body in process memory. It is designed for **tests and local development**, not production workloads:
-
-- All objects live in RAM for the lifetime of the process; nothing is persisted.
-- The default upload limit is **16 MiB** (vs. 5 GiB for `osfs`/`s3`) to protect the host from accidental OOM. Set `S2_SERVER_MAX_UPLOAD_SIZE` (or `Config.MaxUploadSize`) to raise it if you genuinely need larger uploads against memfs.
-- There is no total-memory budget or backpressure across concurrent uploads.
-
-If you need to handle large files, use the `osfs` or `s3` backend instead.
 
 ## License
 

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -1,0 +1,242 @@
+# Backend Configuration
+
+Configuration options and authentication details for each backend. Each backend is configured via `s2.Config`; the JSON examples below show what that struct looks like encoded.
+
+To load multiple named backends from a single JSON file, use [`s2env`](https://pkg.go.dev/github.com/mojatter/s2/s2env) — its top-level object maps storage names to `s2.Config` values.
+
+## OSFS
+
+Local filesystem storage.
+
+```go
+strg, err := s2.NewStorage(ctx, s2.Config{
+    Type: s2.TypeOSFS,
+    Root: "/var/data/my-bucket",
+})
+```
+
+As JSON:
+
+```json
+{
+  "type": "osfs",
+  "root": "/var/data/my-bucket"
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `root` | Filesystem path under which objects are stored |
+
+Access control is governed by filesystem permissions.
+
+## MEMFS
+
+In-memory storage designed for **tests and local development** — nothing is persisted. Swap in `memfs` where you would otherwise start a Docker container or create a temp directory for tests.
+
+```go
+strg, err := s2.NewStorage(ctx, s2.Config{
+    Type: s2.TypeMemFS,
+})
+```
+
+As JSON:
+
+```json
+{ "type": "memfs" }
+```
+
+`memfs` takes no configuration fields.
+
+**Production caveats** — `memfs` holds every object body in process memory. It is **not** intended for production workloads:
+
+- All objects live in RAM for the lifetime of the process; nothing is persisted.
+- The default upload limit is **16 MiB** (vs. 5 GiB for `osfs`/`s3`) to protect the host from accidental OOM. Set `S2_SERVER_MAX_UPLOAD_SIZE` (or `Config.MaxUploadSize`) to raise it if you genuinely need larger uploads against memfs.
+- There is no total-memory budget or backpressure across concurrent uploads.
+
+If you need to handle large files, use `osfs` or `s3` instead.
+
+## S3
+
+When using the `s3` backend, you can provide S3-specific settings via `S3Config`. Any field left empty falls back to the AWS SDK defaults (environment variables, `~/.aws/config`, IAM roles, etc.).
+
+```go
+strg, err := s2.NewStorage(ctx, s2.Config{
+    Type: s2.TypeS3,
+    Root: "my-bucket/optional-prefix",
+    S3: &s2.S3Config{
+        EndpointURL:    "http://localhost:9000",
+        Region:         "ap-northeast-1",
+        AccessKeyID:    "s2user",
+        SecretAccessKey: "s2password",
+    },
+})
+```
+
+As JSON:
+
+```json
+{
+  "type": "s3",
+  "root": "my-bucket/optional-prefix",
+  "s3": {
+    "endpoint_url": "http://localhost:9000",
+    "region": "ap-northeast-1",
+    "access_key_id": "s2user",
+    "secret_access_key": "s2password"
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `endpoint_url` | Custom S3-compatible endpoint URL |
+| `region` | AWS region (e.g. `ap-northeast-1`) |
+| `access_key_id` | AWS access key ID |
+| `secret_access_key` | AWS secret access key |
+
+When `S3Config` is nil or all fields are empty, the standard AWS SDK credential chain is used.
+
+## GCS
+
+When using the `gcs` backend, authentication uses [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials) by default. Run `gcloud auth application-default login` for local development.
+
+```go
+strg, err := s2.NewStorage(ctx, s2.Config{
+    Type: s2.TypeGCS,
+    Root: "my-bucket/optional-prefix",
+    // GCS: nil — ADC is used automatically
+})
+```
+
+To use a service account key file:
+
+```go
+strg, err := s2.NewStorage(ctx, s2.Config{
+    Type: s2.TypeGCS,
+    Root: "my-bucket",
+    GCS: &s2.GCSConfig{
+        CredentialsFile: "/path/to/service-account.json",
+    },
+})
+```
+
+As JSON:
+
+```json
+{
+  "type": "gcs",
+  "root": "my-bucket/assets",
+  "gcs": {
+    "credentials_file": "/path/to/service-account.json"
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `credentials_file` | Path to a service account JSON key file |
+
+## Azure Blob Storage
+
+When using the `azblob` backend, you can authenticate with a connection string, shared key, or [DefaultAzureCredential](https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication).
+
+```go
+// Shared key authentication
+strg, err := s2.NewStorage(ctx, s2.Config{
+    Type: s2.TypeAzblob,
+    Root: "my-container/optional-prefix",
+    Azblob: &s2.AzblobConfig{
+        AccountName: "mystorageaccount",
+        AccountKey:  "base64-encoded-key",
+    },
+})
+```
+
+As JSON:
+
+```json
+{
+  "type": "azblob",
+  "root": "my-container",
+  "azblob": {
+    "account_name": "mystorageaccount",
+    "account_key": "base64-encoded-key"
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `account_name` | Azure storage account name |
+| `account_key` | Shared key for the storage account |
+| `connection_string` | Full Azure Storage connection string (takes precedence over name+key) |
+
+Authentication priority: `connection_string` > `account_name`+`account_key` > DefaultAzureCredential.
+
+## Combining backends with s2env
+
+To manage several named storages from a single JSON file, use [`s2env`](https://pkg.go.dev/github.com/mojatter/s2/s2env). Its top-level object is a map of storage name → `s2.Config`, so each entry takes the same shape as the per-backend examples above:
+
+```json
+{
+  "assets": {
+    "type": "osfs",
+    "root": "/var/data/assets"
+  },
+  "tests": {
+    "type": "memfs"
+  },
+  "uploads": {
+    "type": "s3",
+    "root": "uploads-bucket",
+    "s3": {
+      "region": "ap-northeast-1"
+    }
+  },
+  "backups": {
+    "type": "gcs",
+    "root": "my-backups",
+    "gcs": {
+      "credentials_file": "/etc/s2/sa.json"
+    }
+  }
+}
+```
+
+Load and access them by name:
+
+```go
+storages, err := s2env.Load(ctx, "s2.json")
+if err != nil {
+    panic(err)
+}
+assets := storages["assets"]
+```
+
+`s2env` registers all built-in backends automatically — no blank imports required.
+
+## Cherry-picking backends with s2.LoadConfigsFile
+
+`s2env` is convenient because it auto-registers every built-in backend, but that pulls in the AWS, GCS, and Azure SDKs as transitive dependencies. If you want to control which backends — and which SDKs — your binary depends on, use `s2.LoadConfigsFile` from the main package and blank-import only the backends you need:
+
+```go
+import (
+    "github.com/mojatter/s2"
+    _ "github.com/mojatter/s2/fs" // osfs + memfs only — no cloud SDKs pulled in
+    _ "github.com/mojatter/s2/s3" // add only what you actually use
+)
+
+// ...
+configs, err := s2.LoadConfigsFile("s2.json")
+if err != nil {
+    panic(err)
+}
+storages, err := configs.Storages(ctx)
+if err != nil {
+    panic(err)
+}
+assets := storages["assets"]
+```
+
+Any backend type referenced in the JSON that has not been blank-imported will fail at `Storages(ctx)` time.


### PR DESCRIPTION
## Summary
- Add **Anatomy** section to README and reorder so the server is presented first
- Add **Terminology** section to CONTRIBUTING
- Split per-backend Configuration into `docs/backends.md` (with `s2env` and `s2.LoadConfigsFile` examples)
- Polish: prose tightening, dedicated `### Build tags` subsection, anchor cleanup, MinIO env-var mapping accuracy (`MINIO_BROWSER` / `MINIO_CONSOLE_ADDRESS`)

## Test plan
- [x] Render README on GitHub and verify all anchors resolve (Anatomy, Build tags, backends.md cherry-pick)
- [x] Verify docs/backends.md headings match the anchor links from README