### PR TITLE
docs(releasing): Drop the root-tag decision gate

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -19,7 +19,7 @@ The repo ships several independently tagged Go modules:
 | `github.com/mojatter/s2/cmd/s2-server` | `cmd/s2-server/v*` | Binary entry point. Tagged for `go install` users. |
 
 Only the root tag (`v*`) triggers CI / GoReleaser. The submodule tags
-are publication-only, for `go get`.
+(including `cmd/s2-server/v*`) are publication-only, for `go get`.
 
 ## Release flow (example: v0.11.1)
 
@@ -27,7 +27,16 @@ The flow is **two PRs**. The five modules that carry `replace`
 directives are bumped and tagged first; `cmd/s2-server` (which has no
 `replace`) follows once those tags are published. This is what v0.11.0
 (#119 → #120) and v0.11.1 (#130 → #131) actually did — a single PR that
-also bumps `cmd/s2-server` would fail the e2e build (see step 3).
+also bumps `cmd/s2-server` would fail before the submodule tags exist
+(`go get`/`go mod tidy` can't resolve a version that isn't published
+yet).
+
+Both PRs can be done at your own pace: pushing the root tag right
+after step 2 always produces a correct GitHub Release / Docker image,
+regardless of whether `cmd/s2-server` has been bumped yet (see
+"Why the root tag doesn't need to wait for step 3" below). Step 3 has
+no urgency — it only affects `go install .../cmd/s2-server@vX.Y.Z`,
+not what step 2 already published.
 
 ### 1. Bump the replace-module `go.mod` files
 
@@ -47,19 +56,13 @@ green before any new tag exists. Don't run `go mod tidy` on the branch
 
 Merge the PR.
 
-### 2. Tag the five submodules, push (root tag not yet)
+### 2. Tag all six, push (submodules batched, root alone)
 
-Before tagging anything, decide: does this release contain library
-*code* (not just a dependency bump) that `cmd/s2-server`'s binary must
-actually run — e.g. a fix under `fs/`, `server/`, or root package code?
-If unsure, treat it as yes. This decides whether the root tag goes out
-now (below) or after step 3 (see the decision gate at the end of this
-section).
-
-Create the five submodule tags at the merge commit (**not** root,
-**not** `cmd/s2-server`):
+At the merge commit, create the root tag plus the five submodule tags
+(**not** `cmd/s2-server` — it isn't bumped yet):
 
 ```sh
+git tag -a v0.11.1        -m "Release v0.11.1"
 git tag -a s3/v0.11.1     -m "Release s3/v0.11.1"
 git tag -a gcs/v0.11.1    -m "Release gcs/v0.11.1"
 git tag -a azblob/v0.11.1 -m "Release azblob/v0.11.1"
@@ -67,53 +70,37 @@ git tag -a s2env/v0.11.1  -m "Release s2env/v0.11.1"
 git tag -a server/v0.11.1 -m "Release server/v0.11.1"
 ```
 
-Push them, batched:
+Push the submodule tags first, then the root tag **separately**:
 
 ```sh
 git push origin s3/v0.11.1 gcs/v0.11.1 azblob/v0.11.1 s2env/v0.11.1 server/v0.11.1
+git push origin v0.11.1
 ```
 
-**Decision gate — root tag now, or after step 3?**
+The root tag must be pushed alone — pushing multiple tags in a single
+`git push` has occasionally failed to fire GitHub Actions. Pushing the
+root tag triggers the release workflow: `tests` (unit tests + lint)
+gates GoReleaser, but e2e does not (see below), so this always
+produces a correct GitHub Release / Docker image. Proceed to step 3
+whenever.
 
-- **Pure dependency/security bump** (nothing under `cmd/s2-server`'s
-  own linked library code changed in a way the binary must pick up) →
-  push the root tag now:
+#### Why the root tag doesn't need to wait for step 3
 
-  ```sh
-  git tag -a v0.11.1 -m "Release v0.11.1"
-  git push origin v0.11.1
-  ```
-
-  The root tag must be pushed alone — pushing multiple tags in a
-  single `git push` has occasionally failed to fire GitHub Actions.
-  This triggers GoReleaser. At this commit `cmd/s2-server` still
-  requires the **previous** release's intra-repo versions (it is
-  bumped in step 3), so the binary links the previous version of the
-  library code. That is fine here: the dependency is pinned directly
-  in `cmd/s2-server/go.mod` (e.g. `golang.org/x/net`), and MVS picks
-  the higher version from `cmd/s2-server`'s own requires regardless of
-  the library versions. Proceed to step 3 whenever.
-
-- **Ships library code `cmd/s2-server`'s binary must include** → do
-  **not** push the root tag yet. Go to step 3 first, merge it, and
-  push the root tag from there instead. Pushing root here would make
-  the release workflow's own e2e job build `cmd/s2-server` against the
-  *old*, not-yet-bumped code, fail, and silently skip the GoReleaser
-  job — producing no binary/Docker image for that tag. Tags are
-  immutable once `proxy.golang.org` caches them, so recovering costs a
-  whole extra patch version, not just a retry (see Gotchas below).
+GoReleaser builds without `GOWORK=off`, so `go.work` resolves everything
+from local source, not `cmd/s2-server/go.mod`'s pins. The published
+binary/Docker image is always correct. Only `go install
+.../cmd/s2-server@vX.Y.Z` and the e2e Docker build (which sets
+`GOWORK=off` on purpose) depend on step 3 — and neither gates the release.
 
 ### 3. Bump `cmd/s2-server` (after the submodule tags are published)
 
 `cmd/s2-server` has no `replace` directives, so its `GOWORK=off` build
-— the e2e image (`server/Dockerfile` builds `cmd/s2-server`) and the
-GoReleaser binary — resolves intra-repo deps from `proxy.golang.org`.
-It can only require the new version once steps 1–2 have published the
-submodule tags; bumping it earlier breaks the e2e build, which cannot
-fetch the not-yet-published version.
+— the e2e image (`server/Dockerfile` builds `cmd/s2-server`) — resolves
+intra-repo deps from `proxy.golang.org`. It can only require the new
+version once steps 1–2 have published the tags; bumping it earlier
+breaks that resolution.
 
-Open a follow-up PR (the submodule tags now exist, so `go get`
-resolves them):
+Open a follow-up PR (the tags now exist, so `go get` resolves them):
 
 ```sh
 cd cmd/s2-server
@@ -126,22 +113,14 @@ GOWORK=off go get \
 GOWORK=off go mod tidy
 ```
 
-Merge it, then tag `cmd/s2-server` at the merge commit and push
-(publication-only, no workflow):
+Merge it, then tag at the merge commit and push:
 
 ```sh
 git tag -a cmd/s2-server/v0.11.1 -m "Release cmd/s2-server/v0.11.1"
 git push origin cmd/s2-server/v0.11.1
 ```
 
-If the root tag was deliberately deferred (library-code case in step
-2), push it now, at this same merge commit, so the release workflow's
-e2e job builds `cmd/s2-server` with the fix already in place:
-
-```sh
-git tag -a v0.11.1 -m "Release v0.11.1"
-git push origin v0.11.1
-```
+`cmd/s2-server/v*` is publication-only and triggers no workflow.
 
 ### 4. Replace the auto-generated release notes
 
@@ -182,37 +161,38 @@ A `200 OK` means the content is cached. If you tagged with a stale
 `go.mod`, the recovery path is to cut a new patch version (`v0.11.1`)
 and add `retract v0.11.0` to the respective `go.mod`.
 
-**Incident (2026-07-02, v0.12.1/v0.12.2):** a bugfix release (the
-`fs.Storage.Delete` no-op fix) pushed the root tag right after step 2,
-before step 3. The release workflow's e2e job built `cmd/s2-server`
-from the still-unbumped `go.mod` — pre-fix code — failed, and the
-GoReleaser job (`needs: [tests, e2e]`) was silently *skipped*, not
-failed. No GitHub Release or Docker image was published for v0.12.1,
-and that tag couldn't be reused. Recovery required a full extra patch
-version (v0.12.2): the `cmd/s2-server` bump PR was merged first, then
-the root tag was cut at that later commit. The decision gate in step 2
-above exists so this ordering mistake is caught before any tag is
-pushed, not after.
-
 ### `GOWORK=off` paths bypass the workspace
 
-`go mod tidy` and the production Docker build (`server/Dockerfile.goreleaser`,
-which sets `GOWORK=off`) both ignore `go.work` and resolve intra-repo
-deps through `proxy.golang.org`. CI is configured to use `go test`
-without a preceding `go mod tidy`, so the bump PR passes even before
-the new tags are published. But:
+`go mod tidy` and the e2e Docker build (`server/Dockerfile`, which sets
+`GOWORK=off`) both ignore `go.work` and resolve intra-repo deps through
+`proxy.golang.org`. CI is configured to use `go test` without a
+preceding `go mod tidy`, so the bump PR passes even before the new tags
+are published. Running `go mod tidy` locally on the bump branch will
+fail until the new tags exist — run it after pushing tags (that's what
+step 3 does), or skip it entirely (CI will accept your branch).
 
-- Running `go mod tidy` locally on the bump branch will fail until the
-  new tags exist. Run it after pushing tags, or skip it (CI will
-  accept your branch).
-- The GoReleaser binary build relies on `cmd/s2-server/go.mod`'s
-  pinned requires, which are bumped in step 3 (after tagging). At the
-  root tag the binary therefore still links the previous library
-  version; step 2 explains why that is acceptable for
-  dependency/security bumps and when to reorder.
+GoReleaser's own build does **not** use `GOWORK=off` — it resolves via
+`go.work` from local source, so it never depends on
+`cmd/s2-server/go.mod`'s pins. Only the e2e Docker image and
+`go install .../cmd/s2-server@vX.Y.Z` do, and neither gates `release`.
 
 ### Multi-tag push can miss webhooks
 
 Pushing several tags in one `git push` has occasionally failed to
 trigger the corresponding GitHub Actions workflow. Push the root `v*`
 tag alone; non-trigger submodule tags can be batched.
+
+### Incident (2026-07-02, v0.12.1 → v0.12.3)
+
+`release` used to depend on `needs: [tests, e2e]`. e2e's `GOWORK=off`
+Docker build always fails until step 3 bumps `cmd/s2-server` — which
+lands in a later commit than the root tag by construction. So v0.12.1's
+root tag made e2e fail as expected, `release` was silently *skipped*,
+and no GitHub Release was published even though GoReleaser would have
+built a correct one. Recovery cost a wasted patch version (v0.12.2, then
+v0.12.3), since an un-released tag can't be reused.
+
+Fix (#149): drop `e2e` from `release`'s `needs:`. It never protected the
+artifact (GoReleaser doesn't use `GOWORK=off`) and the same commit
+already passed e2e on its regular `main` push. That's why step 2 no
+longer needs a decision gate.


### PR DESCRIPTION
## Summary
- Remove the Step-2 "decision gate" (does this release ship library code the binary must include?) added after the v0.12.1 incident. It's obsolete: #149 removed `e2e` from the release workflow's `needs:`, so pushing the root tag right after the submodule tags always produces a correct GitHub Release / Docker image, regardless of what the release contains.
- Restore the simpler flow: tag root + five submodules together in step 2, bump `cmd/s2-server` in step 3 at no particular urgency.
- Add a short "Why the root tag doesn't need to wait for step 3" explanation (GoReleaser doesn't use `GOWORK=off`, so it never depends on `cmd/s2-server/go.mod`'s pins).
- Rewrite the incident note to describe the actual root cause and fix (#149) instead of the abandoned decision-gate workaround.

## Test plan
N/A — documentation only.