### PR TITLE
fix(console): Avoid flex-start trap on .table-controls at mobile

### DIFF
--- a/server/static/style.css
+++ b/server/static/style.css
@@ -1218,7 +1218,12 @@ tr:hover td {
 
   .table-controls {
     flex-direction: column;
-    align-items: flex-start;
+    align-items: stretch;
+  }
+
+  .table-controls-left {
+    flex-direction: column;
+    align-items: stretch;
   }
 
   .search-input {


### PR DESCRIPTION
## Summary
- At `≤600px`, `.table-controls` switched to `flex-direction: column` but kept `align-items: flex-start`, which shrink-wraps children in the now-horizontal cross axis. `.search-input { width: 100% }` happened to rescue the search field, but any new child with long content would have broken the layout.
- Switch `.table-controls` to `align-items: stretch` and apply the same change (plus `flex-direction: column`) to `.table-controls-left` so its children fill the viewport predictably.

## Visible change
- Only at `≤600px`. The search chip (active-search indicator) now stacks on its own row below the search input, instead of sitting inline with it. Everything else looks the same.
- `≥601px` unchanged.

## Test plan
- [x] Viewport ≤600px: search chip stacks below search input, no horizontal scroll
- [x] Viewport ≤600px: list/gallery toggle, action buttons, delete confirm all still work
- [x] Viewport ≥601px: layout unchanged (chip inline, toggle at right)
- [x] `go test -race ./server/...` passes
- [x] `golangci-lint run ./server/...` clean