### PR TITLE
chore: Bump intra-repo deps to v0.12.5

### DIFF
--- a/azblob/go.mod
+++ b/azblob/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0
-	github.com/mojatter/s2 v0.12.4
+	github.com/mojatter/s2 v0.12.5
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/gcs/go.mod
+++ b/gcs/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	cloud.google.com/go/storage v1.64.0
-	github.com/mojatter/s2 v0.12.4
+	github.com/mojatter/s2 v0.12.5
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/api v0.290.0
 )

--- a/s2env/go.mod
+++ b/s2env/go.mod
@@ -3,10 +3,10 @@ module github.com/mojatter/s2/s2env
 go 1.25.8
 
 require (
-	github.com/mojatter/s2 v0.12.4
-	github.com/mojatter/s2/azblob v0.12.4
-	github.com/mojatter/s2/gcs v0.12.4
-	github.com/mojatter/s2/s3 v0.12.4
+	github.com/mojatter/s2 v0.12.5
+	github.com/mojatter/s2/azblob v0.12.5
+	github.com/mojatter/s2/gcs v0.12.5
+	github.com/mojatter/s2/s3 v0.12.5
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/s3/go.mod
+++ b/s3/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.31
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.106.0
 	github.com/aws/smithy-go v1.27.4
-	github.com/mojatter/s2 v0.12.4
+	github.com/mojatter/s2 v0.12.5
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.30
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.106.0
 	github.com/chromedp/chromedp v0.16.0
-	github.com/mojatter/s2 v0.12.4
+	github.com/mojatter/s2 v0.12.5
 	github.com/stretchr/testify v1.11.1
 )
 


### PR DESCRIPTION
## Summary
- Prepares the v0.12.5 patch release: bumps the intra-repo `github.com/mojatter/s2` (and, for s2env, s3/gcs/azblob) require lines in the five replace-modules to v0.12.5.
- `cmd/s2-server` is intentionally excluded here; it's bumped in a follow-up PR after the submodule tags are published (see docs/releasing.md).

## Test plan
- [x] `go vet ./...` and `go test ./...` at the workspace root
- [x] `go test ./...` in s3, gcs, azblob, s2env, server, cmd/s2-server
- [x] `GOWORK=off go build .` in cmd/s2-server (against the previous published version)
- [x] `GOWORK=off go build ./...` in server
- [x] `GOWORK=off go test -tags integtest -c` in s3