### PR TITLE
fix(fs): Make Delete a no-op for missing objects

### DIFF
--- a/fs/storage.go
+++ b/fs/storage.go
@@ -287,7 +287,7 @@ func (s *storage) Move(ctx context.Context, src, dst string) error {
 func (s *storage) Delete(ctx context.Context, name string) error {
 	// Ignore metadata deletion errors (file may not have metadata)
 	_ = wfs.RemoveFile(s.fsys, metaPath(name))
-	if err := wfs.RemoveFile(s.fsys, name); err != nil {
+	if err := wfs.RemoveFile(s.fsys, name); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("failed to delete %q: %w", name, err)
 	}
 	return nil

--- a/s2test/s2test.go
+++ b/s2test/s2test.go
@@ -364,6 +364,11 @@ func TestStorageDelete(ctx context.Context, strg s2.Storage) error {
 		errorf("Delete(%q): object still exists", name)
 	}
 
+	// Deleting a non-existent object is a no-op and must not error.
+	if err := strg.Delete(ctx, name); err != nil {
+		errorf("Delete(%q) on already-deleted object returned %v, want nil", name, err)
+	}
+
 	// Recursive delete
 	files := []string{
 		"s2test-delrec/a.txt",

--- a/server/handlers/s3api/objects_test.go
+++ b/server/handlers/s3api/objects_test.go
@@ -891,7 +891,7 @@ func (s *ObjectsTestSuite) TestDeleteObject() {
 		s.Equal(http.StatusNotFound, getW.Code)
 	})
 
-	s.Run("non-existing key returns error", func() {
+	s.Run("non-existing key is a no-op", func() {
 		s.createBucket("di")
 
 		req := httptest.NewRequest("DELETE", "/di/ghost.txt", nil)
@@ -900,8 +900,8 @@ func (s *ObjectsTestSuite) TestDeleteObject() {
 		w := httptest.NewRecorder()
 		handleDeleteObject(s.server, w, req)
 
-		// fs backend returns error for missing keys
-		s.NotEqual(http.StatusNoContent, w.Code)
+		// S3 DeleteObject is idempotent: deleting a missing key succeeds.
+		s.Equal(http.StatusNoContent, w.Code)
 	})
 }
 
@@ -950,7 +950,7 @@ func (s *ObjectsTestSuite) TestDeleteObjects() {
 		s.Empty(result.Errors)
 	})
 
-	s.Run("nonexistent key reports error", func() {
+	s.Run("nonexistent key is reported as deleted", func() {
 		s.createBucket("de")
 
 		body := `<Delete><Object><Key>ghost.txt</Key></Object></Delete>`
@@ -962,9 +962,11 @@ func (s *ObjectsTestSuite) TestDeleteObjects() {
 		s.Equal(http.StatusOK, w.Code)
 		var result DeleteObjectsResult
 		s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &result))
-		s.Empty(result.Deleted)
-		s.Len(result.Errors, 1)
-		s.Equal("ghost.txt", result.Errors[0].Key)
+		// S3 DeleteObjects is idempotent: a missing key is reported as
+		// deleted, not as an error.
+		s.Len(result.Deleted, 1)
+		s.Equal("ghost.txt", result.Deleted[0].Key)
+		s.Empty(result.Errors)
 	})
 
 	s.Run("nonexistent bucket", func() {


### PR DESCRIPTION
## Summary
- `fs.Storage.Delete` returned `fs.ErrNotExist` (wrapped in a generic error) when the target object did not exist, violating the documented `Storage.Delete` contract that deleting a non-existent object is a no-op.
- This diverged from the `azblob` and `gcs` backends, which already swallow their respective not-found errors.
- Added a case to the shared `s2test.TestStorageDelete` conformance suite so all backends (fs/s3/azblob/gcs) are checked against this contract going forward.
- Updated two `server/handlers/s3api` unit tests that had codified the old buggy behavior (`non-existing key returns error` / `nonexistent key reports error`) to instead assert the correct, idempotent S3 semantics.

## Known limitation
- The `e2e` job builds the `s2` container from `server/Dockerfile`, which uses `GOWORK=off` and therefore pulls the published `fs` module version pinned in `cmd/s2-server/go.mod`, not this branch's code. `e2e` will keep exercising the old behavior until the `fs` module is released and that dependency is bumped in a follow-up.

## Test plan
- [x] `go test ./fs/...`
- [x] `go test ./server/...`
- [x] `golangci-lint run ./fs/... ./s2test/...`
- [x] `golangci-lint run ./...` (server module)