### PR TITLE
chore: Bump intra-repo deps to v0.12.0

### DIFF
--- a/azblob/go.mod
+++ b/azblob/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0
-	github.com/mojatter/s2 v0.11.2
+	github.com/mojatter/s2 v0.12.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/gcs/go.mod
+++ b/gcs/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	cloud.google.com/go/storage v1.62.3
-	github.com/mojatter/s2 v0.11.2
+	github.com/mojatter/s2 v0.12.0
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/api v0.286.0
 )

--- a/s2env/go.mod
+++ b/s2env/go.mod
@@ -3,10 +3,10 @@ module github.com/mojatter/s2/s2env
 go 1.25.8
 
 require (
-	github.com/mojatter/s2 v0.11.2
-	github.com/mojatter/s2/azblob v0.11.2
-	github.com/mojatter/s2/gcs v0.11.2
-	github.com/mojatter/s2/s3 v0.11.2
+	github.com/mojatter/s2 v0.12.0
+	github.com/mojatter/s2/azblob v0.12.0
+	github.com/mojatter/s2/gcs v0.12.0
+	github.com/mojatter/s2/s3 v0.12.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/s3/go.mod
+++ b/s3/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.25
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.104.0
-	github.com/mojatter/s2 v0.11.2
+	github.com/mojatter/s2 v0.12.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.24
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.104.0
-	github.com/mojatter/s2 v0.11.2
+	github.com/mojatter/s2 v0.12.0
 	github.com/stretchr/testify v1.11.1
 )
 


### PR DESCRIPTION
## Summary

- Bumps the intra-repo `github.com/mojatter/s2...` require lines in `s3`, `gcs`, `azblob`, `server`, and `s2env` to v0.12.0, ahead of tagging the v0.12.0 release.
- `cmd/s2-server` is intentionally excluded — its build resolves intra-repo deps from the proxy (no `replace`), so it can only require v0.12.0 after that version's tags are published. It will be bumped in a follow-up PR once the tags exist.
- `go.sum` is unchanged: each module's `replace ... => ../` resolves the bumped version locally during this PR.

## Test plan

- [x] `go vet ./...` (workspace) and `go test ./...` (root) pass
- [x] `go test ./...` passes in each of `s3`, `gcs`, `azblob`, `s2env`, `server`, `cmd/s2-server`
- [x] `(cd cmd/s2-server && GOWORK=off go build .)` succeeds (still resolves the previously published v0.11.2 via the proxy)
- [x] `(cd server && GOWORK=off go build ./...)` succeeds
- [x] `(cd s3 && GOWORK=off go test -tags integtest -c -o /tmp/s3it .)` succeeds