### PR TITLE
fix(makefile): Add server to test target submodule loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build:
 .PHONY: test
 test:
 	go test -short ./...
-	@for dir in s3 gcs azblob s2env cmd/s2-server; do \
+	@for dir in s3 gcs azblob s2env server cmd/s2-server; do \
 		echo "=== Testing $$dir ==="; \
 		(cd $$dir && go test -short ./...); \
 	done


### PR DESCRIPTION
## Summary
- The `make test` submodule loop was missing `server`, even though it's a workspace module and CI's tests.yaml already covers it.

## Test plan
- [x] `make test` passes, including the `server` submodule