### PR TITLE
refactor(server)!: Thread context through Buckets.Names/Exists

### DIFF
--- a/server/buckets.go
+++ b/server/buckets.go
@@ -101,8 +101,7 @@ func isValidBucketName(name string) bool {
 	return true
 }
 
-func (bs *Buckets) Names() ([]string, error) {
-	ctx := context.Background()
+func (bs *Buckets) Names(ctx context.Context) ([]string, error) {
 	res, err := bs.strg.List(ctx, s2.ListOptions{})
 	if err != nil {
 		return nil, err
@@ -111,7 +110,7 @@ func (bs *Buckets) Names() ([]string, error) {
 }
 
 func (bs *Buckets) Get(ctx context.Context, name string) (s2.Storage, error) {
-	exists, err := bs.Exists(name)
+	exists, err := bs.Exists(ctx, name)
 	if err != nil {
 		return nil, err
 	}
@@ -147,8 +146,8 @@ func (bs *Buckets) CreatedAt(ctx context.Context, name string) time.Time {
 // the s3 backend would need a different implementation because S3
 // has no "directory" primitive; s3 is intended for library-style use
 // against a single bucket, not as a multi-bucket server backend.
-func (bs *Buckets) Exists(name string) (bool, error) {
-	return bs.strg.Exists(context.Background(), name)
+func (bs *Buckets) Exists(ctx context.Context, name string) (bool, error) {
+	return bs.strg.Exists(ctx, name)
 }
 
 func (bs *Buckets) Create(ctx context.Context, name string) error {

--- a/server/buckets_test.go
+++ b/server/buckets_test.go
@@ -102,7 +102,7 @@ func (s *BucketsTestSuite) TestCreateAndNames() {
 	s.Require().NoError(s.buckets.Create(ctx, "alpha"))
 	s.Require().NoError(s.buckets.Create(ctx, "beta"))
 
-	names, err := s.buckets.Names()
+	names, err := s.buckets.Names(ctx)
 	s.Require().NoError(err)
 	s.Len(names, 2)
 	s.Contains(names, "alpha")
@@ -113,11 +113,11 @@ func (s *BucketsTestSuite) TestExists() {
 	ctx := context.Background()
 	s.Require().NoError(s.buckets.Create(ctx, "exists-test"))
 
-	ok, err := s.buckets.Exists("exists-test")
+	ok, err := s.buckets.Exists(ctx, "exists-test")
 	s.Require().NoError(err)
 	s.True(ok)
 
-	ok, err = s.buckets.Exists("no-such-bucket")
+	ok, err = s.buckets.Exists(ctx, "no-such-bucket")
 	s.Require().NoError(err)
 	s.False(ok)
 }
@@ -146,12 +146,12 @@ func (s *BucketsTestSuite) TestDelete() {
 	ctx := context.Background()
 	s.Require().NoError(s.buckets.Create(ctx, "to-delete"))
 
-	ok, _ := s.buckets.Exists("to-delete")
+	ok, _ := s.buckets.Exists(ctx, "to-delete")
 	s.True(ok)
 
 	s.Require().NoError(s.buckets.Delete(ctx, "to-delete"))
 
-	ok, _ = s.buckets.Exists("to-delete")
+	ok, _ = s.buckets.Exists(ctx, "to-delete")
 	s.False(ok)
 }
 

--- a/server/console.go
+++ b/server/console.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"log/slog"
 	"net/http"
 	"time"
@@ -25,8 +26,8 @@ func RegisterConsoleHandleFunc(pattern string, handler HandlerFunc) {
 // RenderConsoleIndex renders the full index.html page into w. The
 // current bucket list is added to data under the "Buckets" key before
 // template execution; data may be nil.
-func (s *Server) RenderConsoleIndex(w http.ResponseWriter, data map[string]any) error {
-	names, err := s.Buckets.Names()
+func (s *Server) RenderConsoleIndex(ctx context.Context, w http.ResponseWriter, data map[string]any) error {
+	names, err := s.Buckets.Names(ctx)
 	if err != nil {
 		return err
 	}

--- a/server/console_test.go
+++ b/server/console_test.go
@@ -38,7 +38,7 @@ func TestRenderConsoleIndex(t *testing.T) {
 			}
 
 			w := httptest.NewRecorder()
-			require.NoError(t, srv.RenderConsoleIndex(w, nil))
+			require.NoError(t, srv.RenderConsoleIndex(context.Background(), w, nil))
 
 			body := w.Body.String()
 			for _, want := range tc.wantContains {

--- a/server/handlers/console/buckets/objects.go
+++ b/server/handlers/console/buckets/objects.go
@@ -118,7 +118,7 @@ func handleObjects(s *server.Server, w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
-	if err := s.RenderConsoleIndex(w, data); err != nil {
+	if err := s.RenderConsoleIndex(ctx, w, data); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/server/handlers/console/console_test.go
+++ b/server/handlers/console/console_test.go
@@ -76,7 +76,7 @@ func (s *IndexTestSuite) TestHandleCreateBucket() {
 		s.Equal(http.StatusOK, w.Code)
 		s.Contains(w.Body.String(), "new-bucket")
 
-		exists, err := s.server.Buckets.Exists("new-bucket")
+		exists, err := s.server.Buckets.Exists(req.Context(), "new-bucket")
 		s.Require().NoError(err)
 		s.True(exists)
 	})
@@ -107,7 +107,7 @@ func (s *IndexTestSuite) TestHandleDeleteBucket() {
 		s.Equal("/", w.Header().Get("HX-Push-Url"))
 		s.Contains(w.Body.String(), "bucket-list")
 
-		exists, err := s.server.Buckets.Exists("to-delete")
+		exists, err := s.server.Buckets.Exists(req.Context(), "to-delete")
 		s.Require().NoError(err)
 		s.False(exists)
 	})

--- a/server/handlers/console/index.go
+++ b/server/handlers/console/index.go
@@ -2,14 +2,15 @@ package console
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 
 	"github.com/mojatter/s2/server"
 	"github.com/mojatter/s2/server/middleware"
 )
 
-func handleIndex(s *server.Server, w http.ResponseWriter, _ *http.Request) {
-	if err := s.RenderConsoleIndex(w, nil); err != nil {
+func handleIndex(s *server.Server, w http.ResponseWriter, r *http.Request) {
+	if err := s.RenderConsoleIndex(r.Context(), w, nil); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -26,7 +27,7 @@ func handleCreateBucket(s *server.Server, w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	renderBucketList(s, w)
+	renderBucketList(r.Context(), s, w)
 }
 
 func handleDeleteBucket(s *server.Server, w http.ResponseWriter, r *http.Request) {
@@ -40,7 +41,7 @@ func handleDeleteBucket(s *server.Server, w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	names, err := s.Buckets.Names()
+	names, err := s.Buckets.Names(r.Context())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -69,8 +70,8 @@ func handleDeleteBucket(s *server.Server, w http.ResponseWriter, r *http.Request
 }
 
 // renderBucketList renders the sidebar bucket list fragment.
-func renderBucketList(s *server.Server, w http.ResponseWriter) {
-	names, err := s.Buckets.Names()
+func renderBucketList(ctx context.Context, s *server.Server, w http.ResponseWriter) {
+	names, err := s.Buckets.Names(ctx)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/server/handlers/s3api/buckets.go
+++ b/server/handlers/s3api/buckets.go
@@ -8,7 +8,8 @@ import (
 )
 
 func HandleListBuckets(s *server.Server, w http.ResponseWriter, r *http.Request) {
-	names, err := s.Buckets.Names()
+	ctx := r.Context()
+	names, err := s.Buckets.Names(ctx)
 	if err != nil {
 		code, msg, status := s2ErrorToS3Error(err)
 		writeError(w, r, code, msg, status)
@@ -19,7 +20,7 @@ func HandleListBuckets(s *server.Server, w http.ResponseWriter, r *http.Request)
 	for _, name := range names {
 		buckets = append(buckets, Bucket{
 			Name:         name,
-			CreationDate: s.Buckets.CreatedAt(r.Context(), name),
+			CreationDate: s.Buckets.CreatedAt(ctx, name),
 		})
 	}
 
@@ -51,7 +52,7 @@ func handleDeleteBucket(s *server.Server, w http.ResponseWriter, r *http.Request
 	ctx := r.Context()
 	bucketName := r.PathValue("bucket")
 
-	exists, err := s.Buckets.Exists(bucketName)
+	exists, err := s.Buckets.Exists(ctx, bucketName)
 	if err != nil {
 		code, msg, status := s2ErrorToS3Error(err)
 		writeError(w, r, code, msg, status)
@@ -74,7 +75,7 @@ func handleDeleteBucket(s *server.Server, w http.ResponseWriter, r *http.Request
 func handleHeadBucket(s *server.Server, w http.ResponseWriter, r *http.Request) {
 	bucketName := r.PathValue("bucket")
 
-	exists, err := s.Buckets.Exists(bucketName)
+	exists, err := s.Buckets.Exists(r.Context(), bucketName)
 	if err != nil {
 		code, msg, status := s2ErrorToS3Error(err)
 		writeError(w, r, code, msg, status)
@@ -91,7 +92,7 @@ func handleHeadBucket(s *server.Server, w http.ResponseWriter, r *http.Request) 
 func handleGetBucketLocation(s *server.Server, w http.ResponseWriter, r *http.Request) {
 	bucketName := r.PathValue("bucket")
 
-	exists, err := s.Buckets.Exists(bucketName)
+	exists, err := s.Buckets.Exists(r.Context(), bucketName)
 	if err != nil {
 		code, msg, status := s2ErrorToS3Error(err)
 		writeError(w, r, code, msg, status)

--- a/server/handlers/s3api/buckets_test.go
+++ b/server/handlers/s3api/buckets_test.go
@@ -88,7 +88,7 @@ func (s *BucketsTestSuite) TestCreateBucket() {
 
 			s.Equal(tc.wantStatus, w.Code)
 			if tc.wantErrCode == "" {
-				exists, err := s.server.Buckets.Exists(tc.bucket)
+				exists, err := s.server.Buckets.Exists(req.Context(), tc.bucket)
 				s.Require().NoError(err)
 				s.True(exists)
 				return
@@ -113,7 +113,7 @@ func (s *BucketsTestSuite) TestDeleteBucket() {
 
 		s.Equal(http.StatusNoContent, w.Code)
 
-		exists, err := s.server.Buckets.Exists("to-delete")
+		exists, err := s.server.Buckets.Exists(req.Context(), "to-delete")
 		s.Require().NoError(err)
 		s.False(exists)
 	})

--- a/server/handlers/s3api/s3api_test.go
+++ b/server/handlers/s3api/s3api_test.go
@@ -27,7 +27,7 @@ func (s *s3apiSuite) SetupTest() {
 func (s *s3apiSuite) putObject(bucket, key, content string) {
 	s.T().Helper()
 	ctx := context.Background()
-	if ok, _ := s.server.Buckets.Exists(bucket); !ok {
+	if ok, _ := s.server.Buckets.Exists(ctx, bucket); !ok {
 		s.Require().NoError(s.server.Buckets.Create(ctx, bucket))
 	}
 	strg, err := s.server.Buckets.Get(ctx, bucket)

--- a/server/server.go
+++ b/server/server.go
@@ -150,7 +150,7 @@ func Run(args []string) error {
 		return err
 	}
 	for _, name := range cfg.Buckets {
-		if ok, _ := srv.Buckets.Exists(name); ok {
+		if ok, _ := srv.Buckets.Exists(ctx, name); ok {
 			continue
 		}
 		if err := srv.Buckets.Create(ctx, name); err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -262,13 +262,14 @@ func TestInitBuckets(t *testing.T) {
 		srv, err := NewServer(context.Background(), cfg)
 		require.NoError(t, err)
 
+		ctx := context.Background()
 		for _, name := range cfg.Buckets {
-			if ok, _ := srv.Buckets.Exists(name); !ok {
-				require.NoError(t, srv.Buckets.Create(context.Background(), name))
+			if ok, _ := srv.Buckets.Exists(ctx, name); !ok {
+				require.NoError(t, srv.Buckets.Create(ctx, name))
 			}
 		}
 
-		names, err := srv.Buckets.Names()
+		names, err := srv.Buckets.Names(ctx)
 		require.NoError(t, err)
 		assert.Contains(t, names, "alpha")
 		assert.Contains(t, names, "bravo")
@@ -279,18 +280,19 @@ func TestInitBuckets(t *testing.T) {
 		cfg.Root = t.TempDir()
 		cfg.Buckets = []string{"existing"}
 
-		srv, err := NewServer(context.Background(), cfg)
+		ctx := context.Background()
+		srv, err := NewServer(ctx, cfg)
 		require.NoError(t, err)
 
-		require.NoError(t, srv.Buckets.Create(context.Background(), "existing"))
+		require.NoError(t, srv.Buckets.Create(ctx, "existing"))
 
 		for _, name := range cfg.Buckets {
-			if ok, _ := srv.Buckets.Exists(name); !ok {
-				require.NoError(t, srv.Buckets.Create(context.Background(), name))
+			if ok, _ := srv.Buckets.Exists(ctx, name); !ok {
+				require.NoError(t, srv.Buckets.Create(ctx, name))
 			}
 		}
 
-		names, err := srv.Buckets.Names()
+		names, err := srv.Buckets.Names(ctx)
 		require.NoError(t, err)
 		assert.Contains(t, names, "existing")
 	})


### PR DESCRIPTION
Fixes #84.

## Summary

Add `ctx context.Context` as the first parameter of `Buckets.Names` and `Buckets.Exists` so request cancellation and tracing reach the storage layer through these methods. Also propagate the change to `Server.RenderConsoleIndex`, which is the next-frame caller of `Buckets.Names` and is part of the public API.

## Breaking changes

Three exported method signatures change:

```go
// before
func (bs *Buckets) Names() ([]string, error)
func (bs *Buckets) Exists(name string) (bool, error)
func (s *Server) RenderConsoleIndex(w http.ResponseWriter, data map[string]any) error

// after
func (bs *Buckets) Names(ctx context.Context) ([]string, error)
func (bs *Buckets) Exists(ctx context.Context, name string) (bool, error)
func (s *Server) RenderConsoleIndex(ctx context.Context, w http.ResponseWriter, data map[string]any) error
```

Acceptable on `v0.x` per the v1.0 roadmap (#63). Will be flagged in v0.10.0 release notes.

## Internal updates

- `Buckets.Get` already had `ctx`; now passes it to the internal `Exists` call (previously `context.Background()`).
- All in-repo callers updated to thread `r.Context()` (HTTP handlers) or `context.Background()` (startup paths).

## Test plan

- [x] `go test ./...`
- [x] `golangci-lint run ./...`