### PR TITLE
fix(e2e): Use go.work for e2e server image builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+.git
+
+# Code coverage profiles and other test artifacts
+*.out
+coverage.*
+*.coverprofile
+profile.cov
+
+# Editor/IDE
+.idea/
+.vscode/
+.claude/
+
+# goreleaser
+dist/
+
+# build output
+bin/
+
+# default data directory
+data/
+
+.DS_Store

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,16 +11,14 @@ jobs:
 
   # e2e is intentionally NOT a dependency of `release`. The tagged commit
   # already ran e2e when it was pushed to main (see e2e.yaml's own
-  # `push: branches: [main]` trigger), so re-running it here only checks
-  # one narrow, unrelated thing: whether cmd/s2-server/go.mod has been
-  # bumped to reference the library tags just published. For releases that
-  # touch library code, that bump (release-s2 skill Step 3) always lands
-  # in a later, separate PR/commit, so this job would be red on every such
-  # release regardless of whether the release is actually broken.
-  # GoReleaser's own build (below) does not depend on cmd/s2-server/go.mod
-  # either: it runs `go build` without GOWORK=off, so go.work resolves
-  # every intra-repo dependency from local source and always produces a
-  # correct binary/Docker image. See docs/releasing.md.
+  # `push: branches: [main]` trigger). e2e's server images build with
+  # go.work in scope (see s2test/e2e/docker-compose.yml), so they no
+  # longer depend on cmd/s2-server/go.mod having been bumped to the
+  # tags this release just published — but gating on e2e still buys
+  # nothing here: GoReleaser's own build (below) doesn't depend on
+  # cmd/s2-server/go.mod either, since it runs `go build` without
+  # GOWORK=off and resolves every intra-repo dependency from local
+  # source via go.work. See docs/releasing.md.
   release:
     needs:
       - tests

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -80,25 +80,27 @@ git push origin v0.11.1
 The root tag must be pushed alone — pushing multiple tags in a single
 `git push` has occasionally failed to fire GitHub Actions. Pushing the
 root tag triggers the release workflow: `tests` (unit tests + lint)
-gates GoReleaser, but e2e does not (see below), so this always
-produces a correct GitHub Release / Docker image. Proceed to step 3
-whenever.
+gates GoReleaser; e2e isn't part of this workflow at all, so this
+always produces a correct GitHub Release / Docker image. Proceed to
+step 3 whenever.
 
 #### Why the root tag doesn't need to wait for step 3
 
 GoReleaser builds without `GOWORK=off`, so `go.work` resolves everything
 from local source, not `cmd/s2-server/go.mod`'s pins. The published
-binary/Docker image is always correct. Only `go install
-.../cmd/s2-server@vX.Y.Z` and the e2e Docker build (which sets
-`GOWORK=off` on purpose) depend on step 3 — and neither gates the release.
+binary/Docker image is always correct. The e2e Docker build
+(`server/Dockerfile`) also builds with `go.work` in scope (see
+"`GOWORK=off` paths bypass the workspace" below), so it doesn't depend
+on step 3 either. Only `go install .../cmd/s2-server@vX.Y.Z` does — and
+it doesn't gate the release.
 
 ### 3. Bump `cmd/s2-server` (after the submodule tags are published)
 
-`cmd/s2-server` has no `replace` directives, so its `GOWORK=off` build
-— the e2e image (`server/Dockerfile` builds `cmd/s2-server`) — resolves
-intra-repo deps from `proxy.golang.org`. It can only require the new
-version once steps 1–2 have published the tags; bumping it earlier
-breaks that resolution.
+`cmd/s2-server` has no `replace` directives, so a plain `GOWORK=off`
+build of it resolves intra-repo deps from `proxy.golang.org`. It can
+only require the new version once steps 1–2 have published the tags;
+bumping it earlier breaks that resolution — this fails at `go get`/`go
+mod tidy` time, on your machine, before you can even open the PR.
 
 Open a follow-up PR (the tags now exist, so `go get` resolves them):
 
@@ -163,18 +165,31 @@ and add `retract v0.11.0` to the respective `go.mod`.
 
 ### `GOWORK=off` paths bypass the workspace
 
-`go mod tidy` and the e2e Docker build (`server/Dockerfile`, which sets
-`GOWORK=off`) both ignore `go.work` and resolve intra-repo deps through
+`go mod tidy` ignores `go.work` and resolves intra-repo deps through
 `proxy.golang.org`. CI is configured to use `go test` without a
 preceding `go mod tidy`, so the bump PR passes even before the new tags
 are published. Running `go mod tidy` locally on the bump branch will
 fail until the new tags exist — run it after pushing tags (that's what
 step 3 does), or skip it entirely (CI will accept your branch).
 
-GoReleaser's own build does **not** use `GOWORK=off` — it resolves via
-`go.work` from local source, so it never depends on
-`cmd/s2-server/go.mod`'s pins. Only the e2e Docker image and
-`go install .../cmd/s2-server@vX.Y.Z` do, and neither gates `release`.
+`server/Dockerfile` defaults to `GOWORK=off` too — that's what `go
+install .../cmd/s2-server@vX.Y.Z` depends on, and why it needs step 3.
+But the e2e compose builds (`s2test/e2e/docker-compose.yml`) override
+this to `GOWORK=/app/go.work`, so e2e exercises in-repo module changes
+before they're tagged/released — this was added so a PR can add a
+feature and its e2e coverage together instead of splitting across the
+step-3 boundary. One side effect: e2e no longer fails when
+`cmd/s2-server/go.mod` is stale relative to the tags steps 1–2 just
+published (previously it did, as an unenforced byproduct of
+`GOWORK=off` — see the 2026-07-02 incident below). That's an acceptable
+trade: `release` never depended on that failure either, and a stale
+`cmd/s2-server/go.mod` still fails loudly at `go get`/`go mod tidy`
+time in step 3 itself.
+
+GoReleaser's own build does **not** use `GOWORK=off` either — it
+resolves via `go.work` from local source, so it never depends on
+`cmd/s2-server/go.mod`'s pins. Only `go install
+.../cmd/s2-server@vX.Y.Z` does now, and it doesn't gate `release`.
 
 ### Multi-tag push can miss webhooks
 
@@ -196,3 +211,8 @@ Fix (#149): drop `e2e` from `release`'s `needs:`. It never protected the
 artifact (GoReleaser doesn't use `GOWORK=off`) and the same commit
 already passed e2e on its regular `main` push. That's why step 2 no
 longer needs a decision gate.
+
+Update: since e2e's server images switched to `GOWORK=/app/go.work`
+(see "`GOWORK=off` paths bypass the workspace" above), this specific
+failure mode — e2e red during the step 2 → step 3 window — no longer
+occurs at all, on top of no longer being gated on.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -191,6 +191,22 @@ resolves via `go.work` from local source, so it never depends on
 `cmd/s2-server/go.mod`'s pins. Only `go install
 .../cmd/s2-server@vX.Y.Z` does now, and it doesn't gate `release`.
 
+### `server/Dockerfile`'s Go version must satisfy `go.work`, not just `cmd/s2-server/go.mod`
+
+Before e2e switched to `GOWORK=/app/go.work` (above), `server/Dockerfile`
+always built with `GOWORK=off`, so its `FROM golang:X.Y-alpine` only had
+to satisfy `cmd/s2-server/go.mod`'s own `go` directive — independent of
+`go.work`'s. Now that the e2e compose builds resolve in workspace mode,
+that same base image must also satisfy `go.work`'s `go` directive, the
+same constraint GoReleaser's build already has.
+
+Practical effect: if a release bumps `go.work`'s `go` directive (any
+module's `go` directive moving up forces the workspace minimum up),
+bump `server/Dockerfile`'s `FROM golang` line in the **same** PR that
+bumps `go.work` — step 1, not step 3. Waiting until step 3 (when
+`cmd/s2-server/go.mod` happens to catch up) leaves e2e on `main` broken
+from the moment the step 1 PR merges.
+
 ### Multi-tag push can miss webhooks
 
 Pushing several tags in one `git push` has occasionally failed to

--- a/s2test/e2e/docker-compose.yml
+++ b/s2test/e2e/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: ../..
       dockerfile: server/Dockerfile
+      args:
+        GOWORK: "/app/go.work"
     environment:
       S2_SERVER_LISTEN: ":9000"
       S2_SERVER_USER: "testkey"
@@ -15,6 +17,8 @@ services:
     build:
       context: ../..
       dockerfile: server/Dockerfile
+      args:
+        GOWORK: "/app/go.work"
     environment:
       S2_SERVER_LISTEN: ":9000"
       S2_SERVER_TYPE: "memfs"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,13 +1,20 @@
 FROM golang:1.26-alpine AS builder
+# Source is COPYed rather than bind-mounted so that GOWORK=on (see below)
+# can freely rewrite go.work.sum inside the image layer without ever
+# touching the host checkout.
+COPY . /app
 WORKDIR /app/cmd/s2-server
 # DefaultRoot is overridden via -ldflags so the Docker image defaults to
 # /var/lib/s2 while a bare "go install" binary keeps the friendlier
 # relative "./data" default (see server/config.go).
-# GOWORK=off disables workspace mode so the build does not try to update
-# go.work.sum on the read-only --mount; production builds use the
-# published module versions from cmd/s2-server/go.mod, not workspace
-# replacements.
-RUN --mount=target=/app GOOS=linux CGO_ENABLED=0 GOWORK=off \
+# GOWORK is off by default so production builds use the published module
+# versions from cmd/s2-server/go.mod, not workspace replacements - this
+# is what a "go install" of the tagged release would actually resolve to.
+# E2E builds (see s2test/e2e) override this to /app/go.work via the
+# GOWORK build arg so they exercise in-repo module changes that haven't
+# been tagged/released yet.
+ARG GOWORK=off
+RUN GOOS=linux CGO_ENABLED=0 GOWORK=${GOWORK} \
     go build \
       -ldflags "-s -w -X github.com/mojatter/s2/server.DefaultRoot=/var/lib/s2" \
       -o /s2-server .


### PR DESCRIPTION
## Summary
- `server/Dockerfile`'s e2e builds previously resolved intra-repo modules (e.g. `server/`) via `cmd/s2-server/go.mod`'s pinned, published versions (`GOWORK=off`), so a PR that adds a feature to an in-repo module plus e2e coverage for it in the same PR would fail until that module was tagged and released.
- The e2e compose services (`s2`, `s2-mem`) now build with `GOWORK=/app/go.work`, resolving from local source instead. Production builds are unaffected (`GOWORK=off` remains the default).
- Switched the build from a bind `--mount` to `COPY . /app` so workspace mode can freely rewrite `go.work.sum` inside the image layer without touching the host checkout, and added `.dockerignore` so that `COPY` doesn't bake `.git`, `bin/`, `data/`, coverage artifacts, etc. into the image.
- Updated `docs/releasing.md` and the `release.yaml` comment, which both described the old `GOWORK=off` e2e behavior as a signal for a stale `cmd/s2-server/go.mod` — that signal no longer exists, though `go get`/`go mod tidy` still fail loudly at step 3 if the tags aren't published yet.

## Test plan
- [x] `docker build -f server/Dockerfile .` (default `GOWORK=off`) builds and runs
- [x] `docker compose -f s2test/e2e/docker-compose.yml build s2` (`GOWORK=/app/go.work`) builds and runs
- [x] `make test-e2e` passes
- [x] Confirmed `go.work.sum` on the host is untouched after building either path