### PR TITLE
chore: Bump intra-repo deps to v0.12.4

### DIFF
--- a/azblob/go.mod
+++ b/azblob/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0
-	github.com/mojatter/s2 v0.12.3
+	github.com/mojatter/s2 v0.12.4
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/gcs/go.mod
+++ b/gcs/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	cloud.google.com/go/storage v1.63.0
-	github.com/mojatter/s2 v0.12.3
+	github.com/mojatter/s2 v0.12.4
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/api v0.287.0
 )

--- a/s2env/go.mod
+++ b/s2env/go.mod
@@ -3,10 +3,10 @@ module github.com/mojatter/s2/s2env
 go 1.25.8
 
 require (
-	github.com/mojatter/s2 v0.12.3
-	github.com/mojatter/s2/azblob v0.12.3
-	github.com/mojatter/s2/gcs v0.12.3
-	github.com/mojatter/s2/s3 v0.12.3
+	github.com/mojatter/s2 v0.12.4
+	github.com/mojatter/s2/azblob v0.12.4
+	github.com/mojatter/s2/gcs v0.12.4
+	github.com/mojatter/s2/s3 v0.12.4
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/s3/go.mod
+++ b/s3/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.27
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.104.2
 	github.com/aws/smithy-go v1.27.3
-	github.com/mojatter/s2 v0.12.3
+	github.com/mojatter/s2 v0.12.4
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.26
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.104.2
 	github.com/chromedp/chromedp v0.14.2
-	github.com/mojatter/s2 v0.12.3
+	github.com/mojatter/s2 v0.12.4
 	github.com/stretchr/testify v1.11.1
 )
 


### PR DESCRIPTION
## Summary
- Bump the intra-repo dependency versions in s3, gcs, azblob, s2env, and server go.mod files to v0.12.4, ahead of the v0.12.4 release.
- cmd/s2-server is intentionally excluded here; it will be bumped in a follow-up PR once the submodule tags are published.

## Test plan
- [x] go vet ./... / go test ./... at root and in each submodule
- [x] GOWORK=off go build in cmd/s2-server and server (still resolving against published v0.12.3)
- [x] GOWORK=off go test -tags integtest -c in s3