### PR TITLE
feat(console): Add prefix search to objects view

### DIFF
--- a/server/handlers/console/buckets/objects.go
+++ b/server/handlers/console/buckets/objects.go
@@ -21,6 +21,7 @@ func handleObjects(s *server.Server, w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	name := r.PathValue("name")
 	prefix := strings.TrimRight(r.URL.Query().Get("prefix"), "/")
+	search := r.URL.Query().Get("search")
 
 	strg, err := s.Buckets.Get(ctx, name)
 	if err != nil {
@@ -28,13 +29,30 @@ func handleObjects(s *server.Server, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res, err := strg.List(ctx, s2.ListOptions{Prefix: prefix})
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+	var (
+		objs     []s2.Object
+		prefixes []string
+	)
+	if search != "" {
+		listPrefix := search
+		if prefix != "" {
+			listPrefix = prefix + "/" + search
+		}
+		res, err := strg.List(ctx, s2.ListOptions{Prefix: listPrefix, Recursive: true})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		objs = server.FilterKeep(res.Objects)
+	} else {
+		res, err := strg.List(ctx, s2.ListOptions{Prefix: prefix})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		objs = server.FilterKeep(res.Objects)
+		prefixes = res.CommonPrefixes
 	}
-	objs := server.FilterKeep(res.Objects)
-	prefixes := res.CommonPrefixes
 
 	// Calculate breadcrumbs
 	var breadcrumbs []Breadcrumb
@@ -77,6 +95,7 @@ func handleObjects(s *server.Server, w http.ResponseWriter, r *http.Request) {
 		ParentPrefix  string
 		Breadcrumbs   []Breadcrumb
 		HasParent     bool
+		Search        string
 	}{
 		BucketName:    name,
 		Objects:       objs,
@@ -85,6 +104,7 @@ func handleObjects(s *server.Server, w http.ResponseWriter, r *http.Request) {
 		ParentPrefix:  parentPrefix,
 		Breadcrumbs:   breadcrumbs,
 		HasParent:     prefix != "" && prefix != "/",
+		Search:        search,
 	}
 
 	var buf bytes.Buffer
@@ -200,7 +220,6 @@ func handleDeleteObject(s *server.Server, w http.ResponseWriter, r *http.Request
 	handleObjects(s, w, r)
 }
 
-
 func init() {
 	server.RegisterConsoleHandleFunc("GET /buckets/{name}", middleware.BasicAuth(handleObjects))
 	server.RegisterConsoleHandleFunc("POST /buckets/{name}/folders", middleware.BasicAuth(handleCreateFolder))
@@ -208,4 +227,3 @@ func init() {
 	server.RegisterConsoleHandleFunc("DELETE /buckets/{name}/objects", middleware.BasicAuth(handleDeleteObject))
 	server.RegisterTemplate("buckets/objects.html")
 }
-

--- a/server/handlers/console/buckets/objects_test.go
+++ b/server/handlers/console/buckets/objects_test.go
@@ -48,70 +48,142 @@ func TestObjectsTestSuite(t *testing.T) {
 // --- GET /buckets/{name} ---
 
 func (s *ObjectsTestSuite) TestHandleObjects() {
-	s.Run("empty bucket", func() {
-		s.createBucket("empty")
+	testCases := []struct {
+		caseName        string
+		setup           func()
+		bucketName      string
+		url             string
+		htmx            bool
+		wantCode        int
+		wantContains    []string
+		wantNotContains []string
+		wantHeader      map[string]string
+	}{
+		{
+			caseName:     "empty bucket",
+			setup:        func() { s.createBucket("empty") },
+			bucketName:   "empty",
+			url:          "/buckets/empty",
+			htmx:         true,
+			wantCode:     http.StatusOK,
+			wantContains: []string{"This folder is empty"},
+		},
+		{
+			caseName:     "with objects",
+			setup:        func() { s.createBucket("files"); s.putObject("files", "readme.txt", "hello") },
+			bucketName:   "files",
+			url:          "/buckets/files",
+			htmx:         true,
+			wantCode:     http.StatusOK,
+			wantContains: []string{"readme.txt"},
+		},
+		{
+			caseName: "with prefix",
+			setup: func() {
+				s.createBucket("nested")
+				s.Require().NoError(s.server.Buckets.CreateFolder(context.Background(), "nested", "sub"))
+				s.putObject("nested", "sub/file.txt", "data")
+			},
+			bucketName:   "nested",
+			url:          "/buckets/nested?prefix=sub",
+			htmx:         true,
+			wantCode:     http.StatusOK,
+			wantContains: []string{"file.txt", "Parent Directory"},
+		},
+		{
+			caseName:   "nonexistent bucket",
+			setup:      func() {},
+			bucketName: "nope",
+			url:        "/buckets/nope",
+			htmx:       false,
+			wantCode:   http.StatusNotFound,
+		},
+		{
+			// search="logo" matches keys starting with "logo"
+			caseName: "search at root finds files recursively",
+			setup: func() {
+				s.createBucket("srch")
+				s.putObject("srch", "logo.png", "data")
+				s.putObject("srch", "logo/small.png", "data")
+				s.putObject("srch", "other.png", "data")
+			},
+			bucketName:      "srch",
+			url:             "/buckets/srch?search=logo",
+			htmx:            true,
+			wantCode:        http.StatusOK,
+			wantContains:    []string{"logo.png", "logo/small.png"},
+			wantNotContains: []string{"other.png"},
+		},
+		{
+			// prefix="a", search="s2" → listPrefix="a/s2"; b/s2* excluded
+			caseName: "search with prefix scopes results to prefix",
+			setup: func() {
+				s.createBucket("srchp")
+				s.putObject("srchp", "a/s2-foo.png", "data")
+				s.putObject("srchp", "a/s2/bar.png", "data")
+				s.putObject("srchp", "b/s2-baz.png", "data")
+			},
+			bucketName:      "srchp",
+			url:             "/buckets/srchp?prefix=a&search=s2",
+			htmx:            true,
+			wantCode:        http.StatusOK,
+			wantContains:    []string{"s2-foo.png", "s2/bar.png"},
+			wantNotContains: []string{"s2-baz.png"},
+		},
+		{
+			caseName:     "search with no matches shows empty state",
+			setup:        func() { s.createBucket("srchem"); s.putObject("srchem", "readme.txt", "data") },
+			bucketName:   "srchem",
+			url:          "/buckets/srchem?search=nomatch",
+			htmx:         true,
+			wantCode:     http.StatusOK,
+			wantContains: []string{"This folder is empty"},
+		},
+		{
+			caseName:     "search renders chip with search term",
+			setup:        func() { s.createBucket("srchc"); s.putObject("srchc", "doc.txt", "data") },
+			bucketName:   "srchc",
+			url:          "/buckets/srchc?search=doc",
+			htmx:         true,
+			wantCode:     http.StatusOK,
+			wantContains: []string{"search-chip"},
+		},
+		{
+			caseName:    "full page without HX-Request redirects to index",
+			setup:       func() { s.createBucket("full") },
+			bucketName:  "full",
+			url:         "/buckets/full",
+			htmx:        false,
+			wantCode:    http.StatusFound,
+			wantHeader:  map[string]string{"Location": "/"},
+		},
+	}
 
-		req := httptest.NewRequest("GET", "/buckets/empty", nil)
-		req.SetPathValue("name", "empty")
-		req.Header.Set("HX-Request", "true")
-		w := httptest.NewRecorder()
-		handleObjects(s.server, w, req)
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			tc.setup()
 
-		s.Equal(http.StatusOK, w.Code)
-		s.Contains(w.Body.String(), "This folder is empty")
-	})
+			req := httptest.NewRequest("GET", tc.url, nil)
+			req.SetPathValue("name", tc.bucketName)
+			if tc.htmx {
+				req.Header.Set("HX-Request", "true")
+			}
+			w := httptest.NewRecorder()
+			handleObjects(s.server, w, req)
 
-	s.Run("with objects", func() {
-		s.createBucket("files")
-		s.putObject("files", "readme.txt", "hello")
-
-		req := httptest.NewRequest("GET", "/buckets/files", nil)
-		req.SetPathValue("name", "files")
-		req.Header.Set("HX-Request", "true")
-		w := httptest.NewRecorder()
-		handleObjects(s.server, w, req)
-
-		s.Equal(http.StatusOK, w.Code)
-		s.Contains(w.Body.String(), "readme.txt")
-	})
-
-	s.Run("with prefix", func() {
-		s.createBucket("nested")
-		s.server.Buckets.CreateFolder(context.Background(), "nested", "sub")
-		s.putObject("nested", "sub/file.txt", "data")
-
-		req := httptest.NewRequest("GET", "/buckets/nested?prefix=sub", nil)
-		req.SetPathValue("name", "nested")
-		req.Header.Set("HX-Request", "true")
-		w := httptest.NewRecorder()
-		handleObjects(s.server, w, req)
-
-		s.Equal(http.StatusOK, w.Code)
-		body := w.Body.String()
-		s.Contains(body, "file.txt")
-		s.Contains(body, "Parent Directory")
-	})
-
-	s.Run("nonexistent bucket", func() {
-		req := httptest.NewRequest("GET", "/buckets/nope", nil)
-		req.SetPathValue("name", "nope")
-		w := httptest.NewRecorder()
-		handleObjects(s.server, w, req)
-
-		s.Equal(http.StatusNotFound, w.Code)
-	})
-
-	s.Run("full page without HX-Request redirects to index", func() {
-		s.createBucket("full")
-
-		req := httptest.NewRequest("GET", "/buckets/full", nil)
-		req.SetPathValue("name", "full")
-		w := httptest.NewRecorder()
-		handleObjects(s.server, w, req)
-
-		s.Equal(http.StatusFound, w.Code)
-		s.Equal("/", w.Header().Get("Location"))
-	})
+			s.Equal(tc.wantCode, w.Code)
+			body := w.Body.String()
+			for _, want := range tc.wantContains {
+				s.Contains(body, want)
+			}
+			for _, notWant := range tc.wantNotContains {
+				s.NotContains(body, notWant)
+			}
+			for k, v := range tc.wantHeader {
+				s.Equal(v, w.Header().Get(k))
+			}
+		})
+	}
 }
 
 // --- POST /buckets/{name}/folders ---

--- a/server/static/style.css
+++ b/server/static/style.css
@@ -635,12 +635,26 @@ tr:hover td {
   padding: 3rem;
 }
 
+/* Table controls row (search left, view-toggle right) */
+.table-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+  gap: 1rem;
+}
+
+.table-controls-left {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 /* View Toggle */
 .view-toggle {
   display: flex;
   gap: 0.25rem;
-  margin-bottom: 1rem;
-  justify-content: flex-end;
+  flex-shrink: 0;
 }
 
 .view-toggle-btn {
@@ -812,3 +826,55 @@ tr:hover td {
   border-bottom: none;
 }
 
+
+.search-form {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.search-input {
+  -webkit-appearance: none;
+  appearance: none;
+  box-sizing: border-box;
+  height: 34px;
+  line-height: 34px;
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background-color: var(--surface);
+  color: var(--text);
+  font-size: 0.875rem;
+  width: 200px;
+  transition: border-color 0.2s;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: var(--primary);
+}
+
+.search-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 34px;
+  padding: 0 10px;
+  border: 1px solid var(--primary);
+  border-radius: 8px;
+  background-color: rgba(59, 130, 246, 0.1);
+  color: var(--primary);
+  text-decoration: none;
+  font-size: 0.875rem;
+  white-space: nowrap;
+  transition: background-color 0.2s;
+}
+
+.search-chip:hover {
+  background-color: rgba(59, 130, 246, 0.2);
+}
+
+.search-chip span {
+  font-size: 0.75rem;
+  opacity: 0.7;
+}

--- a/server/templates.go
+++ b/server/templates.go
@@ -142,6 +142,12 @@ func templateFuncs(cfg *Config) template.FuncMap {
 			return t.Format("2006-01-02 15:04")
 		},
 		"baseName": path.Base,
+		"trimPrefix": func(prefix, key string) string {
+			if prefix == "" {
+				return key
+			}
+			return strings.TrimPrefix(key, prefix+"/")
+		},
 		"isImage": func(name string) bool {
 			return imageExts[strings.ToLower(path.Ext(name))]
 		},

--- a/server/templates/buckets/objects.html
+++ b/server/templates/buckets/objects.html
@@ -84,18 +84,32 @@
       <input type="hidden" name="prefix" value="{{.CurrentPrefix}}">
       <input type="file" name="file" onchange="this.form.requestSubmit()">
     </form>
+
   </div>
 </div>
 
 
 <div class="main-view">
-  <div class="view-toggle">
-    <button class="view-toggle-btn active" onclick="setViewMode('list', this)" title="List View">
-      <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><use href="#icon-view-list"></use></svg>
-    </button>
+  <div class="table-controls">
+    <div class="table-controls-left">
+      <form hx-get="/buckets/{{.BucketName}}" hx-target="#main-content" hx-push-url="true" class="search-form">
+        <input type="hidden" name="prefix" value="{{.CurrentPrefix}}">
+        <input type="search" name="search" value="{{.Search}}" placeholder="Search by prefix..." class="search-input">
+      </form>
+      {{if .Search}}
+      <a href="/buckets/{{.BucketName}}?prefix={{.CurrentPrefix}}" hx-get="/buckets/{{.BucketName}}?prefix={{.CurrentPrefix}}" hx-target="#main-content" hx-push-url="true" class="search-chip" title="Clear search">
+        {{.Search}} <span>✕</span>
+      </a>
+      {{end}}
+    </div>
+    <div class="view-toggle">
+      <button class="view-toggle-btn active" onclick="setViewMode('list', this)" title="List View">
+        <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><use href="#icon-view-list"></use></svg>
+      </button>
     <button class="view-toggle-btn" onclick="setViewMode('gallery', this)" title="Gallery View">
       <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><use href="#icon-view-gallery"></use></svg>
     </button>
+    </div>
   </div>
 
   <div id="list-view" class="object-table-container">
@@ -155,7 +169,7 @@
               <span class="obj-icon">
                 <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><use href="#icon-file"></use></svg>
               </span>
-              {{baseName .Name}}
+              {{if $.Search}}{{trimPrefix $.CurrentPrefix .Name}}{{else}}{{baseName .Name}}{{end}}
             </div>
           </td>
           <td>{{formatSize .Length}}</td>
@@ -232,7 +246,7 @@
             <svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><use href="#icon-image"></use></svg>
           </div>
         </div>
-        <span class="gallery-label">{{baseName .Name}}</span>
+        <span class="gallery-label">{{if $.Search}}{{trimPrefix $.CurrentPrefix .Name}}{{else}}{{baseName .Name}}{{end}}</span>
         <span class="gallery-size">{{formatSize .Length}}</span>
       </div>
       <div class="gallery-card-actions">
@@ -252,7 +266,7 @@
         <div class="gallery-file-icon">
           <svg width="32" height="32" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><use href="#icon-file"></use></svg>
         </div>
-        <span class="gallery-label">{{baseName .Name}}</span>
+        <span class="gallery-label">{{if $.Search}}{{trimPrefix $.CurrentPrefix .Name}}{{else}}{{baseName .Name}}{{end}}</span>
         <span class="gallery-size">{{formatSize .Length}}</span>
       </div>
       <div class="gallery-card-actions">


### PR DESCRIPTION
## Summary

- Add a search box above the object table that filters by key prefix (Enter to search, chip to clear)
- Search is recursive (`Recursive: true`): traverses all subdirectories under the current prefix
- Display names in search results show paths relative to the current prefix (e.g. `s2/bar.png` instead of `a/s2/bar.png` when inside `a/`)
- Add `trimPrefix` template function for relative path display
- Table-driven tests covering search at root, search with prefix, no-match empty state, and chip rendering