### PR TITLE
test(s3api): Cover error and dispatch branches in hot paths

### DIFF
--- a/server/handlers/s3api/buckets_test.go
+++ b/server/handlers/s3api/buckets_test.go
@@ -58,16 +58,46 @@ func (s *BucketsTestSuite) TestListBuckets() {
 // --- CreateBucket ---
 
 func (s *BucketsTestSuite) TestCreateBucket() {
-	req := httptest.NewRequest("PUT", "/new-bucket", nil)
-	req.SetPathValue("bucket", "new-bucket")
-	w := httptest.NewRecorder()
-	handleCreateBucket(s.server, w, req)
+	testCases := []struct {
+		caseName    string
+		bucket      string
+		wantStatus  int
+		wantErrCode string
+	}{
+		{
+			caseName:   "success",
+			bucket:     "new-bucket",
+			wantStatus: http.StatusOK,
+		},
+		{
+			// DefaultConfig.HealthPath = "/healthz" reserves the bucket name "healthz".
+			// Buckets.Create returns ErrReservedBucketName, which currently has no
+			// specific S3 mapping and falls through to InternalError + 500.
+			caseName:    "reserved name",
+			bucket:      "healthz",
+			wantStatus:  http.StatusInternalServerError,
+			wantErrCode: "InternalError",
+		},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			req := httptest.NewRequest("PUT", "/"+tc.bucket, nil)
+			req.SetPathValue("bucket", tc.bucket)
+			w := httptest.NewRecorder()
+			handleCreateBucket(s.server, w, req)
 
-	s.Equal(http.StatusOK, w.Code)
-
-	exists, err := s.server.Buckets.Exists("new-bucket")
-	s.Require().NoError(err)
-	s.True(exists)
+			s.Equal(tc.wantStatus, w.Code)
+			if tc.wantErrCode == "" {
+				exists, err := s.server.Buckets.Exists(tc.bucket)
+				s.Require().NoError(err)
+				s.True(exists)
+				return
+			}
+			var errResp ErrorResponse
+			s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &errResp))
+			s.Equal(tc.wantErrCode, errResp.Code)
+		})
+	}
 }
 
 // --- DeleteBucket ---

--- a/server/handlers/s3api/multipart_test.go
+++ b/server/handlers/s3api/multipart_test.go
@@ -2,14 +2,75 @@ package s3api
 
 import (
 	"crypto/md5" // #nosec G501 -- MD5 is used here only to mirror S3 multipart ETag semantics under test.
+	"encoding/xml"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 
 	"github.com/mojatter/s2"
 )
+
+type MultipartTestSuite struct{ s3apiSuite }
+
+func TestMultipartTestSuite(t *testing.T) {
+	suite.Run(t, &MultipartTestSuite{})
+}
+
+func (s *MultipartTestSuite) TestCreateMultipartUpload() {
+	testCases := []struct {
+		caseName    string
+		setupBucket bool
+		bucket      string
+		key         string
+		wantStatus  int
+		wantErrCode string
+	}{
+		{
+			caseName:    "success",
+			setupBucket: true,
+			bucket:      "mp-bucket",
+			key:         "file.bin",
+			wantStatus:  http.StatusOK,
+		},
+		{
+			caseName:    "bucket not found",
+			bucket:      "no-such",
+			key:         "file.bin",
+			wantStatus:  http.StatusNotFound,
+			wantErrCode: "NoSuchBucket",
+		},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			if tc.setupBucket {
+				s.createBucket(tc.bucket)
+			}
+			req := httptest.NewRequest("POST", "/"+tc.bucket+"/"+tc.key+"?uploads", nil)
+			req.SetPathValue("bucket", tc.bucket)
+			req.SetPathValue("key", tc.key)
+			w := httptest.NewRecorder()
+			handleCreateMultipartUpload(s.server, w, req)
+
+			s.Equal(tc.wantStatus, w.Code)
+			if tc.wantErrCode == "" {
+				var result InitiateMultipartUploadResult
+				s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &result))
+				s.Equal(tc.bucket, result.Bucket)
+				s.Equal(tc.key, result.Key)
+				s.NotEmpty(result.UploadID)
+				return
+			}
+			var errResp ErrorResponse
+			s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &errResp))
+			s.Equal(tc.wantErrCode, errResp.Code)
+		})
+	}
+}
 
 func TestPartsReader(t *testing.T) {
 	testCases := []struct {
@@ -42,6 +103,26 @@ func TestPartsReader(t *testing.T) {
 			assert.NoError(t, pr.Close())
 		})
 	}
+}
+
+func TestPartsReader_CloseMidStream(t *testing.T) {
+	parts := []s2.Object{
+		s2.NewObjectBytes("a", []byte("hello world")),
+	}
+	pr := &partsReader{parts: parts}
+
+	// Read 1 byte to open the underlying part.
+	buf := make([]byte, 1)
+	_, err := pr.Read(buf)
+	require.NoError(t, err)
+	require.NotNil(t, pr.current, "current should be open after a partial read")
+
+	// Closing mid-stream releases current and reports no error.
+	require.NoError(t, pr.Close())
+	assert.Nil(t, pr.current)
+
+	// A subsequent Close is a no-op on the now-empty reader.
+	require.NoError(t, pr.Close())
 }
 
 func TestPartsReader_SmallBuffer(t *testing.T) {

--- a/server/handlers/s3api/objects_test.go
+++ b/server/handlers/s3api/objects_test.go
@@ -396,6 +396,34 @@ func (s *ObjectsTestSuite) TestGetObject() {
 		s.Equal(http.StatusOK, w.Code)
 		s.Equal("nested", w.Body.String())
 	})
+
+	s.Run("trailing-slash GET dispatches to ListObjects", func() {
+		s.putObject("ts", "x.txt", "x")
+
+		req := httptest.NewRequest("GET", "/ts/", nil)
+		req.SetPathValue("bucket", "ts")
+		req.SetPathValue("key", "")
+		w := httptest.NewRecorder()
+		handleGetObject(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		var result ListBucketResult
+		s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &result))
+		s.Equal("ts", result.Name)
+	})
+
+	s.Run("trailing-slash HEAD dispatches to HeadBucket", func() {
+		s.createBucket("ts2")
+
+		req := httptest.NewRequest("HEAD", "/ts2/", nil)
+		req.SetPathValue("bucket", "ts2")
+		req.SetPathValue("key", "")
+		w := httptest.NewRecorder()
+		handleGetObject(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		s.Empty(w.Body.String())
+	})
 }
 
 // --- HeadObject ---


### PR DESCRIPTION
Fixes #88.

## Summary

Lift coverage on the three handlers called out in #88, plus the trailing-slash dispatch in `handleGetObject`:

| symbol | before | after |
| --- | --- | --- |
| `handleCreateBucket` | 57.1% | **100%** |
| `handleCreateMultipartUpload` | 58.3% | **83.3%** |
| `(*partsReader).Close` | 40% | **100%** |
| `handleGetObject` | 79.5% | **92.3%** |

Package coverage: 79.5% → 82.0%.

## Tests added

- `BucketsTestSuite.TestCreateBucket` — converted to table-driven; new `reserved name` case exercises the `Buckets.Create` error branch via the `healthz` reserved name. The expected response is currently `InternalError` + 500 — see #109 for the follow-up to map this to a 4xx.
- `MultipartTestSuite.TestCreateMultipartUpload` — new suite; covers success and `bucket not found` (NoSuchBucket).
- `TestPartsReader_CloseMidStream` — exercises the `current != nil` branch of `(*partsReader).Close` by reading one byte before closing.
- `ObjectsTestSuite.TestGetObject` — added `trailing-slash GET dispatches to ListObjects` and `trailing-slash HEAD dispatches to HeadBucket` sub-cases for the empty-key dispatch branch in `handleGetObject`.

The remaining ~17% gap on `handleCreateMultipartUpload` is the `newUploadID` failure path, which requires `crypto/rand.Read` to fail and isn't worth the dependency injection it would need.

## Test plan

- [x] `go test ./server/...`
- [x] `golangci-lint run ./...`