### PR TITLE
ci(release): Stop gating GoReleaser on e2e

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,13 +9,21 @@ jobs:
   tests:
     uses: ./.github/workflows/tests.yaml
 
-  e2e:
-    uses: ./.github/workflows/e2e.yaml
-
+  # e2e is intentionally NOT a dependency of `release`. The tagged commit
+  # already ran e2e when it was pushed to main (see e2e.yaml's own
+  # `push: branches: [main]` trigger), so re-running it here only checks
+  # one narrow, unrelated thing: whether cmd/s2-server/go.mod has been
+  # bumped to reference the library tags just published. For releases that
+  # touch library code, that bump (release-s2 skill Step 3) always lands
+  # in a later, separate PR/commit, so this job would be red on every such
+  # release regardless of whether the release is actually broken.
+  # GoReleaser's own build (below) does not depend on cmd/s2-server/go.mod
+  # either: it runs `go build` without GOWORK=off, so go.work resolves
+  # every intra-repo dependency from local source and always produces a
+  # correct binary/Docker image. See docs/releasing.md.
   release:
     needs:
       - tests
-      - e2e
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Remove `e2e` from the `release` job's `needs:` in the Release workflow, and drop the redundant `jobs.e2e` re-run entirely.
- The tagged commit already ran e2e when it was pushed to `main` (`e2e.yaml`'s own `push: branches: [main]` trigger). Re-running it in the Release workflow only checks one narrow thing: whether `cmd/s2-server/go.mod` has been bumped to reference the library tags just published. For any release that ships library code, that bump (release-s2 skill Step 3) always lands in a separate, later PR/commit — so this job would be red on every such release regardless of whether the release itself is broken.
- GoReleaser's own build doesn't depend on `cmd/s2-server/go.mod` either: it runs `go build` without `GOWORK=off`, so `go.work` resolves every intra-repo dependency from local workspace source and always produces a correct binary/Docker image.

## Background
This is the actual root cause behind v0.12.1 never getting a GitHub Release: the root tag triggered this workflow before `cmd/s2-server` was bumped, `e2e` failed exactly as expected (it was correctly reporting that `go install .../cmd/s2-server@v0.12.1` wasn't ready yet), and the `release` job (`needs: [tests, e2e]`) was silently *skipped* — even though GoReleaser would have built and published a correct artifact.

## Test plan
N/A — workflow-only change. Verified by inspection: `tests` (unit/lint) still gates `release`, `e2e` continues to run and gate normal PR/main-branch CI unaffected.