### PR TITLE
refactor(console): Extract action-button templates

### DIFF
--- a/server/templates.go
+++ b/server/templates.go
@@ -147,5 +147,19 @@ func templateFuncs(cfg *Config) template.FuncMap {
 			}
 			return true
 		},
+		"dict": func(values ...any) (map[string]any, error) {
+			if len(values)%2 != 0 {
+				return nil, fmt.Errorf("dict: odd number of args")
+			}
+			m := make(map[string]any, len(values)/2)
+			for i := 0; i < len(values); i += 2 {
+				key, ok := values[i].(string)
+				if !ok {
+					return nil, fmt.Errorf("dict: non-string key at position %d", i)
+				}
+				m[key] = values[i+1]
+			}
+			return m, nil
+		},
 	}
 }

--- a/server/templates/console/actions.html
+++ b/server/templates/console/actions.html
@@ -1,0 +1,17 @@
+{{define "action-delete-folder"}}
+<button class="btn btn--icon btn--danger" hx-delete="/buckets/{{.Bucket}}/objects?key={{.Key}}/&prefix={{.Prefix}}" hx-confirm="Are you sure you want to delete folder '{{baseName .Key}}' and all its contents?" hx-target="#main-content" title="Delete Folder">
+  <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><use href="#icon-trash"></use></svg>
+</button>
+{{end}}
+
+{{define "action-delete-file"}}
+<button class="btn btn--icon btn--danger" hx-delete="/buckets/{{.Bucket}}/objects?key={{.Key}}&prefix={{.Prefix}}" hx-confirm="Are you sure you want to delete file '{{baseName .Key}}'?" hx-target="#main-content" title="Delete File">
+  <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><use href="#icon-trash"></use></svg>
+</button>
+{{end}}
+
+{{define "action-download"}}
+<a class="btn btn--icon btn--ghost" href="/buckets/{{.Bucket}}/view/{{.Key}}" download="{{baseName .Key}}" title="Download File">
+  <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><use href="#icon-download"></use></svg>
+</a>
+{{end}}

--- a/server/templates/console/buckets/objects.html
+++ b/server/templates/console/buckets/objects.html
@@ -153,9 +153,7 @@
           <td>-</td>
           <td>
             <div class="actions-cell">
-              <button class="btn btn--icon btn--danger" hx-delete="/buckets/{{$.BucketName}}/objects?key={{.}}/&prefix={{$.CurrentPrefix}}" hx-confirm="Are you sure you want to delete folder '{{baseName .}}' and all its contents?" hx-target="#main-content" title="Delete Folder">
-                <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><use href="#icon-trash"></use></svg>
-              </button>
+              {{template "action-delete-folder" (dict "Bucket" $.BucketName "Key" . "Prefix" $.CurrentPrefix)}}
             </div>
           </td>
         </tr>
@@ -183,12 +181,8 @@
                 <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><use href="#icon-eye"></use></svg>
               </button>
               {{end}}
-              <a class="btn btn--icon btn--ghost" href="/buckets/{{$.BucketName}}/view/{{.Name}}" download="{{baseName .Name}}" title="Download File">
-                <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><use href="#icon-download"></use></svg>
-              </a>
-              <button class="btn btn--icon btn--danger" hx-delete="/buckets/{{$.BucketName}}/objects?key={{.Name}}&prefix={{$.CurrentPrefix}}" hx-confirm="Are you sure you want to delete file '{{baseName .Name}}'?" hx-target="#main-content" title="Delete File">
-                <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><use href="#icon-trash"></use></svg>
-              </button>
+              {{template "action-download" (dict "Bucket" $.BucketName "Key" .Name)}}
+              {{template "action-delete-file" (dict "Bucket" $.BucketName "Key" .Name "Prefix" $.CurrentPrefix)}}
             </div>
           </td>
         </tr>
@@ -228,9 +222,7 @@
         <span class="gallery-label">{{baseName .}}/</span>
       </a>
       <div class="gallery-card-actions">
-        <button class="btn btn--icon btn--danger" hx-delete="/buckets/{{$.BucketName}}/objects?key={{.}}/&prefix={{$.CurrentPrefix}}" hx-confirm="Are you sure you want to delete folder '{{baseName .}}' and all its contents?" hx-target="#main-content" title="Delete Folder">
-          <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><use href="#icon-trash"></use></svg>
-        </button>
+        {{template "action-delete-folder" (dict "Bucket" $.BucketName "Key" . "Prefix" $.CurrentPrefix)}}
       </div>
     </div>
     {{end}}
@@ -250,12 +242,8 @@
         <span class="gallery-size">{{formatSize .Length}}</span>
       </div>
       <div class="gallery-card-actions">
-        <a class="btn btn--icon btn--ghost" href="/buckets/{{$.BucketName}}/view/{{.Name}}" download="{{baseName .Name}}" title="Download File">
-          <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><use href="#icon-download"></use></svg>
-        </a>
-        <button class="btn btn--icon btn--danger" hx-delete="/buckets/{{$.BucketName}}/objects?key={{.Name}}&prefix={{$.CurrentPrefix}}" hx-confirm="Are you sure you want to delete file '{{baseName .Name}}'?" hx-target="#main-content" title="Delete File">
-          <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><use href="#icon-trash"></use></svg>
-        </button>
+        {{template "action-download" (dict "Bucket" $.BucketName "Key" .Name)}}
+        {{template "action-delete-file" (dict "Bucket" $.BucketName "Key" .Name "Prefix" $.CurrentPrefix)}}
       </div>
     </div>
     {{else}}
@@ -270,12 +258,8 @@
         <span class="gallery-size">{{formatSize .Length}}</span>
       </div>
       <div class="gallery-card-actions">
-        <a class="btn btn--icon btn--ghost" href="/buckets/{{$.BucketName}}/view/{{.Name}}" download="{{baseName .Name}}" title="Download File">
-          <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><use href="#icon-download"></use></svg>
-        </a>
-        <button class="btn btn--icon btn--danger" hx-delete="/buckets/{{$.BucketName}}/objects?key={{.Name}}&prefix={{$.CurrentPrefix}}" hx-confirm="Are you sure you want to delete file '{{baseName .Name}}'?" hx-target="#main-content" title="Delete File">
-          <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><use href="#icon-trash"></use></svg>
-        </button>
+        {{template "action-download" (dict "Bucket" $.BucketName "Key" .Name)}}
+        {{template "action-delete-file" (dict "Bucket" $.BucketName "Key" .Name "Prefix" $.CurrentPrefix)}}
       </div>
     </div>
     {{end}}


### PR DESCRIPTION
## Summary
- Delete / download icon buttons were repeated 8 times across list view and gallery view (folder row, file row, gallery folder card, gallery image card, gallery file card).
- Extract them into `console/actions.html` as `action-delete-folder`, `action-delete-file`, and `action-download`, invoked via `{{template "..." (dict ...)}}`.
- Add a `dict` template helper (follows the sprig/Helm convention used across the Go template ecosystem) so call sites can pass key-value pairs inline.

## Test plan
- [x] `go test -race ./server/...` passes (templates parse + fragment renders identically to baseline)
- [x] `golangci-lint run ./server/...` clean
- [x] Manual: list view and gallery view delete/download buttons work — confirm dialog fires, delete succeeds, download serves file with correct filename