### PR TITLE
feat(s3): Add RegisterLoadOptionsFunc extension point for AWS credentials

### DIFF
--- a/s3/storage.go
+++ b/s3/storage.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"path"
 	"strings"
+	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
@@ -47,8 +48,45 @@ func init() {
 	s2.RegisterNewStorageFunc(s2.TypeS3, NewStorage)
 }
 
+// LoadOptionsFunc supplies additional AWS config load options for a given
+// s2.Config. It may inspect cfg and return nil, nil when it has nothing to
+// add for that cfg.
+type LoadOptionsFunc func(cfg s2.Config) ([]func(*awsconfig.LoadOptions) error, error)
+
+var (
+	loadOptionsMux   sync.Mutex
+	extraLoadOptions LoadOptionsFunc
+)
+
+// RegisterLoadOptionsFunc registers fn to supply additional AWS config load
+// options when NewStorage builds the AWS config for an S3 storage. This is
+// the extension point for credential mechanisms s2 does not implement
+// itself (e.g. Cognito Identity, STS AssumeRole, custom federation): build
+// the resolution logic outside s2 and register it here instead of forking
+// NewStorage.
+//
+// Registering again replaces any previously registered fn.
+func RegisterLoadOptionsFunc(fn LoadOptionsFunc) {
+	loadOptionsMux.Lock()
+	defer loadOptionsMux.Unlock()
+
+	extraLoadOptions = fn
+}
+
+// UnregisterLoadOptionsFunc removes a previously registered
+// RegisterLoadOptionsFunc hook. Primarily useful in tests that swap
+// credential strategies.
+func UnregisterLoadOptionsFunc() {
+	loadOptionsMux.Lock()
+	defer loadOptionsMux.Unlock()
+
+	extraLoadOptions = nil
+}
+
 // NewStorage creates a new S3 storage with the default AWS configuration.
-// If cfg.S3 is non-nil, its fields override the AWS SDK defaults.
+// If cfg.S3 is non-nil, its fields override the AWS SDK defaults. See
+// RegisterLoadOptionsFunc for plugging in credential mechanisms beyond
+// cfg.S3's static AccessKeyID/SecretAccessKey.
 func NewStorage(ctx context.Context, cfg s2.Config) (s2.Storage, error) {
 	if cfg.Root == "" {
 		return nil, ErrRequiredConfigRoot
@@ -70,6 +108,17 @@ func NewStorage(ctx context.Context, cfg s2.Config) (s2.Storage, error) {
 				}),
 			))
 		}
+	}
+
+	loadOptionsMux.Lock()
+	fn := extraLoadOptions
+	loadOptionsMux.Unlock()
+	if fn != nil {
+		extra, err := fn(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve registered AWS config load options: %w", err)
+		}
+		opts = append(opts, extra...)
 	}
 
 	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)

--- a/s3/storage_test.go
+++ b/s3/storage_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/mojatter/s2"
@@ -395,6 +396,92 @@ func (s *StorageTestSuite) TestNewStorage() {
 			s.NotNil(st.client)
 		})
 	}
+}
+
+func (s *StorageTestSuite) TestRegisterLoadOptionsFunc() {
+	s.T().Cleanup(func() { UnregisterLoadOptionsFunc() })
+
+	testCases := []struct {
+		caseName    string
+		fn          LoadOptionsFunc
+		cfg         s2.Config
+		wantRegion  string
+		wantAccess  string
+		wantSession string
+	}{
+		{
+			caseName: "applies registered credentials and region",
+			fn: func(cfg s2.Config) ([]func(*awsconfig.LoadOptions) error, error) {
+				return []func(*awsconfig.LoadOptions) error{
+					awsconfig.WithRegion("ap-northeast-1"),
+					awsconfig.WithCredentialsProvider(aws.CredentialsProviderFunc(func(ctx context.Context) (aws.Credentials, error) {
+						return aws.Credentials{
+							AccessKeyID:     "REGISTERED",
+							SecretAccessKey: "REGISTERED-SECRET",
+							SessionToken:    "REGISTERED-SESSION",
+						}, nil
+					})),
+				}, nil
+			},
+			cfg:         s2.Config{Type: s2.TypeS3, Root: "my-bucket"},
+			wantRegion:  "ap-northeast-1",
+			wantAccess:  "REGISTERED",
+			wantSession: "REGISTERED-SESSION",
+		},
+		{
+			caseName: "nil, nil leaves AWS SDK defaults in place",
+			fn: func(cfg s2.Config) ([]func(*awsconfig.LoadOptions) error, error) {
+				return nil, nil
+			},
+			cfg: s2.Config{Type: s2.TypeS3, Root: "my-bucket"},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			RegisterLoadOptionsFunc(tc.fn)
+
+			strg, err := NewStorage(context.Background(), tc.cfg)
+			s.Require().NoError(err)
+
+			st := strg.(*storage)
+			client, ok := st.client.(*s3.Client)
+			s.Require().True(ok)
+
+			opts := client.Options()
+			if tc.wantRegion != "" {
+				s.Equal(tc.wantRegion, opts.Region)
+			}
+			if tc.wantAccess != "" {
+				creds, err := opts.Credentials.Retrieve(context.Background())
+				s.Require().NoError(err)
+				s.Equal(tc.wantAccess, creds.AccessKeyID)
+				s.Equal(tc.wantSession, creds.SessionToken)
+			}
+		})
+	}
+}
+
+func (s *StorageTestSuite) TestRegisterLoadOptionsFuncError() {
+	s.T().Cleanup(func() { UnregisterLoadOptionsFunc() })
+
+	RegisterLoadOptionsFunc(func(cfg s2.Config) ([]func(*awsconfig.LoadOptions) error, error) {
+		return nil, fmt.Errorf("boom")
+	})
+
+	_, err := NewStorage(context.Background(), s2.Config{Type: s2.TypeS3, Root: "my-bucket"})
+	s.Require().Error(err)
+	s.ErrorContains(err, "boom")
+}
+
+func (s *StorageTestSuite) TestUnregisterLoadOptionsFunc() {
+	RegisterLoadOptionsFunc(func(cfg s2.Config) ([]func(*awsconfig.LoadOptions) error, error) {
+		return nil, fmt.Errorf("should not be called after unregister")
+	})
+	UnregisterLoadOptionsFunc()
+
+	_, err := NewStorage(context.Background(), s2.Config{Type: s2.TypeS3, Root: "my-bucket"})
+	s.Require().NoError(err)
 }
 
 func (s *StorageTestSuite) TestType() {


### PR DESCRIPTION
## Summary

- Adds `s3.RegisterLoadOptionsFunc` / `UnregisterLoadOptionsFunc` (with a `LoadOptionsFunc` type), mirroring the existing `s2.RegisterNewStorageFunc` registry pattern.
- A registered hook can supply extra `awsconfig.LoadOptions` (region, credentials provider, etc.) that `NewStorage` applies when building the AWS config.
- This is the extension point for credential mechanisms s2 does not implement itself — Cognito Identity, STS AssumeRole, or any other federation scheme. Callers build the resolution logic entirely outside s2 and register it; `s2.NewStorage(ctx, cfg)` keeps working as the single generic entry point.

## Test plan

- [x] `go build ./...` and `go vet ./...` pass for both the root and `s3` modules
- [x] `go test ./...` passes, including new table-driven tests for `RegisterLoadOptionsFunc` (applying region/credentials, `nil, nil` no-op, error propagation, unregister)
- [x] `golangci-lint run ./...` reports 0 issues for both modules