### PR TITLE
chore: Bump intra-repo deps to v0.12.1

### DIFF
--- a/azblob/go.mod
+++ b/azblob/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0
-	github.com/mojatter/s2 v0.12.0
+	github.com/mojatter/s2 v0.12.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/gcs/go.mod
+++ b/gcs/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	cloud.google.com/go/storage v1.62.3
-	github.com/mojatter/s2 v0.12.0
+	github.com/mojatter/s2 v0.12.1
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/api v0.286.0
 )

--- a/s2env/go.mod
+++ b/s2env/go.mod
@@ -3,10 +3,10 @@ module github.com/mojatter/s2/s2env
 go 1.25.8
 
 require (
-	github.com/mojatter/s2 v0.12.0
-	github.com/mojatter/s2/azblob v0.12.0
-	github.com/mojatter/s2/gcs v0.12.0
-	github.com/mojatter/s2/s3 v0.12.0
+	github.com/mojatter/s2 v0.12.1
+	github.com/mojatter/s2/azblob v0.12.1
+	github.com/mojatter/s2/gcs v0.12.1
+	github.com/mojatter/s2/s3 v0.12.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/s3/go.mod
+++ b/s3/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.25
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.104.0
-	github.com/mojatter/s2 v0.12.0
+	github.com/mojatter/s2 v0.12.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.24
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.104.0
-	github.com/mojatter/s2 v0.12.0
+	github.com/mojatter/s2 v0.12.1
 	github.com/stretchr/testify v1.11.1
 )
 


### PR DESCRIPTION
## Summary
- Bump the intra-repo `github.com/mojatter/s2` (and, for s2env, its `s3`/`gcs`/`azblob` deps) requirement to v0.12.1 in the five replace-modules: s3, gcs, azblob, s2env, server.
- `cmd/s2-server` is intentionally excluded — it builds with `GOWORK=off` and can only require a version once its tag is published on the proxy. It will be bumped in a follow-up PR after v0.12.1 is tagged.
- v0.12.1 carries the fs.Storage.Delete no-op fix from #143.

## Test plan
- [x] `go vet ./...` / `go test ./...` (workspace)
- [x] `go test ./...` in s3, gcs, azblob, s2env, server
- [x] `GOWORK=off go build .` in cmd/s2-server (still resolves the published v0.12.0)
- [x] `GOWORK=off go build ./...` in server
- [x] `GOWORK=off go test -tags integtest -c` in s3
- [x] `golangci-lint run ./...` in root and all five bumped modules