### PR TITLE
chore: Bump intra-repo deps to v0.11.1

### DIFF
--- a/azblob/go.mod
+++ b/azblob/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.7.0
-	github.com/mojatter/s2 v0.11.0
+	github.com/mojatter/s2 v0.11.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/gcs/go.mod
+++ b/gcs/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	cloud.google.com/go/storage v1.62.2
-	github.com/mojatter/s2 v0.11.0
+	github.com/mojatter/s2 v0.11.1
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/api v0.282.0
 )

--- a/s2env/go.mod
+++ b/s2env/go.mod
@@ -3,10 +3,10 @@ module github.com/mojatter/s2/s2env
 go 1.25.8
 
 require (
-	github.com/mojatter/s2 v0.11.0
-	github.com/mojatter/s2/azblob v0.11.0
-	github.com/mojatter/s2/gcs v0.11.0
-	github.com/mojatter/s2/s3 v0.11.0
+	github.com/mojatter/s2 v0.11.1
+	github.com/mojatter/s2/azblob v0.11.1
+	github.com/mojatter/s2/gcs v0.11.1
+	github.com/mojatter/s2/s3 v0.11.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/s3/go.mod
+++ b/s3/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.9
 	github.com/aws/aws-sdk-go-v2/config v1.32.20
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.102.2
-	github.com/mojatter/s2 v0.11.0
+	github.com/mojatter/s2 v0.11.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.9
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.19
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.102.2
-	github.com/mojatter/s2 v0.11.0
+	github.com/mojatter/s2 v0.11.1
 	github.com/stretchr/testify v1.11.1
 )
 


### PR DESCRIPTION
Step 1 of the v0.11.1 release (see [docs/releasing.md](docs/releasing.md)).

Bump the intra-repo `require` versions to `v0.11.1` in the five modules that carry `replace` directives, so their published tags reference each other at the new version:

- `s3`, `gcs`, `azblob`, `server`: `github.com/mojatter/s2` → `v0.11.1`
- `s2env`: `s2`, `azblob`, `gcs`, `s3` → `v0.11.1`

`cmd/s2-server` is intentionally left at `v0.11.0`. It has no `replace` directives, so a `GOWORK=off` build (used by the e2e image and GoReleaser) resolves intra-repo deps from `proxy.golang.org`; it can only require `v0.11.1` after those tags are published. It is bumped in a follow-up PR once the tags exist — same sequence as v0.11.0 (#119 → #120).

`go.sum` is unchanged: the `replace` directives resolve these modules locally, so no proxy hash is needed, and CI resolves them through `go.work`.

## Verification

Local, with the CI toolchain (`go1.25.10`):

- `go vet ./...`, root + all submodule `go test` pass (workspace mode).
- `GOWORK=off` builds pass for `cmd/s2-server` (still on `v0.11.0`), `server`, and the `s3` integ-test binary — i.e. the e2e build path is green.

## Next steps

1. Merge this PR.
2. Tag the merge commit: `v0.11.1` + the five submodule tags (push submodule tags batched, root tag alone).
3. Follow-up PR bumps `cmd/s2-server` to `v0.11.1`; tag `cmd/s2-server/v0.11.1`.
4. Replace the GoReleaser notes with a hand-written changelog.