### PR TITLE
fix(console): Restore fragment state on browser reload

### DIFF
--- a/server/handlers/console/buckets/objects.go
+++ b/server/handlers/console/buckets/objects.go
@@ -80,13 +80,6 @@ func handleObjects(s *server.Server, w http.ResponseWriter, r *http.Request) {
 		parentPrefix = ""
 	}
 
-	// Non-HTMX requests get redirected to the index page where the
-	// sidebar navigation triggers the htmx load.
-	if r.Header.Get("HX-Request") != "true" {
-		http.Redirect(w, r, "/", http.StatusFound)
-		return
-	}
-
 	data := struct {
 		BucketName    string
 		Objects       []s2.Object
@@ -221,7 +214,7 @@ func handleDeleteObject(s *server.Server, w http.ResponseWriter, r *http.Request
 }
 
 func init() {
-	server.RegisterConsoleHandleFunc("GET /buckets/{name}", middleware.BasicAuth(handleObjects))
+	server.RegisterConsoleHandleFunc("GET /buckets/{name}", middleware.BasicAuth(middleware.ServeIndex(handleObjects)))
 	server.RegisterConsoleHandleFunc("POST /buckets/{name}/folders", middleware.BasicAuth(handleCreateFolder))
 	server.RegisterConsoleHandleFunc("POST /buckets/{name}/upload", middleware.BasicAuth(handleUploadFile))
 	server.RegisterConsoleHandleFunc("DELETE /buckets/{name}/objects", middleware.BasicAuth(handleDeleteObject))

--- a/server/handlers/console/buckets/objects_test.go
+++ b/server/handlers/console/buckets/objects_test.go
@@ -148,15 +148,6 @@ func (s *ObjectsTestSuite) TestHandleObjects() {
 			wantCode:     http.StatusOK,
 			wantContains: []string{"search-chip"},
 		},
-		{
-			caseName:    "full page without HX-Request redirects to index",
-			setup:       func() { s.createBucket("full") },
-			bucketName:  "full",
-			url:         "/buckets/full",
-			htmx:        false,
-			wantCode:    http.StatusFound,
-			wantHeader:  map[string]string{"Location": "/"},
-		},
 	}
 
 	for _, tc := range testCases {

--- a/server/handlers/console/index.go
+++ b/server/handlers/console/index.go
@@ -8,26 +8,10 @@ import (
 	"github.com/mojatter/s2/server/middleware"
 )
 
-func handleIndex(s *server.Server, w http.ResponseWriter, r *http.Request) {
-	names, err := s.Buckets.Names()
-
-	if err != nil {
+func handleIndex(s *server.Server, w http.ResponseWriter, _ *http.Request) {
+	if err := s.RenderIndex(w); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
 	}
-
-	data := struct {
-		Buckets []string
-	}{
-		Buckets: names,
-	}
-
-	var buf bytes.Buffer
-	if err := s.Template.ExecuteTemplate(&buf, "index.html", data); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	_, _ = buf.WriteTo(w)
 }
 
 func handleCreateBucket(s *server.Server, w http.ResponseWriter, r *http.Request) {
@@ -107,6 +91,5 @@ func init() {
 	server.RegisterConsoleHandleFunc("GET /{$}", middleware.BasicAuth(handleIndex))
 	server.RegisterConsoleHandleFunc("POST /buckets", middleware.BasicAuth(handleCreateBucket))
 	server.RegisterConsoleHandleFunc("DELETE /buckets/{name}", middleware.BasicAuth(handleDeleteBucket))
-	server.RegisterTemplate("index.html")
 }
 

--- a/server/middleware/serveindex.go
+++ b/server/middleware/serveindex.go
@@ -1,0 +1,21 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/mojatter/s2/server"
+)
+
+// ServeIndex intercepts non-HTMX requests and returns the full index page,
+// allowing client-side JS to restore fragment state from the URL (e.g. on reload).
+func ServeIndex(next server.HandlerFunc) server.HandlerFunc {
+	return func(srv *server.Server, w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("HX-Request") == "true" {
+			next(srv, w, r)
+			return
+		}
+		if err := srv.RenderIndex(w); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}
+}

--- a/server/middleware/serveindex_test.go
+++ b/server/middleware/serveindex_test.go
@@ -1,0 +1,68 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mojatter/s2/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestServer(t *testing.T) *server.Server {
+	t.Helper()
+	cfg := server.DefaultConfig()
+	cfg.Root = t.TempDir()
+	srv, err := server.NewServer(context.Background(), cfg)
+	require.NoError(t, err)
+	return srv
+}
+
+func TestServeIndex(t *testing.T) {
+	testCases := []struct {
+		caseName     string
+		htmx         bool
+		wantCode     int
+		wantContains string
+		handlerCalled bool
+	}{
+		{
+			caseName:      "HTMX request passes through to next handler",
+			htmx:          true,
+			wantCode:      http.StatusOK,
+			handlerCalled: true,
+		},
+		{
+			caseName:     "non-HTMX request returns index page",
+			htmx:         false,
+			wantCode:     http.StatusOK,
+			wantContains: `id="main-content"`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			srv := newTestServer(t)
+			called := false
+			next := func(_ *server.Server, w http.ResponseWriter, _ *http.Request) {
+				called = true
+				w.WriteHeader(http.StatusOK)
+			}
+
+			req := httptest.NewRequest("GET", "/buckets/test", nil)
+			if tc.htmx {
+				req.Header.Set("HX-Request", "true")
+			}
+			w := httptest.NewRecorder()
+			ServeIndex(next)(srv, w, req)
+
+			assert.Equal(t, tc.wantCode, w.Code)
+			assert.Equal(t, tc.handlerCalled, called)
+			if tc.wantContains != "" {
+				assert.Contains(t, w.Body.String(), tc.wantContains)
+			}
+		})
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"flag"
 	"fmt"
@@ -261,9 +262,27 @@ func handleHealthz(_ *Server, w http.ResponseWriter, _ *http.Request) {
 	_, _ = w.Write([]byte("ok"))
 }
 
+func init() {
+	RegisterTemplate("index.html")
+}
+
 // Start starts the S3 API listener and, when cfg.ConsoleListen is set and
 // there are console routes registered, the Web Console listener. Both
 // are shut down gracefully when ctx is cancelled or either listener dies.
+// RenderIndex renders the full index.html page with the current bucket list into w.
+func (s *Server) RenderIndex(w http.ResponseWriter) error {
+	names, err := s.Buckets.Names()
+	if err != nil {
+		return err
+	}
+	var buf bytes.Buffer
+	if err := s.Template.ExecuteTemplate(&buf, "index.html", struct{ Buckets []string }{names}); err != nil {
+		return err
+	}
+	_, _ = buf.WriteTo(w)
+	return nil
+}
+
 func (s *Server) Start(ctx context.Context) error {
 	s3srv := &http.Server{
 		Addr:              s.Config.Listen,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -386,6 +386,45 @@ func TestStart(t *testing.T) {
 	})
 }
 
+func TestRenderIndex(t *testing.T) {
+	testCases := []struct {
+		caseName     string
+		buckets      []string
+		wantContains []string
+	}{
+		{
+			caseName:     "no buckets renders index page",
+			wantContains: []string{`id="main-content"`},
+		},
+		{
+			caseName:     "bucket names appear in rendered page",
+			buckets:      []string{"alpha", "bravo"},
+			wantContains: []string{`id="main-content"`, "alpha", "bravo"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Root = t.TempDir()
+			srv, err := NewServer(context.Background(), cfg)
+			require.NoError(t, err)
+
+			for _, name := range tc.buckets {
+				require.NoError(t, srv.Buckets.Create(context.Background(), name))
+			}
+
+			w := httptest.NewRecorder()
+			require.NoError(t, srv.RenderIndex(w))
+
+			body := w.Body.String()
+			for _, want := range tc.wantContains {
+				assert.Contains(t, body, want)
+			}
+		})
+	}
+}
+
 func TestInitBuckets(t *testing.T) {
 	t.Run("creates buckets on startup", func(t *testing.T) {
 		cfg := DefaultConfig()

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -63,6 +63,14 @@
   </dialog>
 
   {{template "scripts:buckets/objects.html" .}}
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      var path = window.location.pathname + window.location.search;
+      if (path !== '/') {
+        htmx.ajax('GET', path, { target: '#main-content', swap: 'innerHTML' });
+      }
+    });
+  </script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary

- Non-HTMX requests to fragment endpoints (e.g. `/buckets/test`) now return `index.html` instead of redirecting to `/`, so the URL is preserved in the browser
- `DOMContentLoaded` script in `index.html` detects a non-root URL and fires `htmx.ajax` to restore the fragment
- Extract `(*Server).RenderIndex` as the single place that renders `index.html` with the bucket list; used by both `handleIndex` and `middleware.ServeIndex`
- `middleware.ServeIndex` wraps fragment handlers — any future fragment endpoint gets the same behavior by adding `middleware.ServeIndex(handler)` in `init()`
- Move `RegisterTemplate("index.html")` to `server.go` `init()`, co-located with `RenderIndex`