### PR TITLE
chore(deps): Split root into its own Dependabot gomod entry

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,6 +3,15 @@ updates:
   - package-ecosystem: gomod
     directories:
       - /
+    schedule:
+      interval: weekly
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: gomod
+    directories:
       - /azblob
       - /cmd/s2-server
       - /gcs


### PR DESCRIPTION
## Why

The root module (`/`) only depends directly on `github.com/mojatter/wfs` (bumped manually via intra-repo dep PRs) and `github.com/stretchr/testify`. Its dependency closure needs at most `go 1.24` (via wfs), so root never requires a recent Go toolchain on its own.

The problem: root shared a single multi-directory `go-dependencies` group with the AWS/Google submodules. Dependabot normalized that group's `go` directive to the group maximum and wrote it into every directory — including root — even when no root dependency changed. In #123 root's `go.mod` diff was *only* the `go` line: `go 1.25.0` → `go 1.25.8`, borrowed entirely from the aws-sdk / google-api submodules.

## What

Move root (`/`) into its own `gomod` update entry, separate from the submodules. Root's `go` directive is then driven solely by root's own dependency closure (`go 1.24` → `1.25.0`) and is no longer coupled to the submodules' `1.25.8`.

Unlike simply dropping root from Dependabot, this keeps root's direct dependencies (e.g. `testify`) under automated updates.

## Notes

- Workspace consistency is unaffected: even when submodules sit at `go 1.25.8`, `go.work` (which must be ≥ every member) stays ≥ root's `1.25.0`.
- Dependabot's cross-directory `go`-directive normalization is inferred from the #123 behavior rather than documented, so the first Dependabot run after this lands is worth a glance to confirm root's `go` directive stays put.