### PR TITLE
chore(s3,gcs,azblob): Bump s2 require to v0.9.0 and retract v0.9.0

### DIFF
--- a/azblob/go.mod
+++ b/azblob/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
-	github.com/mojatter/s2 v0.5.1
+	github.com/mojatter/s2 v0.9.0
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -27,3 +27,5 @@ require (
 )
 
 replace github.com/mojatter/s2 => ../
+
+retract v0.9.0 // Published with stale require directive; use v0.9.1+.

--- a/gcs/go.mod
+++ b/gcs/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	cloud.google.com/go/storage v1.60.0
-	github.com/mojatter/s2 v0.5.1
+	github.com/mojatter/s2 v0.9.0
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/api v0.265.0
 )
@@ -61,3 +61,5 @@ require (
 )
 
 replace github.com/mojatter/s2 => ../
+
+retract v0.9.0 // Published with stale require directive; use v0.9.1+.

--- a/s3/go.mod
+++ b/s3/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
-	github.com/mojatter/s2 v0.5.1
+	github.com/mojatter/s2 v0.9.0
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -34,3 +34,5 @@ require (
 )
 
 replace github.com/mojatter/s2 => ../
+
+retract v0.9.0 // Published with stale require directive; use v0.9.1+.


### PR DESCRIPTION
## Summary

The s3/gcs/azblob `v0.9.0` tags were published with `require github.com/mojatter/s2` still pinned at `v0.5.1`, so downstream `go get` resolves them against stale main-module code.

This bumps the require to `v0.9.0` and retracts the published `v0.9.0` for each of s3, gcs, and azblob. A follow-up PR will do the same for s2env and cmd/s2-server (which need this PR's v0.9.1 tags to exist first). The corrected tags will be cut as `s3/v0.9.1`, `gcs/v0.9.1`, `azblob/v0.9.1` after merge.

## Test plan

- [x] `go test -race ./...` passes in s3, gcs, azblob
- [x] `golangci-lint run ./...` clean in each