### PR TITLE
chore: Bump intra-repo deps to v0.11.0 and drop v0.9.0 retract

### DIFF
--- a/azblob/go.mod
+++ b/azblob/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
-	github.com/mojatter/s2 v0.10.0
+	github.com/mojatter/s2 v0.11.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/azblob/go.mod
+++ b/azblob/go.mod
@@ -27,5 +27,3 @@ require (
 )
 
 replace github.com/mojatter/s2 => ../
-
-retract v0.9.0 // Published with stale require directive; use v0.9.1+.

--- a/gcs/go.mod
+++ b/gcs/go.mod
@@ -61,5 +61,3 @@ require (
 )
 
 replace github.com/mojatter/s2 => ../
-
-retract v0.9.0 // Published with stale require directive; use v0.9.1+.

--- a/gcs/go.mod
+++ b/gcs/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	cloud.google.com/go/storage v1.62.1
-	github.com/mojatter/s2 v0.10.0
+	github.com/mojatter/s2 v0.11.0
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/api v0.278.0
 )

--- a/s2env/go.mod
+++ b/s2env/go.mod
@@ -96,5 +96,3 @@ replace (
 	github.com/mojatter/s2/gcs => ../gcs
 	github.com/mojatter/s2/s3 => ../s3
 )
-
-retract v0.9.0 // Published with stale require directives; use v0.9.1+.

--- a/s2env/go.mod
+++ b/s2env/go.mod
@@ -3,10 +3,10 @@ module github.com/mojatter/s2/s2env
 go 1.25.0
 
 require (
-	github.com/mojatter/s2 v0.10.0
-	github.com/mojatter/s2/azblob v0.10.0
-	github.com/mojatter/s2/gcs v0.10.0
-	github.com/mojatter/s2/s3 v0.10.0
+	github.com/mojatter/s2 v0.11.0
+	github.com/mojatter/s2/azblob v0.11.0
+	github.com/mojatter/s2/gcs v0.11.0
+	github.com/mojatter/s2/s3 v0.11.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/s3/go.mod
+++ b/s3/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
-	github.com/mojatter/s2 v0.10.0
+	github.com/mojatter/s2 v0.11.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/s3/go.mod
+++ b/s3/go.mod
@@ -33,5 +33,3 @@ require (
 )
 
 replace github.com/mojatter/s2 => ../
-
-retract v0.9.0 // Published with stale require directive; use v0.9.1+.

--- a/server/go.mod
+++ b/server/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
-	github.com/mojatter/s2 v0.10.0
+	github.com/mojatter/s2 v0.11.0
 	github.com/stretchr/testify v1.11.1
 )
 


### PR DESCRIPTION
## Summary

- Bump intra-repo `require` lines to `v0.11.0` in `s3`, `gcs`, `azblob`, `s2env`, and `server` (the new module from #91).
- Drop the `retract v0.9.0` directive from those four modules' `go.mod` files; v0.9.0 was 17 days ago and persisted across two minor cycles, so any consumers still pinned to it have had ample warning. Closes #96.

`cmd/s2-server` is intentionally not bumped here. It needs to require `github.com/mojatter/s2/server v0.11.0`, but `server` is a new module without prior tags, and Go's workspace cannot resolve a not-yet-tagged require during local build (an MVS metadata fetch hits the proxy regardless of `use` directives). After this PR is merged and the v0.11.0 tags are pushed, a follow-up PR will bump `cmd/s2-server/go.mod`. Future releases (v0.12.0+) will not need this split since `server` will already be on the proxy.

## Test plan

- [ ] Tests workflow passes (root + s3 + gcs + azblob + s2env + server)
- [ ] govulncheck workflow passes
- [ ] e2e workflow passes