### PR TITLE
chore: Bump intra-repo deps to v0.12.7

### DIFF
--- a/azblob/go.mod
+++ b/azblob/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0
-	github.com/mojatter/s2 v0.12.6
+	github.com/mojatter/s2 v0.12.7
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/gcs/go.mod
+++ b/gcs/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	cloud.google.com/go/storage v1.64.0
-	github.com/mojatter/s2 v0.12.6
+	github.com/mojatter/s2 v0.12.7
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/api v0.291.0
 )

--- a/s2env/go.mod
+++ b/s2env/go.mod
@@ -3,10 +3,10 @@ module github.com/mojatter/s2/s2env
 go 1.25.8
 
 require (
-	github.com/mojatter/s2 v0.12.6
-	github.com/mojatter/s2/azblob v0.12.6
-	github.com/mojatter/s2/gcs v0.12.6
-	github.com/mojatter/s2/s3 v0.12.6
+	github.com/mojatter/s2 v0.12.7
+	github.com/mojatter/s2/azblob v0.12.7
+	github.com/mojatter/s2/gcs v0.12.7
+	github.com/mojatter/s2/s3 v0.12.7
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/s3/go.mod
+++ b/s3/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.35
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.107.0
 	github.com/aws/smithy-go v1.27.6
-	github.com/mojatter/s2 v0.12.6
+	github.com/mojatter/s2 v0.12.7
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.34
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.107.0
 	github.com/chromedp/chromedp v0.16.0
-	github.com/mojatter/s2 v0.12.6
+	github.com/mojatter/s2 v0.12.7
 	github.com/stretchr/testify v1.11.1
 )
 


### PR DESCRIPTION
## Summary
- Bump the intra-repo `github.com/mojatter/s2...` require lines to v0.12.7 in the five replace-modules (`s3`, `gcs`, `azblob`, `server`, `s2env`).
- `cmd/s2-server` is excluded; it bumps in a follow-up PR after the v0.12.7 submodule tags are published (see docs/releasing.md).

## Test plan
- [x] `go vet ./...`
- [x] `go test ./...` (root and each submodule)
- [x] `GOWORK=off go build .` in `cmd/s2-server` (still on v0.12.6, published)
- [x] `GOWORK=off go build ./...` in `server`
- [x] `GOWORK=off go test -tags integtest -c` in `s3`
- [x] `goreleaser release --snapshot --clean --skip=publish --skip=docker`