### PR TITLE
fix(server): Disable workspace mode in Docker builder

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,7 +3,11 @@ WORKDIR /app
 # DefaultRoot is overridden via -ldflags so the Docker image defaults to
 # /var/lib/s2 while a bare "go install" binary keeps the friendlier
 # relative "./data" default (see server/config.go).
-RUN --mount=target=. GOOS=linux CGO_ENABLED=0 \
+# GOWORK=off disables workspace mode so the build does not try to update
+# go.work.sum on the read-only --mount; production builds use the
+# published module versions from cmd/s2-server/go.mod, not workspace
+# replacements.
+RUN --mount=target=. GOOS=linux CGO_ENABLED=0 GOWORK=off \
     cd cmd/s2-server && \
     go build \
       -ldflags "-s -w -X github.com/mojatter/s2/server.DefaultRoot=/var/lib/s2" \


### PR DESCRIPTION
## Summary

Pass `GOWORK=off` to the `go build` step in [server/Dockerfile](server/Dockerfile) so the builder does not run in Go workspace mode.

## Why

Dependabot PRs that bump dependencies in the root `go.mod` (most recently #97) consistently fail the e2e job, even when the bump itself is benign. The failure looks like:

```
go: updating go.sum: open /app/go.work.sum: read-only file system
```

The Dockerfile mounts the repo with `RUN --mount=target=.` (read-only). With `go.work` present, `go build` enters workspace mode and tries to write fresh hashes into `go.work.sum`, which the read-only mount forbids.

Production Docker builds do not need workspace replacements — `cmd/s2-server/go.mod` already pins published versions of every internal module (no `replace` directives, see #70). Disabling workspace mode in the builder is the right scope: local development still uses `go.work`, only the container build opts out.

## Test plan

- [x] `GOWORK=off go build ./cmd/s2-server` succeeds locally
- [x] CI e2e job goes green on this PR
- [x] After merge, rebase #97 (or `@dependabot rebase`) and confirm its e2e job goes green