### PR TITLE
chore(deps): Scan all submodules for Dependabot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,7 +1,13 @@
 version: 2
 updates:
   - package-ecosystem: gomod
-    directory: /
+    directories:
+      - /
+      - /azblob
+      - /cmd/s2-server
+      - /gcs
+      - /s2env
+      - /s3
     schedule:
       interval: weekly
     groups:


### PR DESCRIPTION
## Summary

Switch the gomod block in [.github/dependabot.yaml](.github/dependabot.yaml) from `directory: /` to `directories:` listing every workspace member, so Dependabot scans all sub-modules and rolls their updates into the existing `go-dependencies` group.

## Why

This monorepo has six Go modules:

```
/, /azblob, /cmd/s2-server, /gcs, /s2env, /s3
```

Sub-modules pin AWS SDK packages directly or indirectly, and the s3 e2e Docker build resolves `github.com/mojatter/s2` via `replace ../`. When Dependabot bumps only root `go.mod`, the sub-module `go.sum` files fall out of sync and the e2e build dies with `go: updates to go.mod needed; to update it: go mod tidy`. We just hit this on #97 and had to ship #100 with a manual `go mod tidy` commit on top of the Dependabot bump.

With `directories:` (plural), Dependabot v2 scans each listed path and the existing group config (`patterns: "*"`) collapses everything into one PR. Future AWS-SDK-class bumps should land already tidy.

## Test plan

- [ ] After merge, watch the next weekly Dependabot run and confirm a single PR covers all sub-modules
- [ ] If a bump is urgent, `@dependabot recreate` on a fresh test bump can validate sooner