### PR TITLE
refactor(console): Extract afterBucketCreate and tidy script blocks

### DIFF
--- a/server/templates/console/buckets/objects.html
+++ b/server/templates/console/buckets/objects.html
@@ -279,16 +279,15 @@
 {{define "scripts:console/buckets/objects.html"}}
 <script>
   function setViewMode(mode, btn) {
-    var listView = document.getElementById('list-view');
-    var galleryView = document.getElementById('gallery-view');
-    if (!listView || !galleryView) return;
+    const listView = document.getElementById('list-view');
+    const galleryView = document.getElementById('gallery-view');
 
-    var btns = document.querySelectorAll('.view-toggle-btn');
+    const btns = document.querySelectorAll('.view-toggle-btn');
     btns.forEach(function(b) { b.classList.remove('active'); });
     if (btn) {
       btn.classList.add('active');
     } else {
-      var idx = mode === 'gallery' ? 1 : 0;
+      const idx = mode === 'gallery' ? 1 : 0;
       if (btns[idx]) btns[idx].classList.add('active');
     }
 
@@ -303,15 +302,15 @@
   }
 
   function initGalleryView() {
-    var thumbs = document.querySelectorAll('.gallery-thumb[data-src]');
+    const thumbs = document.querySelectorAll('.gallery-thumb[data-src]');
     if (thumbs.length > 0) {
-      var observer = new IntersectionObserver(function(entries) {
+      const observer = new IntersectionObserver(function(entries) {
         entries.forEach(function(entry) {
           if (!entry.isIntersecting) return;
-          var el = entry.target;
-          var src = el.getAttribute('data-src');
+          const el = entry.target;
+          const src = el.getAttribute('data-src');
           if (!src) return;
-          var img = new Image();
+          const img = new Image();
           img.onload = function() {
             el.innerHTML = '';
             el.appendChild(img);
@@ -326,12 +325,12 @@
       thumbs.forEach(function(el) { observer.observe(el); });
     }
 
-    var mode = localStorage.getItem('s2-view-mode') || 'list';
+    const mode = localStorage.getItem('s2-view-mode') || 'list';
     setViewMode(mode);
   }
 
   document.addEventListener('htmx:afterSettle', function(evt) {
-    var id = evt.detail.target.id;
+    const id = evt.detail.target.id;
     if (id === 'main-content') {
       initGalleryView();
     } else if (id === 'preview-dialog') {

--- a/server/templates/console/index.html
+++ b/server/templates/console/index.html
@@ -83,16 +83,15 @@
 
   <script>
     (function() {
-      var layout = document.querySelector('.layout');
-      if (!layout) return;
-      var narrowQuery = window.matchMedia('(max-width: 900px)');
-      var stored = localStorage.getItem('s2-sidebar-collapsed');
-      var collapsed = stored === null ? narrowQuery.matches : stored === 'true';
+      const layout = document.querySelector('.layout');
+      const narrowQuery = window.matchMedia('(max-width: 900px)');
+      const stored = localStorage.getItem('s2-sidebar-collapsed');
+      const collapsed = stored === null ? narrowQuery.matches : stored === 'true';
       if (collapsed) {
         layout.classList.add('layout--sidebar-collapsed');
       }
       window.toggleSidebar = function() {
-        var isCollapsed = layout.classList.toggle('layout--sidebar-collapsed');
+        const isCollapsed = layout.classList.toggle('layout--sidebar-collapsed');
         localStorage.setItem('s2-sidebar-collapsed', isCollapsed);
       };
       window.closeSidebarOnNarrow = function() {
@@ -103,7 +102,7 @@
       };
       window.afterBucketCreate = function(form, event) {
         if (!event.detail.successful) return;
-        var name = form.elements.name.value;
+        const name = form.elements.name.value;
         form.reset();
         form.classList.remove('active');
         htmx.ajax('GET', '/buckets/' + encodeURIComponent(name), {target: '#main-content', pushUrl: true});

--- a/server/templates/console/index.html
+++ b/server/templates/console/index.html
@@ -48,7 +48,7 @@
         </div>
 
         <form class="new-bucket-form" hx-post="/buckets" hx-target=".bucket-list" hx-swap="outerHTML"
-          hx-on::after-request="if(event.detail.successful){var n=this.querySelector('[name=name]').value;this.reset();this.classList.remove('active');htmx.ajax('GET','/buckets/'+encodeURIComponent(n),{target:'#main-content',pushUrl:true});closeSidebarOnNarrow();}">
+          hx-on::after-request="afterBucketCreate(this, event)">
           <input type="text" name="name" placeholder="New bucket name..." required>
           <button type="submit">Create</button>
         </form>
@@ -100,6 +100,14 @@
         if (layout.classList.contains('layout--sidebar-collapsed')) return;
         layout.classList.add('layout--sidebar-collapsed');
         localStorage.setItem('s2-sidebar-collapsed', 'true');
+      };
+      window.afterBucketCreate = function(form, event) {
+        if (!event.detail.successful) return;
+        var name = form.elements.name.value;
+        form.reset();
+        form.classList.remove('active');
+        htmx.ajax('GET', '/buckets/' + encodeURIComponent(name), {target: '#main-content', pushUrl: true});
+        closeSidebarOnNarrow();
       };
       // On narrow, close the drawer when a bucket or the logo is clicked
       document.addEventListener('click', function(e) {


### PR DESCRIPTION
Fixes #89.

## Summary

Move the inline JS body out of `hx-on::after-request` on the new-bucket form, and clean up the surrounding script blocks while in the area.

## Commits

1. **Extract afterBucketCreate from inline hx-on::after-request** — the attribute on `<form class="new-bucket-form">` packed six operations (success check, read form value, reset, remove `active`, fire `htmx.ajax`, close drawer on narrow). Move the body to a named `window.afterBucketCreate` in the existing IIFE; the attribute becomes `afterBucketCreate(this, event)`. Also switch the form-value read from `form.querySelector('[name=name]').value` to `form.elements.name.value`.
2. **Tidy index.html script block** — `var` → `const` (no reassignments) and drop `if (!layout) return;`, which can never fire because `.layout` is always rendered as the body wrapper.
3. **Tidy objects.html script block** — same `var` → `const` pass and drop `if (!listView || !galleryView) return;` for the same reason (`#list-view` and `#gallery-view` are always rendered together by this template).

## Test plan

- [x] `go test ./server/...`
- [x] `golangci-lint run ./...`
- [x] Manual: create a new bucket → bucket appears in sidebar list, page navigates to it
- [x] Manual at <900px: same as above + sidebar drawer auto-closes
- [x] Manual: list/gallery view toggle still works on the objects page