### PR TITLE
fix(server): Explicitly allow Authorization in CORS preflight response

### DIFF
--- a/server/s3api.go
+++ b/server/s3api.go
@@ -30,7 +30,7 @@ func corsHandler(next http.Handler) http.Handler {
 		h := w.Header()
 		h.Set("Access-Control-Allow-Origin", "*")
 		h.Set("Access-Control-Allow-Methods", "GET, PUT, POST, DELETE, HEAD, OPTIONS")
-		h.Set("Access-Control-Allow-Headers", "*")
+		h.Set("Access-Control-Allow-Headers", "Authorization, *")
 		h.Set("Access-Control-Max-Age", "86400")
 
 		if r.Method == http.MethodOptions {

--- a/server/s3api_test.go
+++ b/server/s3api_test.go
@@ -149,7 +149,10 @@ func TestCORSHandler(t *testing.T) {
 			assert.Equal(t, tc.wantHandlerHit, handlerHit)
 			assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
 			assert.NotEmpty(t, w.Header().Get("Access-Control-Allow-Methods"))
-			assert.NotEmpty(t, w.Header().Get("Access-Control-Allow-Headers"))
+			// Access-Control-Allow-Headers: "*" alone does not cover the
+			// Authorization request header per the Fetch spec, so it must
+			// be listed explicitly for browser SigV4 requests to work.
+			assert.Contains(t, w.Header().Get("Access-Control-Allow-Headers"), "Authorization")
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- `Access-Control-Allow-Headers: *` does not cover the `Authorization` request header per the Fetch spec, so browser requests signed with SigV4 (aws-sdk `listObjectsV2`, `headObject`, `deleteObjects`, `upload`, ...) were rejected by CORS preflight even though the wildcard was set.
- `Authorization` is now listed explicitly alongside the wildcard in `corsHandler` (server/s3api.go).

## Test plan
- [x] `go test ./server/...`
- [x] `golangci-lint run ./server/...`