### PR TITLE
feat(s3api): Add CORS middleware to S3 handler

### DIFF
--- a/server/cors.go
+++ b/server/cors.go
@@ -1,0 +1,22 @@
+package server
+
+import "net/http"
+
+// corsHandler wraps next and adds permissive CORS headers to every response.
+// OPTIONS preflight requests are answered immediately with 200 OK.
+func corsHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := w.Header()
+		h.Set("Access-Control-Allow-Origin", "*")
+		h.Set("Access-Control-Allow-Methods", "GET, PUT, POST, DELETE, HEAD, OPTIONS")
+		h.Set("Access-Control-Allow-Headers", "*")
+		h.Set("Access-Control-Max-Age", "86400")
+
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/server/cors_test.go
+++ b/server/cors_test.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCORSHandler(t *testing.T) {
+	testCases := []struct {
+		caseName        string
+		method          string
+		wantCode        int
+		wantHandlerHit  bool
+	}{
+		{
+			caseName:       "GET passes through with CORS headers",
+			method:         http.MethodGet,
+			wantCode:       http.StatusOK,
+			wantHandlerHit: true,
+		},
+		{
+			caseName:       "PUT passes through with CORS headers",
+			method:         http.MethodPut,
+			wantCode:       http.StatusOK,
+			wantHandlerHit: true,
+		},
+		{
+			caseName:       "OPTIONS preflight returns 200 without hitting handler",
+			method:         http.MethodOptions,
+			wantCode:       http.StatusOK,
+			wantHandlerHit: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			handlerHit := false
+			next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				handlerHit = true
+				w.WriteHeader(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(tc.method, "/bucket/key", nil)
+			w := httptest.NewRecorder()
+			corsHandler(next).ServeHTTP(w, req)
+
+			assert.Equal(t, tc.wantCode, w.Code)
+			assert.Equal(t, tc.wantHandlerHit, handlerHit)
+			assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+			assert.NotEmpty(t, w.Header().Get("Access-Control-Allow-Methods"))
+			assert.NotEmpty(t, w.Header().Get("Access-Control-Allow-Headers"))
+		})
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -200,7 +200,7 @@ func NewServer(ctx context.Context, cfg *Config) (*Server, error) {
 // It includes routes registered via RegisterS3HandleFunc and, when
 // cfg.HealthPath is non-empty, a health endpoint at that path.
 func (s *Server) S3Handler() http.Handler {
-	return s.buildMux(s3Handlers)
+	return corsHandler(s.buildMux(s3Handlers))
 }
 
 // ConsoleHandler builds an HTTP handler that serves the Web Console.


### PR DESCRIPTION
## Summary

- Wrap the S3 API handler with permissive CORS headers (`Access-Control-Allow-Origin: *`) to support browser clients using presigned URLs
- `OPTIONS` preflight requests are answered with `200 OK` without reaching any S3 handler
- Applied once in `S3Handler()` via `corsHandler` in `server/cors.go`; no changes needed to individual S3 handlers