### PR TITLE
test(server): Fix data race on nilCalled/realCalled flags

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,7 +27,7 @@ jobs:
         name: Run go test
         run: |
           go mod tidy
-          go test -v ./...
+          go test -race -v ./...
       -
         name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -38,7 +38,7 @@ jobs:
         run: |
           for dir in s3 gcs azblob s2env cmd/s2-server; do
             echo "=== Testing $dir ==="
-            (cd $dir && go mod tidy && go test -v ./...)
+            (cd $dir && go mod tidy && go test -race -v ./...)
           done
       -
         name: Lint submodules

--- a/server/s3api_test.go
+++ b/server/s3api_test.go
@@ -277,9 +277,6 @@ func TestStartSkipsNilFactories(t *testing.T) {
 		return true
 	}, 3*time.Second, 10*time.Millisecond)
 
-	assert.True(t, nilCalled, "nil-returning factory should still be invoked")
-	assert.True(t, realCalled, "non-nil factory should be invoked")
-
 	cancel()
 	select {
 	case err := <-errCh:
@@ -287,4 +284,9 @@ func TestStartSkipsNilFactories(t *testing.T) {
 	case <-time.After(15 * time.Second):
 		t.Fatal("Start did not return after context cancel")
 	}
+
+	// Asserted after <-errCh: the channel receive establishes happens-before
+	// with the factory writes inside Start, so these reads are race-free.
+	assert.True(t, nilCalled, "nil-returning factory should still be invoked")
+	assert.True(t, realCalled, "non-nil factory should be invoked")
 }


### PR DESCRIPTION
## Summary
- `TestStartSkipsNilFactories` wrote `nilCalled` / `realCalled` from factory closures running on the `Server.Start` goroutine, and read them from the test goroutine after `require.Eventually` — `net.Dial` is not a Go memory-model synchronization point, so `-race` flagged it.
- Move both assertions after `<-errCh`, which is a real channel synchronization point with `Start`'s return. No additional imports needed.

## Test plan
- [x] `go clean -testcache && go test -race ./server/...` passes
- [x] `go test -race -run TestStartSkipsNilFactories ./server/` passes
- [x] `golangci-lint run ./server/...` clean