### PR TITLE
fix(console): Make gallery card body keyboard-accessible

### DIFF
--- a/server/static/style.css
+++ b/server/static/style.css
@@ -713,13 +713,32 @@ tr:hover td {
   text-decoration: none;
   color: var(--text);
   position: relative;
+  display: flex;
+  flex-direction: column;
 }
 
 .gallery-card-body {
   display: block;
+  flex: 1;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  font: inherit;
+  text-align: inherit;
   cursor: pointer;
   text-decoration: none;
   color: inherit;
+}
+
+.gallery-card-body:disabled {
+  cursor: default;
+}
+
+.gallery-card-body:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: -2px;
+  border-radius: 12px;
 }
 
 .gallery-card-actions {
@@ -732,7 +751,8 @@ tr:hover td {
   transition: opacity 0.15s;
 }
 
-.gallery-card:hover .gallery-card-actions {
+.gallery-card:hover .gallery-card-actions,
+.gallery-card:focus-within .gallery-card-actions {
   opacity: 1;
 }
 

--- a/server/templates/console/buckets/objects.html
+++ b/server/templates/console/buckets/objects.html
@@ -230,7 +230,7 @@
     {{range .Objects}}
     {{if isImage .Name}}
     <div class="gallery-card gallery-image" data-name="{{baseName .Name}}">
-      <div class="gallery-card-body"
+      <button type="button" class="gallery-card-body"
         hx-get="/buckets/{{$.BucketName}}/preview/{{.Name}}"
         hx-target="#preview-dialog" hx-swap="innerHTML">
         <div class="gallery-thumb" data-src="/buckets/{{$.BucketName}}/view/{{.Name}}">
@@ -240,7 +240,7 @@
         </div>
         <span class="gallery-label">{{if $.Search}}{{trimPrefix $.CurrentPrefix .Name}}{{else}}{{baseName .Name}}{{end}}</span>
         <span class="gallery-size">{{formatSize .Length}}</span>
-      </div>
+      </button>
       <div class="gallery-card-actions">
         {{template "action-download" (dict "Bucket" $.BucketName "Key" .Name)}}
         {{template "action-delete-file" (dict "Bucket" $.BucketName "Key" .Name "Prefix" $.CurrentPrefix)}}
@@ -248,15 +248,15 @@
     </div>
     {{else}}
     <div class="gallery-card gallery-file" data-name="{{baseName .Name}}">
-      <div class="gallery-card-body"
+      <button type="button" class="gallery-card-body"
         {{if isPreviewable .Name .Length}}hx-get="/buckets/{{$.BucketName}}/preview/{{.Name}}"
-        hx-target="#preview-dialog" hx-swap="innerHTML"{{end}}>
+        hx-target="#preview-dialog" hx-swap="innerHTML"{{else}}disabled{{end}}>
         <div class="gallery-file-icon">
           <svg width="32" height="32" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><use href="#icon-file"></use></svg>
         </div>
         <span class="gallery-label">{{if $.Search}}{{trimPrefix $.CurrentPrefix .Name}}{{else}}{{baseName .Name}}{{end}}</span>
         <span class="gallery-size">{{formatSize .Length}}</span>
-      </div>
+      </button>
       <div class="gallery-card-actions">
         {{template "action-download" (dict "Bucket" $.BucketName "Key" .Name)}}
         {{template "action-delete-file" (dict "Bucket" $.BucketName "Key" .Name "Prefix" $.CurrentPrefix)}}


### PR DESCRIPTION
Fixes #90.

## Summary

Make the gallery card body click target reachable by keyboard and screen readers.

## Changes

- `.gallery-card-body` for image and file cards: `<div>` → `<button type="button">`
- File card without preview: `<button disabled>` (was a `<div>` with no `hx-get`)
- Folder card body keeps its existing `<a>`
- Reset native button chrome on `.gallery-card-body` (width / padding / border / background / font / text-align) so it looks identical to the previous div
- `.gallery-card` becomes a flex column and `.gallery-card-body` gets `flex: 1`, so the body fills the visible card area; without this, folder cards (which have no size line) leave empty space at the bottom and the focus ring doesn't cover the full card
- `:focus-visible` on `.gallery-card-body` draws an inset 2px outline with matching `border-radius: 12px`, since the parent's `overflow: hidden` would otherwise clip a default outset outline
- `:focus-within` mirrors `:hover` on `.gallery-card-actions` so the action buttons (download, delete) become visible during keyboard navigation, not only on mouse hover

## Test plan

- [x] Mouse: cards still hover/click as before
- [x] Tab: focus visibly travels through `card body → action buttons → next card body → ...` for both folders and files
- [x] Disabled file cards (non-previewable) are skipped by Tab
- [x] `go test ./server/...` passes
- [x] `golangci-lint run ./...` clean