### PR TITLE
docs: Add --rm and use $(pwd)/data in docker run examples

### DIFF
--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -6,7 +6,7 @@ A drop-in replacement for MinIO in local development and CI environments.
 ## Quick Start
 
 ```sh
-docker run -p 9000:9000 -p 9001:9001 mojatter/s2-server
+docker run --rm -p 9000:9000 -p 9001:9001 mojatter/s2-server
 ```
 
 S2 serves the S3 API on `:9000` at the root path (same layout as MinIO), and the Web Console on `:9001`. Use any S3 client without extra configuration:
@@ -21,7 +21,7 @@ Access the Web Console at http://localhost:9001.
 ## Persistent Storage
 
 ```sh
-docker run -p 9000:9000 -p 9001:9001 -v /your/data:/var/lib/s2 mojatter/s2-server
+docker run --rm -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/var/lib/s2 mojatter/s2-server
 ```
 
 ## docker-compose
@@ -58,7 +58,7 @@ services:
 Set `S2_SERVER_USER` and `S2_SERVER_PASSWORD` to enable authentication:
 
 ```sh
-docker run -p 9000:9000 -p 9001:9001 \
+docker run --rm -p 9000:9000 -p 9001:9001 \
   -e S2_SERVER_USER=myuser \
   -e S2_SERVER_PASSWORD=mypassword \
   mojatter/s2-server

--- a/README.md
+++ b/README.md
@@ -151,12 +151,6 @@ The bind-mounted directory is auto-recognized as a bucket — no `S2_SERVER_BUCK
 go install github.com/mojatter/s2/cmd/s2-server@latest
 ```
 
-Or run with Docker:
-
-```sh
-docker run -p 9000:9000 -p 9001:9001 mojatter/s2-server
-```
-
 ### Install library
 
 ```sh
@@ -184,7 +178,7 @@ Start the server:
 s2-server
 
 # via Docker
-docker run -p 9000:9000 -p 9001:9001 -v /your/data:/var/lib/s2 mojatter/s2-server
+docker run --rm -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/var/lib/s2 mojatter/s2-server
 ```
 
 Then access it with any S3 client:


### PR DESCRIPTION
- Add `--rm` to all `docker run` examples so containers are cleaned up automatically
- Replace `/your/data` with `$(pwd)/data` for a more practical bind mount path
- Remove the redundant `docker run` snippet from the Install section (it belongs in Quick Start, not Install)