### PR TITLE
test(console): Cover handleUploadFile and handlePreview

### DIFF
--- a/server/handlers/console/buckets/objects/view_test.go
+++ b/server/handlers/console/buckets/objects/view_test.go
@@ -231,3 +231,99 @@ func (s *ViewTestSuite) TestHandleMeta() {
 		s.Equal(http.StatusNotFound, w.Code)
 	})
 }
+
+// --- GET /buckets/{name}/preview/{object...} ---
+
+func (s *ViewTestSuite) TestHandlePreview() {
+	testCases := []struct {
+		caseName        string
+		setup           func()
+		bucketName      string
+		objectName      string
+		wantCode        int
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{
+			caseName: "text file embeds content",
+			setup: func() {
+				s.createBucket("prv")
+				s.putObject("prv", "hello.txt", []byte("hello world"))
+			},
+			bucketName:   "prv",
+			objectName:   "hello.txt",
+			wantCode:     http.StatusOK,
+			wantContains: []string{"hello world", "hello.txt"},
+		},
+		{
+			caseName: "image renders via view URL, not inline bytes",
+			setup: func() {
+				s.createBucket("prvi")
+				s.putObject("prvi", "pic.png", []byte("fake-png-bytes"))
+			},
+			bucketName:      "prvi",
+			objectName:      "pic.png",
+			wantCode:        http.StatusOK,
+			wantContains:    []string{"pic.png", "<img"},
+			wantNotContains: []string{"fake-png-bytes"},
+		},
+		{
+			caseName: "pdf renders an iframe",
+			setup: func() {
+				s.createBucket("prvp")
+				s.putObject("prvp", "doc.pdf", []byte("%PDF-fake"))
+			},
+			bucketName:   "prvp",
+			objectName:   "doc.pdf",
+			wantCode:     http.StatusOK,
+			wantContains: []string{"doc.pdf", "<iframe"},
+		},
+		{
+			caseName: "custom metadata appears in the table",
+			setup: func() {
+				s.createBucket("prvm")
+				md := s2.Metadata{"author": "tester"}
+				s.putObject("prvm", "meta.txt", []byte("x"), s2.WithMetadata(md))
+			},
+			bucketName:   "prvm",
+			objectName:   "meta.txt",
+			wantCode:     http.StatusOK,
+			wantContains: []string{"author", "tester"},
+		},
+		{
+			caseName:   "nonexistent bucket",
+			setup:      func() {},
+			bucketName: "nope",
+			objectName: "x.txt",
+			wantCode:   http.StatusNotFound,
+		},
+		{
+			caseName:   "nonexistent object",
+			setup:      func() { s.createBucket("prvx") },
+			bucketName: "prvx",
+			objectName: "missing.txt",
+			wantCode:   http.StatusNotFound,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			tc.setup()
+
+			req := httptest.NewRequest("GET", "/buckets/"+tc.bucketName+"/preview/"+tc.objectName, nil)
+			req.SetPathValue("name", tc.bucketName)
+			req.SetPathValue("object", tc.objectName)
+			w := httptest.NewRecorder()
+			handlePreview(s.server, w, req)
+
+			s.Equal(tc.wantCode, w.Code)
+			body := w.Body.String()
+			for _, want := range tc.wantContains {
+				s.Contains(body, want)
+			}
+			for _, notWant := range tc.wantNotContains {
+				s.NotContains(body, notWant)
+			}
+		})
+	}
+}

--- a/server/handlers/console/buckets/objects_test.go
+++ b/server/handlers/console/buckets/objects_test.go
@@ -1,7 +1,9 @@
 package buckets
 
 import (
+	"bytes"
 	"context"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -207,6 +209,97 @@ func (s *ObjectsTestSuite) TestHandleCreateFolder() {
 
 		s.Equal(http.StatusBadRequest, w.Code)
 	})
+}
+
+// --- POST /buckets/{name}/upload ---
+
+func (s *ObjectsTestSuite) TestHandleUploadFile() {
+	testCases := []struct {
+		caseName   string
+		setup      func()
+		bucketName string
+		prefix     string
+		filename   string
+		content    []byte
+		omitFile   bool
+		wantCode   int
+		wantKey    string // if non-empty, verify this key landed in the bucket
+	}{
+		{
+			caseName:   "success at root",
+			setup:      func() { s.createBucket("up") },
+			bucketName: "up",
+			prefix:     "",
+			filename:   "hello.txt",
+			content:    []byte("hello"),
+			wantCode:   http.StatusOK,
+			wantKey:    "hello.txt",
+		},
+		{
+			caseName: "success with prefix",
+			setup: func() {
+				s.createBucket("upp")
+				s.Require().NoError(s.server.Buckets.CreateFolder(context.Background(), "upp", "docs"))
+			},
+			bucketName: "upp",
+			prefix:     "docs",
+			filename:   "report.txt",
+			content:    []byte("content"),
+			wantCode:   http.StatusOK,
+			wantKey:    "docs/report.txt",
+		},
+		{
+			caseName:   "nonexistent bucket",
+			setup:      func() {},
+			bucketName: "nope",
+			prefix:     "",
+			filename:   "x.txt",
+			content:    []byte("x"),
+			wantCode:   http.StatusNotFound,
+		},
+		{
+			caseName:   "missing file field",
+			setup:      func() { s.createBucket("upn") },
+			bucketName: "upn",
+			prefix:     "",
+			omitFile:   true,
+			wantCode:   http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			tc.setup()
+
+			body := &bytes.Buffer{}
+			mw := multipart.NewWriter(body)
+			s.Require().NoError(mw.WriteField("prefix", tc.prefix))
+			if !tc.omitFile {
+				fw, err := mw.CreateFormFile("file", tc.filename)
+				s.Require().NoError(err)
+				_, err = fw.Write(tc.content)
+				s.Require().NoError(err)
+			}
+
+			s.Require().NoError(mw.Close())
+
+			req := httptest.NewRequest("POST", "/buckets/"+tc.bucketName+"/upload", body)
+			req.Header.Set("Content-Type", mw.FormDataContentType())
+			req.Header.Set("HX-Request", "true")
+			req.SetPathValue("name", tc.bucketName)
+			w := httptest.NewRecorder()
+			handleUploadFile(s.server, w, req)
+
+			s.Equal(tc.wantCode, w.Code)
+			if tc.wantKey != "" {
+				strg, err := s.server.Buckets.Get(context.Background(), tc.bucketName)
+				s.Require().NoError(err)
+				exists, err := strg.Exists(context.Background(), tc.wantKey)
+				s.Require().NoError(err)
+				s.True(exists, "object %q should exist after upload", tc.wantKey)
+			}
+		})
+	}
 }
 
 // --- DELETE /buckets/{name}/objects ---


### PR DESCRIPTION
## Summary
- Both handlers had 0% coverage per `go tool cover`.
- `TestHandleUploadFile` — table-driven, 4 cases: success at root / success with prefix / nonexistent bucket / missing file field. Verifies the object actually lands at the expected key.
- `TestHandlePreview` — table-driven, 6 cases: text content embedded / image renders via view URL (not inline bytes) / pdf renders iframe / custom metadata appears / nonexistent bucket / nonexistent object.

## Test plan
- [x] `go test -race ./server/handlers/console/buckets/...` passes
- [x] `golangci-lint run ./server/...` clean