### PR TITLE
fix(ci): Point release workflow's Set up Go at go.work

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version-file: cmd/s2-server/go.mod
+          go-version-file: go.work
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v4


### PR DESCRIPTION
## Summary
- GoReleaser's `builds` step (`.goreleaser.yaml`) runs in workspace mode (no `GOWORK=off`), so the release job's runner must have a Go toolchain satisfying `go.work`'s directive, not `cmd/s2-server/go.mod`'s deliberately-lagging one (see docs/releasing.md's two-PR flow).
- `go.work`'s directive was bumped to `1.26` in #157 (following `server`'s chromedp-driven bump in #156), and `tests.yaml` was repointed at `go.work` in that same PR — but `release.yaml` was missed.
- v0.12.5's root tag push hit this: GoReleaser failed immediately with `go.work requires go >= 1.26 (running go 1.25.8; GOTOOLCHAIN=local)`, and no GitHub Release was published.

## Test plan
- [x] Confirmed `tests.yaml` already uses this same pattern successfully in CI
- [x] `actions/setup-go` supports `go-version-file` pointing at a `go.work` file