### PR TITLE
chore(deps): Drop root gomod entry from Dependabot, add /server

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,21 +2,12 @@ version: 2
 updates:
   - package-ecosystem: gomod
     directories:
-      - /
-    schedule:
-      interval: weekly
-    groups:
-      go-dependencies:
-        patterns:
-          - "*"
-
-  - package-ecosystem: gomod
-    directories:
       - /azblob
       - /cmd/s2-server
       - /gcs
       - /s2env
       - /s3
+      - /server
     schedule:
       interval: weekly
     groups:


### PR DESCRIPTION
## Why

The earlier split (#124) gave the root module (`/`) its own `gomod` entry, intending to keep root's `go.mod` from being rewritten. It did not work: because `go.work` lives in `/`, any Dependabot job targeting `/` runs the Go tooling in workspace mode and sees the entire workspace. The root job's dependency snapshot pulled in every submodule's deps (Azure / AWS / Google / x/net) and rewrote root's `go` directive to the workspace maximum (`1.25.0` → `1.25.8`) even though root itself requires none of them and only needs `go 1.24`.

The root-entry PR (#126) therefore still modified root's `go.mod`. Neither `ignore` nor `directories` globbing can scope a `/` entry to "root only" while `go.work` sits there.

## What

- Remove the `/` (root) `gomod` entry entirely. With no root entry, Dependabot never opens a workspace-wide / root-touching PR; the submodule entry leaves root's `go.mod` alone (confirmed: #125 did not touch root).
- Add `/server` to the submodule entry so its own dependencies are tracked.

This supersedes #124's split.

## Trade-off

Root's two direct dependencies are no longer auto-updated:

- `wfs` is already bumped manually via intra-repo dep PRs, so no change in practice.
- `testify` is still tracked in every submodule, so it keeps getting updated there; only the root copy may lag, which is low-churn and harmless.

Workspace consistency is unaffected: even when submodules sit at `go 1.25.8`, `go.work` (which must be ≥ every member) stays ≥ root's `1.25.0`.