### PR TITLE
fix(ci): Bump e2e SDK image to golang:1.25-alpine

### DIFF
--- a/s2test/e2e/Dockerfile.sdk
+++ b/s2test/e2e/Dockerfile.sdk
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine
+FROM golang:1.25-alpine
 WORKDIR /app
 RUN --mount=target=. cd s3 && \
     GOWORK=off go test -tags integtest -c -o /usr/local/bin/s3-integ-test .


### PR DESCRIPTION
## Summary

- Bump `s2test/e2e/Dockerfile.sdk` from `golang:1.24-alpine` to `golang:1.25-alpine`.
- Required because `aws-sdk-go-v2` (bumped in #115) raises the root module's `go` directive to `1.25.0`. The s3 integration test build follows `replace github.com/mojatter/s2 => ../`, which then fails on the 1.24 image with `module ../ requires go >= 1.25.0`.
- The rest of the project (server image, GitHub Actions workflows) is already on Go 1.25; this Dockerfile was the lone laggard.

## Test plan

- [x] e2e job passes on this PR
- [ ] After merging, rebase #115 onto main and confirm e2e passes there too