### PR TITLE
fix(s3api): Map ErrReservedBucketName to InvalidBucketName (400)

### DIFF
--- a/server/handlers/s3api/buckets_test.go
+++ b/server/handlers/s3api/buckets_test.go
@@ -71,12 +71,12 @@ func (s *BucketsTestSuite) TestCreateBucket() {
 		},
 		{
 			// DefaultConfig.HealthPath = "/healthz" reserves the bucket name "healthz".
-			// Buckets.Create returns ErrReservedBucketName, which currently has no
-			// specific S3 mapping and falls through to InternalError + 500.
+			// Buckets.Create returns ErrReservedBucketName, which s2ErrorToS3Error
+			// maps to InvalidBucketName + 400.
 			caseName:    "reserved name",
 			bucket:      "healthz",
-			wantStatus:  http.StatusInternalServerError,
-			wantErrCode: "InternalError",
+			wantStatus:  http.StatusBadRequest,
+			wantErrCode: "InvalidBucketName",
 		},
 	}
 	for _, tc := range testCases {

--- a/server/handlers/s3api/utils.go
+++ b/server/handlers/s3api/utils.go
@@ -145,5 +145,8 @@ func s2ErrorToS3Error(err error) (string, string, int) {
 	if errors.As(err, &bucketNotFound) {
 		return "NoSuchBucket", err.Error(), http.StatusNotFound
 	}
+	if errors.Is(err, server.ErrReservedBucketName) {
+		return "InvalidBucketName", err.Error(), http.StatusBadRequest
+	}
 	return "InternalError", err.Error(), http.StatusInternalServerError
 }


### PR DESCRIPTION
Fixes #109.

## Summary

Add a case to `s2ErrorToS3Error` so `ErrReservedBucketName` returns `InvalidBucketName` + HTTP 400 instead of falling through to `InternalError` + HTTP 500.

Trying to `PUT /healthz` (or whichever first segment of `cfg.HealthPath` is reserved) is a client error — the user can never use this name on this s2 deployment, regardless of timing — so a 4xx response is correct. AWS S3's `InvalidBucketName` is the closest spec'd code; `BucketAlreadyExists` (409) was the alternative but doesn't fit because the name isn't "owned by another account", it's structurally unavailable on this server.

## Test impact

The existing `BucketsTestSuite.TestCreateBucket / reserved name` case (added in #108) flips its expectations from `StatusInternalServerError` / `"InternalError"` to `StatusBadRequest` / `"InvalidBucketName"`.

## Test plan

- [x] `go test ./server/...`
- [x] `golangci-lint run ./...`