### PR TITLE
feat(server): Add multi-user authentication and IAM-style policy authorization

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -256,6 +256,7 @@ github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvM
 github.com/spf13/afero v1.10.0/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
 github.com/spf13/afero v1.15.0/go.mod h1:NC2ByUVxtQs4b3sIUphxK0NioZnmxgyCrfzeuq8lxMg=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/objx v0.5.3/go.mod h1:rDQraq+vQZU7Fde9LOZLr8Tax6zZvy4kuNKF+QYS+U0=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zeebo/errs v1.4.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
@@ -282,4 +283,5 @@ google.golang.org/genproto/googleapis/bytestream v0.0.0-20260319201613-d00831a3d
 google.golang.org/genproto/googleapis/bytestream v0.0.0-20260610212136-7ab31c22f7ad/go.mod h1:6TABGosqSqU2l1+fJ3jdvOYPPVryeKybxYF0cCZkTBE=
 google.golang.org/genproto/googleapis/bytestream v0.0.0-20260630182238-925bb5da69e7/go.mod h1:6TABGosqSqU2l1+fJ3jdvOYPPVryeKybxYF0cCZkTBE=
 google.golang.org/genproto/googleapis/bytestream v0.0.0-20260706201446-f0a921348800/go.mod h1:MS5Wgu4uvm+nhCBwXzKEpYKPawaaNNUT7WfgpH44YVQ=
+google.golang.org/genproto/googleapis/bytestream v0.0.0-20260807164820-c8921c73eeea/go.mod h1:zpqRtTwVou7odpidkkHm+GTCum9L4nuS3SvU5rrEeik=
 google.golang.org/grpc/examples v0.0.0-20250407062114-b368379ef8f6/go.mod h1:6ytKWczdvnpnO+m+JiG9NjEDzR1FJfsnmJdG7B8QVZ8=

--- a/s2test/e2e/docker-compose.yml
+++ b/s2test/e2e/docker-compose.yml
@@ -29,6 +29,8 @@ services:
     build:
       context: ../..
       dockerfile: server/Dockerfile
+      args:
+        GOWORK: "/app/go.work"
     environment:
       S2_SERVER_CONFIG: "/etc/s2/config.json"
     volumes:

--- a/s2test/e2e/docker-compose.yml
+++ b/s2test/e2e/docker-compose.yml
@@ -25,12 +25,25 @@ services:
       S2_SERVER_USER: "testkey"
       S2_SERVER_PASSWORD: "testsecret"
 
+  s2-users:
+    build:
+      context: ../..
+      dockerfile: server/Dockerfile
+    environment:
+      S2_SERVER_CONFIG: "/etc/s2/config.json"
+    volumes:
+      - ./users-config.json:/etc/s2/config.json:ro
+    tmpfs:
+      - /var/lib/s2
+
   test:
     image: amazon/aws-cli
     depends_on:
       s2:
         condition: service_started
       s2-mem:
+        condition: service_started
+      s2-users:
         condition: service_started
     environment:
       AWS_ACCESS_KEY_ID: "testkey"

--- a/s2test/e2e/run.sh
+++ b/s2test/e2e/run.sh
@@ -3,6 +3,7 @@ set -eu
 
 ENDPOINT="http://s2:9000"
 ENDPOINT_MEM="http://s2-mem:9000"
+ENDPOINT_USERS="http://s2-users:9000"
 
 aws_s3() {
   aws s3 --endpoint-url "$ENDPOINT" "$@"
@@ -29,8 +30,29 @@ wait_for_server() {
   exit 1
 }
 
+wait_for_server_as() {
+  name="$1"
+  key="$2"
+  secret="$3"
+  ep="$4"
+  echo "==> Waiting for $name..."
+  i=0
+  while [ "$i" -lt 30 ]; do
+    if AWS_ACCESS_KEY_ID="$key" AWS_SECRET_ACCESS_KEY="$secret" \
+        aws s3api --endpoint-url "$ep" list-buckets >/dev/null 2>&1; then
+      echo "    $name is ready."
+      return 0
+    fi
+    i=$((i + 1))
+    sleep 1
+  done
+  echo "FAIL: $name did not become ready"
+  exit 1
+}
+
 wait_for_server "s2 (osfs)" "$ENDPOINT"
 wait_for_server "s2-mem" "$ENDPOINT_MEM"
+wait_for_server_as "s2-users" "rootkey" "rootsecret" "$ENDPOINT_USERS"
 
 passed=0
 failed=0
@@ -243,6 +265,67 @@ run_test "Memfs_MultipartUploadStreams" sh -c '
   src=$(sha256sum /tmp/mp.bin | cut -d" " -f1)
   dst=$(sha256sum /tmp/mp.out | cut -d" " -f1)
   [ "$src" = "$dst" ]
+'
+
+# === Multi-user auth + IAM policy (s2-users) ===
+# rootkey has no Policy attached (legacy full-access user); readonlykey is
+# restricted to s3:ListAllMyBuckets / s3:ListBucket / s3:GetObject via the
+# policy in users-config.json (mirrors the read-only example from
+# https://github.com/mojatter/s2/issues/162).
+
+run_test "Users_RootCreateBucket" sh -c '
+  AWS_ACCESS_KEY_ID=rootkey AWS_SECRET_ACCESS_KEY=rootsecret \
+    aws s3api --endpoint-url "'"$ENDPOINT_USERS"'" create-bucket --bucket users-bucket
+'
+
+run_test "Users_RootPutObject" sh -c '
+  echo -n "root-owned object" | \
+  AWS_ACCESS_KEY_ID=rootkey AWS_SECRET_ACCESS_KEY=rootsecret \
+    aws s3 --endpoint-url "'"$ENDPOINT_USERS"'" cp - s3://users-bucket/hello.txt
+'
+
+run_test "Users_ReadOnlyListBuckets" sh -c '
+  out=$(AWS_ACCESS_KEY_ID=readonlykey AWS_SECRET_ACCESS_KEY=readonlysecret \
+    aws s3api --endpoint-url "'"$ENDPOINT_USERS"'" list-buckets --query "Buckets[].Name" --output text)
+  echo "$out" | grep -q "users-bucket"
+'
+
+run_test "Users_ReadOnlyListBucket" sh -c '
+  out=$(AWS_ACCESS_KEY_ID=readonlykey AWS_SECRET_ACCESS_KEY=readonlysecret \
+    aws s3api --endpoint-url "'"$ENDPOINT_USERS"'" list-objects-v2 --bucket users-bucket --query "Contents[].Key" --output text)
+  echo "$out" | grep -q "hello.txt"
+'
+
+run_test "Users_ReadOnlyGetObject" sh -c '
+  out=$(AWS_ACCESS_KEY_ID=readonlykey AWS_SECRET_ACCESS_KEY=readonlysecret \
+    aws s3 --endpoint-url "'"$ENDPOINT_USERS"'" cp s3://users-bucket/hello.txt -)
+  [ "$out" = "root-owned object" ]
+'
+
+run_test "Users_ReadOnlyPutObjectDenied" sh -c '
+  ! echo -n "should not be allowed" | \
+  AWS_ACCESS_KEY_ID=readonlykey AWS_SECRET_ACCESS_KEY=readonlysecret \
+    aws s3 --endpoint-url "'"$ENDPOINT_USERS"'" cp - s3://users-bucket/denied.txt
+'
+
+run_test "Users_ReadOnlyDeleteObjectDenied" sh -c '
+  ! AWS_ACCESS_KEY_ID=readonlykey AWS_SECRET_ACCESS_KEY=readonlysecret \
+    aws s3api --endpoint-url "'"$ENDPOINT_USERS"'" delete-object --bucket users-bucket --key hello.txt
+'
+
+run_test "Users_ReadOnlyCreateBucketDenied" sh -c '
+  ! AWS_ACCESS_KEY_ID=readonlykey AWS_SECRET_ACCESS_KEY=readonlysecret \
+    aws s3api --endpoint-url "'"$ENDPOINT_USERS"'" create-bucket --bucket should-not-exist
+'
+
+run_test "Users_UnknownAccessKeyRejected" sh -c '
+  ! AWS_ACCESS_KEY_ID=nosuchkey AWS_SECRET_ACCESS_KEY=whatever \
+    aws s3api --endpoint-url "'"$ENDPOINT_USERS"'" list-buckets
+'
+
+run_test "Users_RootStillHasFullAccess" sh -c '
+  AWS_ACCESS_KEY_ID=rootkey AWS_SECRET_ACCESS_KEY=rootsecret \
+    aws s3api --endpoint-url "'"$ENDPOINT_USERS"'" delete-object --bucket users-bucket --key hello.txt
 '
 
 # Cleanup

--- a/s2test/e2e/run.sh
+++ b/s2test/e2e/run.sh
@@ -269,9 +269,13 @@ run_test "Memfs_MultipartUploadStreams" sh -c '
 
 # === Multi-user auth + IAM policy (s2-users) ===
 # rootkey has no Policy attached (legacy full-access user); readonlykey is
-# restricted to s3:ListAllMyBuckets / s3:ListBucket / s3:GetObject via the
-# policy in users-config.json (mirrors the read-only example from
-# https://github.com/mojatter/s2/issues/162).
+# restricted to s3:ListBucket / s3:GetObject via the policy in
+# users-config.json (mirrors the read-only example from
+# https://github.com/mojatter/s2/issues/162). ListBuckets (GET /) doesn't
+# require an up-front s3:ListAllMyBuckets Allow in s2 -- it defers and
+# returns whatever FilterBucketNames' per-bucket s3:ListBucket check
+# allows, unless the policy carries an explicit Deny on
+# s3:ListAllMyBuckets, which still hard-blocks the endpoint.
 
 run_test "Users_RootCreateBucket" sh -c '
   AWS_ACCESS_KEY_ID=rootkey AWS_SECRET_ACCESS_KEY=rootsecret \

--- a/s2test/e2e/users-config.json
+++ b/s2test/e2e/users-config.json
@@ -1,0 +1,24 @@
+{
+  "listen": ":9000",
+  "type": "osfs",
+  "root": "/var/lib/s2",
+  "user": "rootkey",
+  "password": "rootsecret",
+  "users": [
+    {
+      "access_key_id": "readonlykey",
+      "secret_access_key": "readonlysecret",
+      "policy": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "ReadOnly",
+            "Effect": "Allow",
+            "Action": ["s3:ListAllMyBuckets", "s3:ListBucket", "s3:GetObject"],
+            "Resource": ["arn:aws:s3:::*"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/s2test/e2e/users-config.json
+++ b/s2test/e2e/users-config.json
@@ -14,7 +14,7 @@
           {
             "Sid": "ReadOnly",
             "Effect": "Allow",
-            "Action": ["s3:ListAllMyBuckets", "s3:ListBucket", "s3:GetObject"],
+            "Action": ["s3:ListBucket", "s3:GetObject"],
             "Resource": ["arn:aws:s3:::*"]
           }
         ]

--- a/server/config.go
+++ b/server/config.go
@@ -73,6 +73,12 @@ type Config struct {
 	User string `json:"user"`
 	// Password is the password for authentication (Basic Auth password for Web Console, Secret Access Key for S3 API).
 	Password string `json:"password"`
+	// Users is a list of additional principals for multi-user auth. SigV4
+	// and BasicAuth check these in addition to the legacy single User/
+	// Password pair above; each entry's Policy (if set) governs what that
+	// principal may do. Config-file only -- there is no environment
+	// variable equivalent.
+	Users []User `json:"users,omitempty"`
 	// Buckets is a list of bucket names to create on startup if they don't already exist.
 	Buckets []string `json:"buckets"`
 }
@@ -123,6 +129,28 @@ func (cfg *Config) Validate() error {
 		}
 		if cfg.HealthPath == "/" {
 			return fmt.Errorf("server: HealthPath %q must have at least one path segment", cfg.HealthPath)
+		}
+	}
+
+	seen := make(map[string]bool, len(cfg.Users)+1)
+	if cfg.User != "" {
+		seen[cfg.User] = true
+	}
+	for i, u := range cfg.Users {
+		if u.AccessKeyID == "" {
+			return fmt.Errorf("server: users[%d]: access_key_id must not be empty", i)
+		}
+		if u.SecretAccessKey == "" {
+			return fmt.Errorf("server: users[%d] (%s): secret_access_key must not be empty", i, u.AccessKeyID)
+		}
+		if seen[u.AccessKeyID] {
+			return fmt.Errorf("server: duplicate access_key_id %q", u.AccessKeyID)
+		}
+		seen[u.AccessKeyID] = true
+		if u.Policy != nil {
+			if err := u.Policy.Validate(); err != nil {
+				return fmt.Errorf("server: users[%d] (%s): %w", i, u.AccessKeyID, err)
+			}
 		}
 	}
 	return nil

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -185,3 +185,90 @@ func TestConfigValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigValidateUsers(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		cfg      *Config
+		wantErr  bool
+	}{
+		{
+			caseName: "valid multi-user config",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.Users = []User{
+					{AccessKeyID: "userA", SecretAccessKey: "secretA"},
+					{AccessKeyID: "userB", SecretAccessKey: "secretB", Policy: &Policy{
+						Statement: []Statement{allowStatement("s3:GetObject", "*")},
+					}},
+				}
+				return c
+			}(),
+			wantErr: false,
+		},
+		{
+			caseName: "empty access key id rejected",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.Users = []User{{SecretAccessKey: "secretA"}}
+				return c
+			}(),
+			wantErr: true,
+		},
+		{
+			caseName: "empty secret access key rejected",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.Users = []User{{AccessKeyID: "userA"}}
+				return c
+			}(),
+			wantErr: true,
+		},
+		{
+			caseName: "duplicate access key id within users rejected",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.Users = []User{
+					{AccessKeyID: "userA", SecretAccessKey: "secretA"},
+					{AccessKeyID: "userA", SecretAccessKey: "secretA2"},
+				}
+				return c
+			}(),
+			wantErr: true,
+		},
+		{
+			caseName: "access key id colliding with legacy user rejected",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.User = "root"
+				c.Password = "rootsecret"
+				c.Users = []User{{AccessKeyID: "root", SecretAccessKey: "other"}}
+				return c
+			}(),
+			wantErr: true,
+		},
+		{
+			caseName: "malformed nested policy rejected",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.Users = []User{{
+					AccessKeyID:     "userA",
+					SecretAccessKey: "secretA",
+					Policy:          &Policy{Statement: []Statement{{Effect: "invalid"}}},
+				}}
+				return c
+			}(),
+			wantErr: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/server/console.go
+++ b/server/console.go
@@ -31,6 +31,7 @@ func (s *Server) RenderConsoleIndex(ctx context.Context, w http.ResponseWriter, 
 	if err != nil {
 		return err
 	}
+	names = FilterBucketNames(UserFromContext(ctx), names)
 	if data == nil {
 		data = map[string]any{}
 	}

--- a/server/console_test.go
+++ b/server/console_test.go
@@ -10,10 +10,16 @@ import (
 )
 
 func TestRenderConsoleIndex(t *testing.T) {
+	restrictedUser := &User{Policy: &Policy{Statement: []Statement{
+		allowStatement("s3:ListBucket", "arn:aws:s3:::alpha"),
+	}}}
+
 	testCases := []struct {
-		caseName     string
-		buckets      []string
-		wantContains []string
+		caseName        string
+		buckets         []string
+		user            *User
+		wantContains    []string
+		wantNotContains []string
 	}{
 		{
 			caseName:     "no buckets renders index page",
@@ -23,6 +29,13 @@ func TestRenderConsoleIndex(t *testing.T) {
 			caseName:     "bucket names appear in rendered page",
 			buckets:      []string{"alpha", "bravo"},
 			wantContains: []string{`id="main-content"`, "alpha", "bravo"},
+		},
+		{
+			caseName:        "policy filters bucket names in rendered page",
+			buckets:         []string{"alpha", "bravo"},
+			user:            restrictedUser,
+			wantContains:    []string{`id="main-content"`, "alpha"},
+			wantNotContains: []string{"bravo"},
 		},
 	}
 
@@ -37,12 +50,16 @@ func TestRenderConsoleIndex(t *testing.T) {
 				require.NoError(t, srv.Buckets.Create(context.Background(), name))
 			}
 
+			ctx := WithUser(context.Background(), tc.user)
 			w := httptest.NewRecorder()
-			require.NoError(t, srv.RenderConsoleIndex(context.Background(), w, nil))
+			require.NoError(t, srv.RenderConsoleIndex(ctx, w, nil))
 
 			body := w.Body.String()
 			for _, want := range tc.wantContains {
 				assert.Contains(t, body, want)
+			}
+			for _, notWant := range tc.wantNotContains {
+				assert.NotContains(t, body, notWant)
 			}
 		})
 	}

--- a/server/handlers/console/buckets/objects.go
+++ b/server/handlers/console/buckets/objects.go
@@ -135,6 +135,10 @@ func handleCreateFolder(s *server.Server, w http.ResponseWriter, r *http.Request
 	}
 
 	key := path.Join(prefix, folderName)
+	if !server.AllowedS3Action(server.UserFromContext(ctx), server.ActionPutObject, name, key) {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
 	if err := s.Buckets.CreateFolder(ctx, name, key); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -169,6 +173,10 @@ func handleUploadFile(s *server.Server, w http.ResponseWriter, r *http.Request) 
 	}
 
 	key := path.Join(prefix, header.Filename)
+	if !server.AllowedS3Action(server.UserFromContext(ctx), server.ActionPutObject, name, key) {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
 	obj := s2.NewObjectReader(key, file, s2.MustUint64(header.Size))
 	if err := strg.Put(ctx, obj); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -194,6 +202,24 @@ func handleDeleteObject(s *server.Server, w http.ResponseWriter, r *http.Request
 	}
 
 	if strings.HasSuffix(key, "/") {
+		// ConsoleAction defers authorization entirely for a recursive
+		// folder delete (the affected keys are only known once we list
+		// the prefix here), so check every descendant individually before
+		// deleting any of them -- a single denied key aborts the whole
+		// operation rather than silently deleting the rest.
+		if user := server.UserFromContext(ctx); user != nil && user.Policy != nil {
+			res, err := strg.List(ctx, s2.ListOptions{Prefix: key, Recursive: true})
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			for _, obj := range server.FilterKeep(res.Objects) {
+				if !server.AllowedS3Action(user, server.ActionDeleteObject, name, obj.Name()) {
+					http.Error(w, "Forbidden", http.StatusForbidden)
+					return
+				}
+			}
+		}
 		if err := strg.DeleteRecursive(ctx, key); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/server/handlers/console/buckets/objects.go
+++ b/server/handlers/console/buckets/objects.go
@@ -135,8 +135,7 @@ func handleCreateFolder(s *server.Server, w http.ResponseWriter, r *http.Request
 	}
 
 	key := path.Join(prefix, folderName)
-	if !server.AllowedS3Action(server.UserFromContext(ctx), server.ActionPutObject, name, key) {
-		http.Error(w, "Forbidden", http.StatusForbidden)
+	if !server.DenyUnlessAllowedS3Action(w, server.UserFromContext(ctx), server.ActionPutObject, name, key) {
 		return
 	}
 	if err := s.Buckets.CreateFolder(ctx, name, key); err != nil {
@@ -173,8 +172,7 @@ func handleUploadFile(s *server.Server, w http.ResponseWriter, r *http.Request) 
 	}
 
 	key := path.Join(prefix, header.Filename)
-	if !server.AllowedS3Action(server.UserFromContext(ctx), server.ActionPutObject, name, key) {
-		http.Error(w, "Forbidden", http.StatusForbidden)
+	if !server.DenyUnlessAllowedS3Action(w, server.UserFromContext(ctx), server.ActionPutObject, name, key) {
 		return
 	}
 	obj := s2.NewObjectReader(key, file, s2.MustUint64(header.Size))
@@ -204,23 +202,27 @@ func handleDeleteObject(s *server.Server, w http.ResponseWriter, r *http.Request
 	if strings.HasSuffix(key, "/") {
 		user := server.UserFromContext(ctx)
 		if user != nil && user.Policy != nil {
-			// ConsoleAction defers authorization entirely for a recursive
-			// folder delete (the affected keys are only known once we
-			// list the prefix here). Collect and check every descendant
-			// across all pages first -- List caps a page at 1000 objects,
-			// so a single-page check would silently skip anything past
-			// that -- and only delete the exact checked set afterward,
-			// rather than calling DeleteRecursive (which would re-list
-			// independently and could sweep in an object written after
-			// the check ran).
+			// ConsoleAction defers authorization for a recursive folder
+			// delete; check and delete each descendant per page instead of
+			// buffering all keys first, to bound memory. Processing stops
+			// at the first denied key rather than skipping it and scanning
+			// the rest of the prefix to completion -- a caller with no
+			// delete permission at all under a huge prefix would otherwise
+			// force a full pagination sweep for no benefit. The refreshed
+			// fragment below still reflects whatever was deleted before
+			// the stop, unlike an old 403 short-circuit that would leave
+			// the console showing already-deleted objects (htmx doesn't
+			// swap on a 4xx response).
 			//
-			// .keep folder markers are deliberately not filtered out here
-			// (unlike elsewhere): they're still checked and deleted like
-			// any other object under the same wildcard grant, so a folder
-			// the caller is authorized to clear doesn't linger empty
-			// afterward the way it would if its marker survived.
-			var keys []string
+			// TODO: stopping early is silent -- the response is always a
+			// plain 200, so the user has no way to tell that the folder
+			// was only partially cleared, or why it stopped where it did.
+			//
+			// .keep markers aren't filtered out here (unlike elsewhere):
+			// they're deleted like any other object under the same
+			// wildcard grant, so an authorized folder doesn't linger empty.
 			after := ""
+		pagination:
 			for {
 				res, err := strg.List(ctx, s2.ListOptions{Prefix: key, Recursive: true, After: after})
 				if err != nil {
@@ -229,21 +231,17 @@ func handleDeleteObject(s *server.Server, w http.ResponseWriter, r *http.Request
 				}
 				for _, obj := range res.Objects {
 					if !server.AllowedS3Action(user, server.ActionDeleteObject, name, obj.Name()) {
-						http.Error(w, "Forbidden", http.StatusForbidden)
+						break pagination
+					}
+					if err := strg.Delete(ctx, obj.Name()); err != nil {
+						http.Error(w, err.Error(), http.StatusInternalServerError)
 						return
 					}
-					keys = append(keys, obj.Name())
 				}
 				if res.NextAfter == "" {
 					break
 				}
 				after = res.NextAfter
-			}
-			for _, k := range keys {
-				if err := strg.Delete(ctx, k); err != nil {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-					return
-				}
 			}
 		} else if err := strg.DeleteRecursive(ctx, key); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/server/handlers/console/buckets/objects.go
+++ b/server/handlers/console/buckets/objects.go
@@ -202,25 +202,50 @@ func handleDeleteObject(s *server.Server, w http.ResponseWriter, r *http.Request
 	}
 
 	if strings.HasSuffix(key, "/") {
-		// ConsoleAction defers authorization entirely for a recursive
-		// folder delete (the affected keys are only known once we list
-		// the prefix here), so check every descendant individually before
-		// deleting any of them -- a single denied key aborts the whole
-		// operation rather than silently deleting the rest.
-		if user := server.UserFromContext(ctx); user != nil && user.Policy != nil {
-			res, err := strg.List(ctx, s2.ListOptions{Prefix: key, Recursive: true})
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
+		user := server.UserFromContext(ctx)
+		if user != nil && user.Policy != nil {
+			// ConsoleAction defers authorization entirely for a recursive
+			// folder delete (the affected keys are only known once we
+			// list the prefix here). Collect and check every descendant
+			// across all pages first -- List caps a page at 1000 objects,
+			// so a single-page check would silently skip anything past
+			// that -- and only delete the exact checked set afterward,
+			// rather than calling DeleteRecursive (which would re-list
+			// independently and could sweep in an object written after
+			// the check ran).
+			//
+			// .keep folder markers are deliberately not filtered out here
+			// (unlike elsewhere): they're still checked and deleted like
+			// any other object under the same wildcard grant, so a folder
+			// the caller is authorized to clear doesn't linger empty
+			// afterward the way it would if its marker survived.
+			var keys []string
+			after := ""
+			for {
+				res, err := strg.List(ctx, s2.ListOptions{Prefix: key, Recursive: true, After: after})
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+					return
+				}
+				for _, obj := range res.Objects {
+					if !server.AllowedS3Action(user, server.ActionDeleteObject, name, obj.Name()) {
+						http.Error(w, "Forbidden", http.StatusForbidden)
+						return
+					}
+					keys = append(keys, obj.Name())
+				}
+				if res.NextAfter == "" {
+					break
+				}
+				after = res.NextAfter
 			}
-			for _, obj := range server.FilterKeep(res.Objects) {
-				if !server.AllowedS3Action(user, server.ActionDeleteObject, name, obj.Name()) {
-					http.Error(w, "Forbidden", http.StatusForbidden)
+			for _, k := range keys {
+				if err := strg.Delete(ctx, k); err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
 					return
 				}
 			}
-		}
-		if err := strg.DeleteRecursive(ctx, key); err != nil {
+		} else if err := strg.DeleteRecursive(ctx, key); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/server/handlers/console/buckets/objects_test.go
+++ b/server/handlers/console/buckets/objects_test.go
@@ -415,7 +415,7 @@ func (s *ObjectsTestSuite) TestHandleDeleteObject() {
 		s.Equal(http.StatusBadRequest, w.Code)
 	})
 
-	s.Run("recursive delete aborts entirely when one descendant is denied", func() {
+	s.Run("recursive delete stops at the first denied descendant", func() {
 		s.createBucket("delp")
 		s.server.Buckets.CreateFolder(context.Background(), "delp", "dir")
 		s.putObject("delp", "dir/keep.txt", "must survive")
@@ -432,7 +432,7 @@ func (s *ObjectsTestSuite) TestHandleDeleteObject() {
 		w := httptest.NewRecorder()
 		handleDeleteObject(s.server, w, req)
 
-		s.Equal(http.StatusForbidden, w.Code)
+		s.Equal(http.StatusOK, w.Code)
 
 		strg, err := s.server.Buckets.Get(context.Background(), "delp")
 		s.Require().NoError(err)
@@ -441,10 +441,12 @@ func (s *ObjectsTestSuite) TestHandleDeleteObject() {
 		s.True(exists, "keep.txt must survive since it was explicitly denied")
 		exists, err = strg.Exists(context.Background(), "dir/other.txt")
 		s.Require().NoError(err)
-		s.True(exists, "other.txt must also survive: the whole operation aborts on any denial")
+		// "keep.txt" sorts before "other.txt", so processing stops at
+		// keep.txt before other.txt is ever reached.
+		s.True(exists, "other.txt must also survive: processing stops at the first denial instead of skipping past it")
 	})
 
-	s.Run("denial past the first list page (1000 objects) is still honored", func() {
+	s.Run("denial past the first list page (1000 objects) stops the sweep there", func() {
 		s.createBucket("delbig")
 		s.server.Buckets.CreateFolder(context.Background(), "delbig", "dir")
 
@@ -467,18 +469,22 @@ func (s *ObjectsTestSuite) TestHandleDeleteObject() {
 		w := httptest.NewRecorder()
 		handleDeleteObject(s.server, w, req)
 
-		s.Equal(http.StatusForbidden, w.Code)
+		s.Equal(http.StatusOK, w.Code)
 
 		strg, err := s.server.Buckets.Get(context.Background(), "delbig")
 		s.Require().NoError(err)
 		exists, err := strg.Exists(context.Background(), deniedKey)
 		s.Require().NoError(err)
 		s.True(exists, "the denied object beyond the first page must survive")
-		// Nothing should have been deleted either, since the check runs
-		// to completion across all pages before any delete happens.
+		// Everything before the denied key in listing order -- on both the
+		// first page and the start of the second page -- is deleted before
+		// the sweep reaches and stops at the denial.
 		exists, err = strg.Exists(context.Background(), "dir/obj-0000.txt")
 		s.Require().NoError(err)
-		s.True(exists, "even an allowed object from the first page must survive: the whole operation aborts on any denial")
+		s.False(exists, "an allowed object from the first page must still be deleted")
+		exists, err = strg.Exists(context.Background(), fmt.Sprintf("dir/obj-%04d.txt", total-2))
+		s.Require().NoError(err)
+		s.False(exists, "an allowed object immediately before the denied one, on the second page, must still be deleted")
 	})
 }
 

--- a/server/handlers/console/buckets/objects_test.go
+++ b/server/handlers/console/buckets/objects_test.go
@@ -3,6 +3,7 @@ package buckets
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -441,6 +442,43 @@ func (s *ObjectsTestSuite) TestHandleDeleteObject() {
 		exists, err = strg.Exists(context.Background(), "dir/other.txt")
 		s.Require().NoError(err)
 		s.True(exists, "other.txt must also survive: the whole operation aborts on any denial")
+	})
+
+	s.Run("denial past the first list page (1000 objects) is still honored", func() {
+		s.createBucket("delbig")
+		s.server.Buckets.CreateFolder(context.Background(), "delbig", "dir")
+
+		const total = 1200
+		for i := range total {
+			s.putObject("delbig", fmt.Sprintf("dir/obj-%04d.txt", i), "data")
+		}
+		// Lexicographically last, so it only appears once List's default
+		// 1000-item page is exhausted and a second page is fetched.
+		deniedKey := fmt.Sprintf("dir/obj-%04d.txt", total-1)
+
+		user := &server.User{Policy: &server.Policy{Statement: []server.Statement{
+			{Effect: "Allow", Action: []string{server.ActionDeleteObject}, Resource: []string{"arn:aws:s3:::delbig/dir/*"}},
+			{Effect: "Deny", Action: []string{server.ActionDeleteObject}, Resource: []string{"arn:aws:s3:::delbig/" + deniedKey}},
+		}}}
+
+		req := httptest.NewRequest("DELETE", "/buckets/delbig/objects?key=dir/&prefix=", nil)
+		req.SetPathValue("name", "delbig")
+		req = req.WithContext(server.WithUser(req.Context(), user))
+		w := httptest.NewRecorder()
+		handleDeleteObject(s.server, w, req)
+
+		s.Equal(http.StatusForbidden, w.Code)
+
+		strg, err := s.server.Buckets.Get(context.Background(), "delbig")
+		s.Require().NoError(err)
+		exists, err := strg.Exists(context.Background(), deniedKey)
+		s.Require().NoError(err)
+		s.True(exists, "the denied object beyond the first page must survive")
+		// Nothing should have been deleted either, since the check runs
+		// to completion across all pages before any delete happens.
+		exists, err = strg.Exists(context.Background(), "dir/obj-0000.txt")
+		s.Require().NoError(err)
+		s.True(exists, "even an allowed object from the first page must survive: the whole operation aborts on any denial")
 	})
 }
 

--- a/server/handlers/console/buckets/objects_test.go
+++ b/server/handlers/console/buckets/objects_test.go
@@ -215,6 +215,31 @@ func (s *ObjectsTestSuite) TestHandleCreateFolder() {
 
 		s.Equal(http.StatusBadRequest, w.Code)
 	})
+
+	s.Run("explicit deny on the exact key is not bypassed by a wildcard allow", func() {
+		s.createBucket("fld3")
+
+		user := &server.User{Policy: &server.Policy{Statement: []server.Statement{
+			{Effect: "Allow", Action: []string{server.ActionPutObject}, Resource: []string{"arn:aws:s3:::fld3/*"}},
+			{Effect: "Deny", Action: []string{server.ActionPutObject}, Resource: []string{"arn:aws:s3:::fld3/secret"}},
+		}}}
+
+		form := url.Values{"prefix": {""}, "folder_name": {"secret"}}
+		req := httptest.NewRequest("POST", "/buckets/fld3/folders", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.SetPathValue("name", "fld3")
+		req = req.WithContext(server.WithUser(req.Context(), user))
+		w := httptest.NewRecorder()
+		handleCreateFolder(s.server, w, req)
+
+		s.Equal(http.StatusForbidden, w.Code)
+
+		strg, err := s.server.Buckets.Get(context.Background(), "fld3")
+		s.Require().NoError(err)
+		exists, err := strg.Exists(context.Background(), "secret/.keep")
+		s.Require().NoError(err)
+		s.False(exists)
+	})
 }
 
 // --- POST /buckets/{name}/upload ---
@@ -306,6 +331,39 @@ func (s *ObjectsTestSuite) TestHandleUploadFile() {
 			}
 		})
 	}
+
+	s.Run("explicit deny on the exact filename is not bypassed by a wildcard allow", func() {
+		s.createBucket("upd")
+
+		user := &server.User{Policy: &server.Policy{Statement: []server.Statement{
+			{Effect: "Allow", Action: []string{server.ActionPutObject}, Resource: []string{"arn:aws:s3:::upd/*"}},
+			{Effect: "Deny", Action: []string{server.ActionPutObject}, Resource: []string{"arn:aws:s3:::upd/secret.txt"}},
+		}}}
+
+		body := &bytes.Buffer{}
+		mw := multipart.NewWriter(body)
+		s.Require().NoError(mw.WriteField("prefix", ""))
+		fw, err := mw.CreateFormFile("file", "secret.txt")
+		s.Require().NoError(err)
+		_, err = fw.Write([]byte("leaked"))
+		s.Require().NoError(err)
+		s.Require().NoError(mw.Close())
+
+		req := httptest.NewRequest("POST", "/buckets/upd/upload", body)
+		req.Header.Set("Content-Type", mw.FormDataContentType())
+		req.SetPathValue("name", "upd")
+		req = req.WithContext(server.WithUser(req.Context(), user))
+		w := httptest.NewRecorder()
+		handleUploadFile(s.server, w, req)
+
+		s.Equal(http.StatusForbidden, w.Code)
+
+		strg, err := s.server.Buckets.Get(context.Background(), "upd")
+		s.Require().NoError(err)
+		exists, err := strg.Exists(context.Background(), "secret.txt")
+		s.Require().NoError(err)
+		s.False(exists)
+	})
 }
 
 // --- DELETE /buckets/{name}/objects ---
@@ -354,6 +412,35 @@ func (s *ObjectsTestSuite) TestHandleDeleteObject() {
 		handleDeleteObject(s.server, w, req)
 
 		s.Equal(http.StatusBadRequest, w.Code)
+	})
+
+	s.Run("recursive delete aborts entirely when one descendant is denied", func() {
+		s.createBucket("delp")
+		s.server.Buckets.CreateFolder(context.Background(), "delp", "dir")
+		s.putObject("delp", "dir/keep.txt", "must survive")
+		s.putObject("delp", "dir/other.txt", "data")
+
+		user := &server.User{Policy: &server.Policy{Statement: []server.Statement{
+			{Effect: "Allow", Action: []string{server.ActionDeleteObject}, Resource: []string{"arn:aws:s3:::delp/dir/*"}},
+			{Effect: "Deny", Action: []string{server.ActionDeleteObject}, Resource: []string{"arn:aws:s3:::delp/dir/keep.txt"}},
+		}}}
+
+		req := httptest.NewRequest("DELETE", "/buckets/delp/objects?key=dir/&prefix=", nil)
+		req.SetPathValue("name", "delp")
+		req = req.WithContext(server.WithUser(req.Context(), user))
+		w := httptest.NewRecorder()
+		handleDeleteObject(s.server, w, req)
+
+		s.Equal(http.StatusForbidden, w.Code)
+
+		strg, err := s.server.Buckets.Get(context.Background(), "delp")
+		s.Require().NoError(err)
+		exists, err := strg.Exists(context.Background(), "dir/keep.txt")
+		s.Require().NoError(err)
+		s.True(exists, "keep.txt must survive since it was explicitly denied")
+		exists, err = strg.Exists(context.Background(), "dir/other.txt")
+		s.Require().NoError(err)
+		s.True(exists, "other.txt must also survive: the whole operation aborts on any denial")
 	})
 }
 

--- a/server/handlers/console/console_test.go
+++ b/server/handlers/console/console_test.go
@@ -130,6 +130,26 @@ func (s *IndexTestSuite) TestHandleCreateBucket() {
 		s.Contains(body, "just-created")
 		s.NotContains(body, "denied-bucket")
 	})
+
+	s.Run("explicit deny on the exact bucket name is not bypassed by a wildcard allow", func() {
+		user := &server.User{Policy: &server.Policy{Statement: []server.Statement{
+			{Effect: "Allow", Action: []string{"s3:CreateBucket"}, Resource: []string{"arn:aws:s3:::*"}},
+			{Effect: "Deny", Action: []string{"s3:CreateBucket"}, Resource: []string{"arn:aws:s3:::secrets"}},
+		}}}
+
+		form := url.Values{"name": {"secrets"}}
+		req := httptest.NewRequest("POST", "/buckets", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req = req.WithContext(server.WithUser(req.Context(), user))
+		w := httptest.NewRecorder()
+		handleCreateBucket(s.server, w, req)
+
+		s.Equal(http.StatusForbidden, w.Code)
+
+		exists, err := s.server.Buckets.Exists(req.Context(), "secrets")
+		s.Require().NoError(err)
+		s.False(exists)
+	})
 }
 
 // --- DELETE /buckets/{name} ---

--- a/server/handlers/console/console_test.go
+++ b/server/handlers/console/console_test.go
@@ -61,6 +61,25 @@ func (s *IndexTestSuite) TestHandleIndex() {
 		s.Contains(body, "alpha")
 		s.Contains(body, "beta")
 	})
+
+	s.Run("filtered by policy", func() {
+		s.createBucket("visible")
+		s.createBucket("denied-bucket")
+
+		user := &server.User{Policy: &server.Policy{Statement: []server.Statement{
+			{Effect: "Allow", Action: []string{"s3:ListBucket"}, Resource: []string{"arn:aws:s3:::visible"}},
+		}}}
+
+		req := httptest.NewRequest("GET", "/", nil)
+		req = req.WithContext(server.WithUser(req.Context(), user))
+		w := httptest.NewRecorder()
+		handleIndex(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		body := w.Body.String()
+		s.Contains(body, "visible")
+		s.NotContains(body, "denied-bucket")
+	})
 }
 
 // --- POST /buckets ---
@@ -89,6 +108,27 @@ func (s *IndexTestSuite) TestHandleCreateBucket() {
 		handleCreateBucket(s.server, w, req)
 
 		s.Equal(http.StatusBadRequest, w.Code)
+	})
+
+	s.Run("rendered bucket list is filtered by policy", func() {
+		s.createBucket("denied-bucket")
+
+		user := &server.User{Policy: &server.Policy{Statement: []server.Statement{
+			{Effect: "Allow", Action: []string{"s3:CreateBucket"}, Resource: []string{"arn:aws:s3:::*"}},
+			{Effect: "Allow", Action: []string{"s3:ListBucket"}, Resource: []string{"arn:aws:s3:::just-created"}},
+		}}}
+
+		form := url.Values{"name": {"just-created"}}
+		req := httptest.NewRequest("POST", "/buckets", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req = req.WithContext(server.WithUser(req.Context(), user))
+		w := httptest.NewRecorder()
+		handleCreateBucket(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		body := w.Body.String()
+		s.Contains(body, "just-created")
+		s.NotContains(body, "denied-bucket")
 	})
 }
 
@@ -119,5 +159,27 @@ func (s *IndexTestSuite) TestHandleDeleteBucket() {
 		handleDeleteBucket(s.server, w, req)
 
 		s.Equal(http.StatusBadRequest, w.Code)
+	})
+
+	s.Run("remaining bucket list is filtered by policy", func() {
+		s.createBucket("to-delete-2")
+		s.createBucket("visible")
+		s.createBucket("denied-bucket")
+
+		user := &server.User{Policy: &server.Policy{Statement: []server.Statement{
+			{Effect: "Allow", Action: []string{"s3:DeleteBucket"}, Resource: []string{"arn:aws:s3:::*"}},
+			{Effect: "Allow", Action: []string{"s3:ListBucket"}, Resource: []string{"arn:aws:s3:::visible"}},
+		}}}
+
+		req := httptest.NewRequest("DELETE", "/buckets/to-delete-2", nil)
+		req.SetPathValue("name", "to-delete-2")
+		req = req.WithContext(server.WithUser(req.Context(), user))
+		w := httptest.NewRecorder()
+		handleDeleteBucket(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		body := w.Body.String()
+		s.Contains(body, "visible")
+		s.NotContains(body, "denied-bucket")
 	})
 }

--- a/server/handlers/console/index.go
+++ b/server/handlers/console/index.go
@@ -46,6 +46,7 @@ func handleDeleteBucket(s *server.Server, w http.ResponseWriter, r *http.Request
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	names = server.FilterBucketNames(server.UserFromContext(r.Context()), names)
 
 	data := struct{ Buckets []string }{Buckets: names}
 
@@ -76,6 +77,7 @@ func renderBucketList(ctx context.Context, s *server.Server, w http.ResponseWrit
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	names = server.FilterBucketNames(server.UserFromContext(ctx), names)
 
 	data := struct{ Buckets []string }{Buckets: names}
 
@@ -93,4 +95,3 @@ func init() {
 	server.RegisterConsoleHandleFunc("POST /buckets", middleware.BasicAuth(handleCreateBucket))
 	server.RegisterConsoleHandleFunc("DELETE /buckets/{name}", middleware.BasicAuth(handleDeleteBucket))
 }
-

--- a/server/handlers/console/index.go
+++ b/server/handlers/console/index.go
@@ -26,8 +26,7 @@ func handleCreateBucket(s *server.Server, w http.ResponseWriter, r *http.Request
 	// this route (the bucket doesn't exist in the URL and isn't known
 	// until the form above is parsed), so re-check the real name here --
 	// a Deny scoped to this specific bucket name must still apply.
-	if !server.AllowedS3BucketAction(server.UserFromContext(r.Context()), server.ActionCreateBucket, name) {
-		http.Error(w, "Forbidden", http.StatusForbidden)
+	if !server.DenyUnlessAllowedS3BucketAction(w, server.UserFromContext(r.Context()), server.ActionCreateBucket, name) {
 		return
 	}
 	if err := s.Buckets.Create(r.Context(), name); err != nil {

--- a/server/handlers/console/index.go
+++ b/server/handlers/console/index.go
@@ -22,6 +22,14 @@ func handleCreateBucket(s *server.Server, w http.ResponseWriter, r *http.Request
 		http.Error(w, "bucket name is required", http.StatusBadRequest)
 		return
 	}
+	// ConsoleAction can only check a wildcard placeholder resource for
+	// this route (the bucket doesn't exist in the URL and isn't known
+	// until the form above is parsed), so re-check the real name here --
+	// a Deny scoped to this specific bucket name must still apply.
+	if !server.AllowedS3BucketAction(server.UserFromContext(r.Context()), server.ActionCreateBucket, name) {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
 	if err := s.Buckets.Create(r.Context(), name); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/server/handlers/s3api/buckets.go
+++ b/server/handlers/s3api/buckets.go
@@ -9,6 +9,15 @@ import (
 
 func HandleListBuckets(s *server.Server, w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	// S3Action defers this route entirely so FilterBucketNames can filter
+	// per-bucket instead of gating the whole request on an up-front
+	// s3:ListAllMyBuckets Allow (see S3Action's doc comment). But an
+	// explicit Deny on that action, as a policy author porting an
+	// AWS-style policy would expect, must still block the endpoint.
+	if server.ExplicitlyDeniedListAllMyBuckets(server.UserFromContext(ctx)) {
+		writeError(w, r, "AccessDenied", "Access Denied", http.StatusForbidden)
+		return
+	}
 	names, err := s.Buckets.Names(ctx)
 	if err != nil {
 		code, msg, status := s2ErrorToS3Error(err)

--- a/server/handlers/s3api/buckets.go
+++ b/server/handlers/s3api/buckets.go
@@ -15,6 +15,7 @@ func HandleListBuckets(s *server.Server, w http.ResponseWriter, r *http.Request)
 		writeError(w, r, code, msg, status)
 		return
 	}
+	names = server.FilterBucketNames(server.UserFromContext(ctx), names)
 
 	buckets := make([]Bucket, 0, len(names))
 	for _, name := range names {

--- a/server/handlers/s3api/buckets_test.go
+++ b/server/handlers/s3api/buckets_test.go
@@ -53,6 +53,26 @@ func (s *BucketsTestSuite) TestListBuckets() {
 			s.True(b.CreationDate.Year() >= 2025, "CreationDate should be a recent timestamp")
 		}
 	})
+
+	s.Run("filtered by policy", func() {
+		s.createBucket("visible")
+		s.createBucket("denied-bucket")
+
+		user := &server.User{Policy: &server.Policy{Statement: []server.Statement{
+			{Effect: "Allow", Action: []string{"s3:ListBucket"}, Resource: []string{"arn:aws:s3:::visible"}},
+		}}}
+
+		req := httptest.NewRequest("GET", "/", nil)
+		req = req.WithContext(server.WithUser(req.Context(), user))
+		w := httptest.NewRecorder()
+		HandleListBuckets(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		var result ListAllMyBucketsResult
+		s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &result))
+		s.Len(result.Buckets, 1)
+		s.Equal("visible", result.Buckets[0].Name)
+	})
 }
 
 // --- CreateBucket ---

--- a/server/handlers/s3api/buckets_test.go
+++ b/server/handlers/s3api/buckets_test.go
@@ -73,6 +73,23 @@ func (s *BucketsTestSuite) TestListBuckets() {
 		s.Len(result.Buckets, 1)
 		s.Equal("visible", result.Buckets[0].Name)
 	})
+
+	s.Run("explicit deny on s3:ListAllMyBuckets blocks the endpoint entirely", func() {
+		s.createBucket("visible2")
+
+		user := &server.User{Policy: &server.Policy{Statement: []server.Statement{
+			{Effect: "Allow", Action: []string{"s3:ListBucket"}, Resource: []string{"arn:aws:s3:::visible2"}},
+			{Effect: "Deny", Action: []string{"s3:ListAllMyBuckets"}, Resource: []string{"arn:aws:s3:::*"}},
+		}}}
+
+		req := httptest.NewRequest("GET", "/", nil)
+		req = req.WithContext(server.WithUser(req.Context(), user))
+		w := httptest.NewRecorder()
+		HandleListBuckets(s.server, w, req)
+
+		s.Equal(http.StatusForbidden, w.Code)
+		s.Contains(w.Body.String(), "AccessDenied")
+	})
 }
 
 // --- CreateBucket ---

--- a/server/handlers/s3api/models.go
+++ b/server/handlers/s3api/models.go
@@ -3,6 +3,8 @@ package s3api
 import (
 	"encoding/xml"
 	"time"
+
+	"github.com/mojatter/s2/server"
 )
 
 // ListAllMyBucketsResult represents the XML response for ListBuckets.
@@ -127,11 +129,8 @@ type CompleteMultipartUploadResult struct {
 	ETag     string   `xml:"ETag"`
 }
 
-// ErrorResponse represents the XML response for S3 errors.
-type ErrorResponse struct {
-	XMLName   xml.Name `xml:"Error"`
-	Code      string   `xml:"Code"`
-	Message   string   `xml:"Message"`
-	Resource  string   `xml:"Resource"`
-	RequestID string   `xml:"RequestId"`
-}
+// ErrorResponse represents the XML response for S3 errors. It's an alias
+// for server.S3ErrorResponse, which server/middleware also uses for SigV4
+// auth/authz errors, so the two error paths can't drift into subtly
+// different XML shapes.
+type ErrorResponse = server.S3ErrorResponse

--- a/server/handlers/s3api/objects.go
+++ b/server/handlers/s3api/objects.go
@@ -577,6 +577,12 @@ func handleDeleteObjects(s *server.Server, w http.ResponseWriter, r *http.Reques
 	// key individually here.
 	user := server.UserFromContext(ctx)
 
+	// Unlike handleCopyObject or the console's recursive-delete handler,
+	// a denied key here is reported as a per-key DeleteError and the loop
+	// continues instead of aborting the whole request -- this mirrors S3's
+	// documented multi-status DeleteObjects semantics (a batch delete
+	// always returns partial results, not an all-or-nothing failure), so
+	// don't change it to abort-on-first-denial to match those other sites.
 	result := DeleteObjectsResult{}
 	for _, obj := range req.Objects {
 		if !server.AllowedS3Action(user, server.ActionDeleteObject, bucketName, obj.Key) {

--- a/server/handlers/s3api/objects.go
+++ b/server/handlers/s3api/objects.go
@@ -457,6 +457,15 @@ func handleCopyObject(s *server.Server, w http.ResponseWriter, r *http.Request, 
 	srcBucket := copySource[:slashIdx]
 	srcKey := copySource[slashIdx+1:]
 
+	// S3Action only authorized the destination (dstBucket/dstKey) against
+	// s3:PutObject up front -- the source is a distinct resource that must
+	// be checked separately, or a PutObject-only policy could be used to
+	// read arbitrary objects via CopyObject.
+	if !server.AllowedS3Action(server.UserFromContext(ctx), server.ActionGetObject, srcBucket, srcKey) {
+		writeError(w, r, "AccessDenied", "Access Denied", http.StatusForbidden)
+		return
+	}
+
 	srcStrg, err := s.Buckets.Get(ctx, srcBucket)
 	if err != nil {
 		code, msg, status := s2ErrorToS3Error(err)
@@ -562,8 +571,22 @@ func handleDeleteObjects(s *server.Server, w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// The keys to delete only become known once the body above is decoded,
+	// so SigV4's up-front check (against the coarse bucket/* resource) is
+	// too imprecise for a policy scoped to a narrower prefix -- check each
+	// key individually here.
+	user := server.UserFromContext(ctx)
+
 	result := DeleteObjectsResult{}
 	for _, obj := range req.Objects {
+		if !server.AllowedS3Action(user, server.ActionDeleteObject, bucketName, obj.Key) {
+			result.Errors = append(result.Errors, DeleteError{
+				Key:     obj.Key,
+				Code:    "AccessDenied",
+				Message: "Access Denied",
+			})
+			continue
+		}
 		if err := strg.Delete(ctx, obj.Key); err != nil {
 			code, msg, _ := s2ErrorToS3Error(err)
 			result.Errors = append(result.Errors, DeleteError{

--- a/server/handlers/s3api/objects_test.go
+++ b/server/handlers/s3api/objects_test.go
@@ -153,10 +153,10 @@ func (s *ObjectsTestSuite) TestListObjects() {
 		s.putObject("nda", "docs/c.txt", "c")
 
 		testCases := []struct {
-			caseName       string
-			prefix         string
-			wantContents   []string
-			wantPrefixes   []string
+			caseName     string
+			prefix       string
+			wantContents []string
+			wantPrefixes []string
 		}{
 			{
 				caseName:     "partial prefix matches subdir as common prefix",
@@ -624,9 +624,9 @@ func (s *ObjectsTestSuite) TestPutObject_AWSChunked() {
 	const chunkSize = 64 * 1024
 
 	testCases := []struct {
-		caseName    string
-		setHeaders  func(r *http.Request)
-		key         string
+		caseName   string
+		setHeaders func(r *http.Request)
+		key        string
 	}{
 		{
 			caseName: "Content-Encoding aws-chunked",
@@ -715,7 +715,7 @@ func (s *ObjectsTestSuite) TestMetadata() {
 		s.Equal("alice", getW.Header().Get("x-amz-meta-author"))
 		s.Equal("42", getW.Header().Get("x-amz-meta-version"))
 		// Internal metadata key should not leak
-		s.Empty(getW.Header().Get("x-amz-meta-"+etagMetadataKey))
+		s.Empty(getW.Header().Get("x-amz-meta-" + etagMetadataKey))
 	})
 
 	s.Run("no metadata headers", func() {
@@ -866,6 +866,35 @@ func (s *ObjectsTestSuite) TestCopyObject() {
 
 		s.Equal(http.StatusNotFound, w.Code)
 	})
+
+	s.Run("source without GetObject rights is denied even with PutObject on destination", func() {
+		s.putObject("private-bkt", "secret.txt", "top secret")
+		s.createBucket("scratch")
+
+		// Only s3:PutObject on scratch/* -- no read rights anywhere,
+		// including on the copy source in private-bkt.
+		user := &server.User{Policy: &server.Policy{Statement: []server.Statement{
+			{Effect: "Allow", Action: []string{server.ActionPutObject}, Resource: []string{"arn:aws:s3:::scratch/*"}},
+		}}}
+
+		req := httptest.NewRequest("PUT", "/scratch/leak.txt", nil)
+		req.SetPathValue("bucket", "scratch")
+		req.SetPathValue("key", "leak.txt")
+		req.Header.Set("x-amz-copy-source", "/private-bkt/secret.txt")
+		req = req.WithContext(server.WithUser(req.Context(), user))
+		w := httptest.NewRecorder()
+		handlePutObject(s.server, w, req)
+
+		s.Equal(http.StatusForbidden, w.Code)
+
+		// leak.txt must not have been created.
+		getReq := httptest.NewRequest("GET", "/scratch/leak.txt", nil)
+		getReq.SetPathValue("bucket", "scratch")
+		getReq.SetPathValue("key", "leak.txt")
+		getW := httptest.NewRecorder()
+		handleGetObject(s.server, getW, getReq)
+		s.Equal(http.StatusNotFound, getW.Code)
+	})
 }
 
 // --- DeleteObject ---
@@ -991,6 +1020,39 @@ func (s *ObjectsTestSuite) TestDeleteObjects() {
 		var errResp ErrorResponse
 		s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &errResp))
 		s.Equal("MalformedXML", errResp.Code)
+	})
+
+	s.Run("policy scoped to a prefix authorizes matching keys and denies others", func() {
+		s.putObject("dpol", "tmp/a.txt", "1")
+		s.putObject("dpol", "keep/b.txt", "2")
+
+		user := &server.User{Policy: &server.Policy{Statement: []server.Statement{
+			{Effect: "Allow", Action: []string{server.ActionDeleteObject}, Resource: []string{"arn:aws:s3:::dpol/tmp/*"}},
+		}}}
+
+		body := `<Delete><Object><Key>tmp/a.txt</Key></Object><Object><Key>keep/b.txt</Key></Object></Delete>`
+		req := httptest.NewRequest("POST", "/dpol?delete", strings.NewReader(body))
+		req.SetPathValue("bucket", "dpol")
+		req = req.WithContext(server.WithUser(req.Context(), user))
+		w := httptest.NewRecorder()
+		handleDeleteObjects(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		var result DeleteObjectsResult
+		s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &result))
+		s.Len(result.Deleted, 1)
+		s.Equal("tmp/a.txt", result.Deleted[0].Key)
+		s.Len(result.Errors, 1)
+		s.Equal("keep/b.txt", result.Errors[0].Key)
+		s.Equal("AccessDenied", result.Errors[0].Code)
+
+		// keep/b.txt must survive the denied delete.
+		getReq := httptest.NewRequest("GET", "/dpol/keep/b.txt", nil)
+		getReq.SetPathValue("bucket", "dpol")
+		getReq.SetPathValue("key", "keep/b.txt")
+		getW := httptest.NewRecorder()
+		handleGetObject(s.server, getW, getReq)
+		s.Equal(http.StatusOK, getW.Code)
 	})
 
 	s.Run("dispatched via handleBucketPOST", func() {

--- a/server/handlers/s3api/utils.go
+++ b/server/handlers/s3api/utils.go
@@ -2,11 +2,9 @@ package s3api
 
 import (
 	"bufio"
-	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -23,23 +21,11 @@ const (
 )
 
 func writeXML(w http.ResponseWriter, status int, v interface{}) {
-	w.Header().Set("Content-Type", "application/xml")
-	w.WriteHeader(status)
-	_, _ = fmt.Fprint(w, xml.Header)
-	enc := xml.NewEncoder(w)
-	if err := enc.Encode(v); err != nil {
-		slog.Error("Failed to encode XML", "error", err)
-	}
+	server.WriteXML(w, status, v)
 }
 
 func writeError(w http.ResponseWriter, r *http.Request, code string, message string, status int) {
-	resp := ErrorResponse{
-		Code:      code,
-		Message:   message,
-		Resource:  r.URL.Path,
-		RequestID: "s2-request-id",
-	}
-	writeXML(w, status, resp)
+	server.WriteS3Error(w, r, code, message, status)
 }
 
 // ErrNoSuchBucket is returned when a bucket does not exist.

--- a/server/middleware/basicauth.go
+++ b/server/middleware/basicauth.go
@@ -8,21 +8,34 @@ import (
 )
 
 // BasicAuth returns a handler that enforces HTTP Basic Auth for Web Console routes.
-// Authentication is skipped when User is not configured.
+// Authentication is skipped when no credentials are configured (AuthEnabled false).
+//
+// Login itself is not policy-gated -- any configured user, restricted or
+// not, may log in (matching MinIO's behavior). Once authenticated, each
+// request is checked against the matched user's Policy (if any) using
+// ConsoleAction, and the matched user is stashed on the request context
+// (server.WithUser) so handlers such as the bucket-list page can filter
+// their results by the same policy.
 func BasicAuth(next server.HandlerFunc) server.HandlerFunc {
 	return func(srv *server.Server, w http.ResponseWriter, r *http.Request) {
-		if srv.Config.User == "" {
+		if !srv.Config.AuthEnabled() {
 			next(srv, w, r)
 			return
 		}
 		user, pass, ok := r.BasicAuth()
-		if !ok ||
-			subtle.ConstantTimeCompare([]byte(user), []byte(srv.Config.User)) != 1 ||
-			subtle.ConstantTimeCompare([]byte(pass), []byte(srv.Config.Password)) != 1 {
+		u := srv.Config.LookupUser(user)
+		if !ok || u == nil || subtle.ConstantTimeCompare([]byte(pass), []byte(u.SecretAccessKey)) != 1 {
 			w.Header().Set("WWW-Authenticate", `Basic realm="s2"`)
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
-		next(srv, w, r)
+
+		action, resource := server.ConsoleAction(r)
+		if !server.Authorized(u, action, resource) {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return
+		}
+
+		next(srv, w, r.WithContext(server.WithUser(r.Context(), u)))
 	}
 }

--- a/server/middleware/basicauth_test.go
+++ b/server/middleware/basicauth_test.go
@@ -15,24 +15,24 @@ func noopHandler(_ *server.Server, w http.ResponseWriter, _ *http.Request) {
 
 func TestBasicAuth(t *testing.T) {
 	testCases := []struct {
-		caseName       string
-		user           string
-		password       string
-		setBasicAuth   bool
-		authUser       string
-		authPass       string
-		wantStatus     int
-		wantWWWAuth    string
+		caseName     string
+		user         string
+		password     string
+		setBasicAuth bool
+		authUser     string
+		authPass     string
+		wantStatus   int
+		wantWWWAuth  string
 	}{
 		{
 			caseName:   "auth disabled",
 			wantStatus: http.StatusOK,
 		},
 		{
-			caseName:   "missing credentials",
-			user:       "admin",
-			password:   "secret",
-			wantStatus: http.StatusUnauthorized,
+			caseName:    "missing credentials",
+			user:        "admin",
+			password:    "secret",
+			wantStatus:  http.StatusUnauthorized,
 			wantWWWAuth: `Basic realm="s2"`,
 		},
 		{
@@ -81,6 +81,88 @@ func TestBasicAuth(t *testing.T) {
 			if tc.wantWWWAuth != "" {
 				assert.Equal(t, tc.wantWWWAuth, w.Header().Get("WWW-Authenticate"))
 			}
+		})
+	}
+}
+
+func TestBasicAuthMultiUser(t *testing.T) {
+	readOnlyPolicy := &server.Policy{Statement: []server.Statement{
+		{Effect: "Allow", Action: []string{"s3:ListAllMyBuckets", "s3:ListBucket", "s3:GetObject"}, Resource: []string{"arn:aws:s3:::*"}},
+	}}
+	cfg := &server.Config{
+		Users: []server.User{
+			{AccessKeyID: "userA", SecretAccessKey: "secretA"},
+			{AccessKeyID: "userB", SecretAccessKey: "secretB", Policy: readOnlyPolicy},
+		},
+	}
+
+	testCases := []struct {
+		caseName   string
+		method     string
+		url        string
+		name       string
+		authUser   string
+		authPass   string
+		wantStatus int
+	}{
+		{
+			caseName:   "restricted user login succeeds (login is not policy-gated)",
+			method:     http.MethodGet,
+			url:        "/",
+			authUser:   "userB",
+			authPass:   "secretB",
+			wantStatus: http.StatusOK,
+		},
+		{
+			caseName:   "wrong password for valid access key rejected",
+			method:     http.MethodGet,
+			url:        "/",
+			authUser:   "userB",
+			authPass:   "wrong",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			caseName:   "restricted user denied console action gets 403",
+			method:     http.MethodDelete,
+			url:        "/buckets/mybucket",
+			name:       "mybucket",
+			authUser:   "userB",
+			authPass:   "secretB",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			caseName:   "restricted user allowed console action passes",
+			method:     http.MethodGet,
+			url:        "/buckets/mybucket",
+			name:       "mybucket",
+			authUser:   "userB",
+			authPass:   "secretB",
+			wantStatus: http.StatusOK,
+		},
+		{
+			caseName:   "unrestricted user allowed anything",
+			method:     http.MethodDelete,
+			url:        "/buckets/mybucket",
+			name:       "mybucket",
+			authUser:   "userA",
+			authPass:   "secretA",
+			wantStatus: http.StatusOK,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			srv := &server.Server{Config: cfg}
+			handler := BasicAuth(noopHandler)
+
+			r := httptest.NewRequest(tc.method, tc.url, nil)
+			if tc.name != "" {
+				r.SetPathValue("name", tc.name)
+			}
+			r.SetBasicAuth(tc.authUser, tc.authPass)
+			w := httptest.NewRecorder()
+			handler(srv, w, r)
+
+			assert.Equal(t, tc.wantStatus, w.Code)
 		})
 	}
 }

--- a/server/middleware/basicauth_test.go
+++ b/server/middleware/basicauth_test.go
@@ -89,10 +89,18 @@ func TestBasicAuthMultiUser(t *testing.T) {
 	readOnlyPolicy := &server.Policy{Statement: []server.Statement{
 		{Effect: "Allow", Action: []string{"s3:ListAllMyBuckets", "s3:ListBucket", "s3:GetObject"}, Resource: []string{"arn:aws:s3:::*"}},
 	}}
+	// noListAllBucketsPolicy deliberately omits s3:ListAllMyBuckets, unlike
+	// readOnlyPolicy above -- GET / must still succeed for this user since
+	// it's the console's only entry point (see ConsoleAction's doc
+	// comment on the GET / case).
+	noListAllBucketsPolicy := &server.Policy{Statement: []server.Statement{
+		{Effect: "Allow", Action: []string{"s3:ListBucket", "s3:GetObject"}, Resource: []string{"arn:aws:s3:::visible"}},
+	}}
 	cfg := &server.Config{
 		Users: []server.User{
 			{AccessKeyID: "userA", SecretAccessKey: "secretA"},
 			{AccessKeyID: "userB", SecretAccessKey: "secretB", Policy: readOnlyPolicy},
+			{AccessKeyID: "userC", SecretAccessKey: "secretC", Policy: noListAllBucketsPolicy},
 		},
 	}
 
@@ -146,6 +154,14 @@ func TestBasicAuthMultiUser(t *testing.T) {
 			name:       "mybucket",
 			authUser:   "userA",
 			authPass:   "secretA",
+			wantStatus: http.StatusOK,
+		},
+		{
+			caseName:   "user without s3:ListAllMyBuckets can still reach the console home page",
+			method:     http.MethodGet,
+			url:        "/",
+			authUser:   "userC",
+			authPass:   "secretC",
 			wantStatus: http.StatusOK,
 		},
 	}

--- a/server/middleware/sigv4.go
+++ b/server/middleware/sigv4.go
@@ -25,31 +25,53 @@ const (
 )
 
 // SigV4 returns a handler that enforces AWS Signature Version 4 authentication for S3 API routes.
-// Authentication is skipped when User is not configured.
+// Authentication is skipped when no credentials are configured (AuthEnabled false).
 // Requests with X-Amz-Date outside ±15 minutes of server time are rejected.
+//
+// After a successful signature verification, if the matched User carries a
+// Policy, the request's S3 action/resource (see S3Action) is checked against
+// it; a denied request gets a 403 AccessDenied response distinct from the
+// SignatureDoesNotMatch used for verification failures. The matched User is
+// stashed on the request context (server.WithUser) so handlers such as
+// HandleListBuckets can filter their results by the same policy.
 func SigV4(next server.HandlerFunc) server.HandlerFunc {
 	return func(srv *server.Server, w http.ResponseWriter, r *http.Request) {
-		if srv.Config.User == "" {
+		if !srv.Config.AuthEnabled() {
 			next(srv, w, r)
 			return
 		}
+
+		lookup := func(accessKeyID string) (*server.User, bool) {
+			u := srv.Config.LookupUser(accessKeyID)
+			return u, u != nil
+		}
+
 		// AWS prefers the Authorization header when both are present.
 		// Fall back to query-string (presigned URL) verification when the header is absent.
+		var matched *server.User
 		var err error
 		if r.Header.Get("Authorization") == "" && r.URL.Query().Get("X-Amz-Algorithm") != "" {
-			err = verifyPresignedV4(r, srv.Config.User, srv.Config.Password, time.Now().UTC())
+			matched, err = verifyPresignedV4(r, lookup, time.Now().UTC())
 		} else {
-			err = verifySignatureV4(r, srv.Config.User, srv.Config.Password)
+			matched, err = verifySignatureV4(r, lookup)
 		}
 		if err != nil {
 			writeS3AuthError(w, r, err.Error())
 			return
 		}
-		next(srv, w, r)
+
+		bucket, key := r.PathValue("bucket"), r.PathValue("key")
+		action, resource := server.S3Action(r, bucket, key)
+		if !server.Authorized(matched, action, resource) {
+			writeS3AccessDeniedError(w, r)
+			return
+		}
+
+		next(srv, w, r.WithContext(server.WithUser(r.Context(), matched)))
 	}
 }
 
-func writeS3AuthError(w http.ResponseWriter, r *http.Request, message string) {
+func writeS3Error(w http.ResponseWriter, r *http.Request, code, message string, status int) {
 	type ErrorResponse struct {
 		XMLName   xml.Name `xml:"Error"`
 		Code      string   `xml:"Code"`
@@ -58,13 +80,13 @@ func writeS3AuthError(w http.ResponseWriter, r *http.Request, message string) {
 		RequestID string   `xml:"RequestId"`
 	}
 	resp := ErrorResponse{
-		Code:      "SignatureDoesNotMatch",
+		Code:      code,
 		Message:   message,
 		Resource:  r.URL.Path,
 		RequestID: "s2-request-id",
 	}
 	w.Header().Set("Content-Type", "application/xml")
-	w.WriteHeader(http.StatusForbidden)
+	w.WriteHeader(status)
 	_, _ = fmt.Fprint(w, xml.Header)
 	enc := xml.NewEncoder(w)
 	if err := enc.Encode(resp); err != nil {
@@ -72,14 +94,25 @@ func writeS3AuthError(w http.ResponseWriter, r *http.Request, message string) {
 	}
 }
 
+func writeS3AuthError(w http.ResponseWriter, r *http.Request, message string) {
+	writeS3Error(w, r, "SignatureDoesNotMatch", message, http.StatusForbidden)
+}
+
+func writeS3AccessDeniedError(w http.ResponseWriter, r *http.Request) {
+	writeS3Error(w, r, "AccessDenied", "Access Denied", http.StatusForbidden)
+}
+
 // verifySignatureV4 verifies the AWS Signature Version 4 of an HTTP request.
-func verifySignatureV4(r *http.Request, accessKeyID, secretAccessKey string) error {
+// lookup resolves the request's access key ID to the matching User, or
+// ok=false for an unrecognized access key. On success, the matched User is
+// returned directly rather than threaded back through a captured variable.
+func verifySignatureV4(r *http.Request, lookup func(accessKeyID string) (user *server.User, ok bool)) (*server.User, error) {
 	authHeader := r.Header.Get("Authorization")
 	if authHeader == "" {
-		return fmt.Errorf("missing Authorization header")
+		return nil, fmt.Errorf("missing Authorization header")
 	}
 	if !strings.HasPrefix(authHeader, "AWS4-HMAC-SHA256 ") {
-		return fmt.Errorf("unsupported authorization scheme")
+		return nil, fmt.Errorf("unsupported authorization scheme")
 	}
 
 	parts := parseAuthHeader(authHeader[len("AWS4-HMAC-SHA256 "):])
@@ -87,33 +120,34 @@ func verifySignatureV4(r *http.Request, accessKeyID, secretAccessKey string) err
 	signedHeadersStr := parts["SignedHeaders"]
 	signature := parts["Signature"]
 	if credential == "" || signedHeadersStr == "" || signature == "" {
-		return fmt.Errorf("malformed Authorization header")
+		return nil, fmt.Errorf("malformed Authorization header")
 	}
 
 	// Credential = <access-key>/<date>/<region>/<service>/aws4_request
 	credParts := strings.SplitN(credential, "/", 5)
 	if len(credParts) != 5 {
-		return fmt.Errorf("malformed Credential")
+		return nil, fmt.Errorf("malformed Credential")
 	}
 	reqAccessKey := credParts[0]
 	date := credParts[1]
 	region := credParts[2]
 	service := credParts[3]
 
-	if subtle.ConstantTimeCompare([]byte(reqAccessKey), []byte(accessKeyID)) != 1 {
-		return fmt.Errorf("invalid access key")
+	user, ok := lookup(reqAccessKey)
+	if !ok {
+		return nil, fmt.Errorf("invalid access key")
 	}
 
 	datetime := r.Header.Get("X-Amz-Date")
 	if datetime == "" {
-		return fmt.Errorf("missing X-Amz-Date header")
+		return nil, fmt.Errorf("missing X-Amz-Date header")
 	}
 	reqTime, err := time.Parse("20060102T150405Z", datetime)
 	if err != nil {
-		return fmt.Errorf("invalid X-Amz-Date: %w", err)
+		return nil, fmt.Errorf("invalid X-Amz-Date: %w", err)
 	}
 	if diff := time.Since(reqTime).Abs(); diff > sigV4MaxClockSkew {
-		return fmt.Errorf("request timestamp too skewed: %v", diff.Round(time.Second))
+		return nil, fmt.Errorf("request timestamp too skewed: %v", diff.Round(time.Second))
 	}
 
 	signedHeaders := strings.Split(signedHeadersStr, ";")
@@ -126,22 +160,24 @@ func verifySignatureV4(r *http.Request, accessKeyID, secretAccessKey string) err
 	scope := date + "/" + region + "/" + service + "/aws4_request"
 	stringToSign := "AWS4-HMAC-SHA256\n" + datetime + "\n" + scope + "\n" + hashSHA256(canonReq)
 
-	signingKey := buildSigningKey(secretAccessKey, date, region, service)
+	signingKey := buildSigningKey(user.SecretAccessKey, date, region, service)
 	expected := hex.EncodeToString(hmacSHA256(signingKey, []byte(stringToSign)))
 
 	if subtle.ConstantTimeCompare([]byte(expected), []byte(signature)) != 1 {
-		return fmt.Errorf("signature mismatch")
+		return nil, fmt.Errorf("signature mismatch")
 	}
-	return nil
+	return user, nil
 }
 
 // verifyPresignedV4 verifies an AWS Signature Version 4 presigned URL request.
 // The signature is carried in query parameters (X-Amz-*) instead of the Authorization header,
 // and the body is treated as UNSIGNED-PAYLOAD per the presigned-URL spec.
-func verifyPresignedV4(r *http.Request, accessKeyID, secretAccessKey string, now time.Time) error {
+// lookup resolves the request's access key ID to the matching User, or
+// ok=false for an unrecognized access key.
+func verifyPresignedV4(r *http.Request, lookup func(accessKeyID string) (user *server.User, ok bool), now time.Time) (*server.User, error) {
 	q := r.URL.Query()
 	if algo := q.Get("X-Amz-Algorithm"); algo != "AWS4-HMAC-SHA256" {
-		return fmt.Errorf("unsupported X-Amz-Algorithm: %q", algo)
+		return nil, fmt.Errorf("unsupported X-Amz-Algorithm: %q", algo)
 	}
 	credential := q.Get("X-Amz-Credential")
 	datetime := q.Get("X-Amz-Date")
@@ -149,33 +185,34 @@ func verifyPresignedV4(r *http.Request, accessKeyID, secretAccessKey string, now
 	signedHeadersStr := q.Get("X-Amz-SignedHeaders")
 	signature := q.Get("X-Amz-Signature")
 	if credential == "" || datetime == "" || expiresStr == "" || signedHeadersStr == "" || signature == "" {
-		return fmt.Errorf("missing presigned query parameters")
+		return nil, fmt.Errorf("missing presigned query parameters")
 	}
 
 	// Credential = <access-key>/<date>/<region>/<service>/aws4_request
 	credParts := strings.SplitN(credential, "/", 5)
 	if len(credParts) != 5 {
-		return fmt.Errorf("malformed Credential")
+		return nil, fmt.Errorf("malformed Credential")
 	}
 	reqAccessKey := credParts[0]
 	date := credParts[1]
 	region := credParts[2]
 	service := credParts[3]
 
-	if subtle.ConstantTimeCompare([]byte(reqAccessKey), []byte(accessKeyID)) != 1 {
-		return fmt.Errorf("invalid access key")
+	user, ok := lookup(reqAccessKey)
+	if !ok {
+		return nil, fmt.Errorf("invalid access key")
 	}
 
 	reqTime, err := time.Parse("20060102T150405Z", datetime)
 	if err != nil {
-		return fmt.Errorf("invalid X-Amz-Date: %w", err)
+		return nil, fmt.Errorf("invalid X-Amz-Date: %w", err)
 	}
 	expires, err := strconv.Atoi(expiresStr)
 	if err != nil || expires <= 0 {
-		return fmt.Errorf("invalid X-Amz-Expires: %q", expiresStr)
+		return nil, fmt.Errorf("invalid X-Amz-Expires: %q", expiresStr)
 	}
 	if now.After(reqTime.Add(time.Duration(expires) * time.Second)) {
-		return fmt.Errorf("presigned URL expired")
+		return nil, fmt.Errorf("presigned URL expired")
 	}
 
 	signedHeaders := strings.Split(signedHeadersStr, ";")
@@ -186,13 +223,13 @@ func verifyPresignedV4(r *http.Request, accessKeyID, secretAccessKey string, now
 	scope := date + "/" + region + "/" + service + "/aws4_request"
 	stringToSign := "AWS4-HMAC-SHA256\n" + datetime + "\n" + scope + "\n" + hashSHA256(canonReq)
 
-	signingKey := buildSigningKey(secretAccessKey, date, region, service)
+	signingKey := buildSigningKey(user.SecretAccessKey, date, region, service)
 	expected := hex.EncodeToString(hmacSHA256(signingKey, []byte(stringToSign)))
 
 	if subtle.ConstantTimeCompare([]byte(expected), []byte(signature)) != 1 {
-		return fmt.Errorf("signature mismatch")
+		return nil, fmt.Errorf("signature mismatch")
 	}
-	return nil
+	return user, nil
 }
 
 // stripQueryParam removes all occurrences of name from a raw (unparsed) query string,

--- a/server/middleware/sigv4.go
+++ b/server/middleware/sigv4.go
@@ -5,9 +5,7 @@ import (
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
-	"encoding/xml"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"net/url"
 	"sort"
@@ -71,35 +69,12 @@ func SigV4(next server.HandlerFunc) server.HandlerFunc {
 	}
 }
 
-func writeS3Error(w http.ResponseWriter, r *http.Request, code, message string, status int) {
-	type ErrorResponse struct {
-		XMLName   xml.Name `xml:"Error"`
-		Code      string   `xml:"Code"`
-		Message   string   `xml:"Message"`
-		Resource  string   `xml:"Resource"`
-		RequestID string   `xml:"RequestId"`
-	}
-	resp := ErrorResponse{
-		Code:      code,
-		Message:   message,
-		Resource:  r.URL.Path,
-		RequestID: "s2-request-id",
-	}
-	w.Header().Set("Content-Type", "application/xml")
-	w.WriteHeader(status)
-	_, _ = fmt.Fprint(w, xml.Header)
-	enc := xml.NewEncoder(w)
-	if err := enc.Encode(resp); err != nil {
-		slog.Error("Failed to encode XML", "error", err)
-	}
-}
-
 func writeS3AuthError(w http.ResponseWriter, r *http.Request, message string) {
-	writeS3Error(w, r, "SignatureDoesNotMatch", message, http.StatusForbidden)
+	server.WriteS3Error(w, r, "SignatureDoesNotMatch", message, http.StatusForbidden)
 }
 
 func writeS3AccessDeniedError(w http.ResponseWriter, r *http.Request) {
-	writeS3Error(w, r, "AccessDenied", "Access Denied", http.StatusForbidden)
+	server.WriteS3Error(w, r, "AccessDenied", "Access Denied", http.StatusForbidden)
 }
 
 // verifySignatureV4 verifies the AWS Signature Version 4 of an HTTP request.

--- a/server/middleware/sigv4_test.go
+++ b/server/middleware/sigv4_test.go
@@ -267,6 +267,181 @@ func TestSigV4Presigned(t *testing.T) {
 	}
 }
 
+func TestSigV4MultiUser(t *testing.T) {
+	readOnlyPolicy := &server.Policy{Statement: []server.Statement{
+		{Effect: "Allow", Action: []string{"s3:GetObject", "s3:ListBucket"}, Resource: []string{"arn:aws:s3:::*"}},
+	}}
+	cfg := &server.Config{
+		Users: []server.User{
+			{AccessKeyID: "userA", SecretAccessKey: "secretA"},
+			{AccessKeyID: "userB", SecretAccessKey: "secretB", Policy: readOnlyPolicy},
+		},
+	}
+
+	testCases := []struct {
+		caseName   string
+		method     string
+		url        string
+		bucket     string
+		key        string
+		signFunc   func(r *http.Request)
+		wantStatus int
+	}{
+		{
+			caseName:   "request resolves against matching user's secret",
+			method:     http.MethodGet,
+			url:        "/",
+			signFunc:   func(r *http.Request) { signRequest(r, "userA", "secretA") },
+			wantStatus: http.StatusOK,
+		},
+		{
+			caseName:   "signature with wrong user's secret rejected",
+			method:     http.MethodGet,
+			url:        "/",
+			signFunc:   func(r *http.Request) { signRequest(r, "userA", "secretB") },
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			caseName:   "unknown access key rejected",
+			method:     http.MethodGet,
+			url:        "/",
+			signFunc:   func(r *http.Request) { signRequest(r, "unknown", "whatever") },
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			caseName:   "restricted user allowed action passes",
+			method:     http.MethodGet,
+			url:        "/mybucket/key.txt",
+			bucket:     "mybucket",
+			key:        "key.txt",
+			signFunc:   func(r *http.Request) { signRequest(r, "userB", "secretB") },
+			wantStatus: http.StatusOK,
+		},
+		{
+			caseName:   "restricted user denied action gets 403",
+			method:     http.MethodPut,
+			url:        "/mybucket/key.txt",
+			bucket:     "mybucket",
+			key:        "key.txt",
+			signFunc:   func(r *http.Request) { signRequest(r, "userB", "secretB") },
+			wantStatus: http.StatusForbidden,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			srv := &server.Server{Config: cfg}
+			handler := SigV4(noopHandler)
+
+			r := httptest.NewRequest(tc.method, tc.url, nil)
+			r.SetPathValue("bucket", tc.bucket)
+			r.SetPathValue("key", tc.key)
+			if tc.signFunc != nil {
+				tc.signFunc(r)
+			}
+			w := httptest.NewRecorder()
+			handler(srv, w, r)
+
+			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
+}
+
+func TestSigV4MultiUserAccessDeniedDistinctFromSignatureError(t *testing.T) {
+	cfg := &server.Config{
+		Users: []server.User{
+			{AccessKeyID: "userB", SecretAccessKey: "secretB", Policy: &server.Policy{Statement: []server.Statement{
+				{Effect: "Allow", Action: []string{"s3:GetObject"}, Resource: []string{"arn:aws:s3:::*"}},
+			}}},
+		},
+	}
+	srv := &server.Server{Config: cfg}
+	handler := SigV4(noopHandler)
+
+	r := httptest.NewRequest(http.MethodPut, "/bucket/key", nil)
+	r.SetPathValue("bucket", "bucket")
+	r.SetPathValue("key", "key")
+	signRequest(r, "userB", "secretB")
+	w := httptest.NewRecorder()
+	handler(srv, w, r)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "AccessDenied")
+	assert.NotContains(t, w.Body.String(), "SignatureDoesNotMatch")
+}
+
+// TestSigV4BatchDeletePassesThroughForNarrowPolicy verifies that a user
+// whose policy is scoped to a bucket sub-prefix (e.g. arn:aws:s3:::bucket/
+// tmp/*) is not denied at the SigV4 layer for POST /{bucket}?delete, even
+// though none of that user's Resource patterns match the coarse
+// arn:aws:s3:::bucket/* the middleware used to check up front. S3Action now
+// returns no action/resource for this route, deferring the real per-key
+// check to handleDeleteObjects (server/handlers/s3api/objects.go).
+func TestSigV4BatchDeletePassesThroughForNarrowPolicy(t *testing.T) {
+	cfg := &server.Config{
+		Users: []server.User{
+			{AccessKeyID: "userC", SecretAccessKey: "secretC", Policy: &server.Policy{Statement: []server.Statement{
+				{Effect: "Allow", Action: []string{server.ActionDeleteObject}, Resource: []string{"arn:aws:s3:::bucket/tmp/*"}},
+			}}},
+		},
+	}
+	srv := &server.Server{Config: cfg}
+	handler := SigV4(noopHandler)
+
+	r := httptest.NewRequest(http.MethodPost, "/bucket?delete", nil)
+	r.SetPathValue("bucket", "bucket")
+	signRequest(r, "userC", "secretC")
+	w := httptest.NewRecorder()
+	handler(srv, w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestSigV4PresignedMultiUser(t *testing.T) {
+	cfg := &server.Config{
+		Users: []server.User{
+			{AccessKeyID: "userA", SecretAccessKey: "secretA"},
+			{AccessKeyID: "userB", SecretAccessKey: "secretB", Policy: &server.Policy{Statement: []server.Statement{
+				{Effect: "Allow", Action: []string{"s3:GetObject"}, Resource: []string{"arn:aws:s3:::*"}},
+			}}},
+		},
+	}
+
+	testCases := []struct {
+		caseName   string
+		method     string
+		setup      func(r *http.Request)
+		wantStatus int
+	}{
+		{
+			caseName:   "resolves against matching user's secret",
+			method:     http.MethodGet,
+			setup:      func(r *http.Request) { presignRequest(r, "userA", "secretA", 300) },
+			wantStatus: http.StatusOK,
+		},
+		{
+			caseName:   "restricted user denied action gets 403",
+			method:     http.MethodPut,
+			setup:      func(r *http.Request) { presignRequest(r, "userB", "secretB", 300) },
+			wantStatus: http.StatusForbidden,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			srv := &server.Server{Config: cfg}
+			handler := SigV4(noopHandler)
+
+			r := httptest.NewRequest(tc.method, "/bucket/key", nil)
+			r.SetPathValue("bucket", "bucket")
+			r.SetPathValue("key", "key")
+			tc.setup(r)
+			w := httptest.NewRecorder()
+			handler(srv, w, r)
+
+			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
+}
+
 func TestStripQueryParam(t *testing.T) {
 	testCases := []struct {
 		caseName string

--- a/server/middleware/sigv4_test.go
+++ b/server/middleware/sigv4_test.go
@@ -396,6 +396,46 @@ func TestSigV4BatchDeletePassesThroughForNarrowPolicy(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
+// TestSigV4TrailingSlashBucketGetRequiresListBucket verifies that a
+// GetObject-only policy cannot use a trailing-slash bucket URL (e.g.
+// "GET /bucket/", the form minio-go/warp send by default) to bypass a
+// missing s3:ListBucket grant. handleGetObject delegates key=="" back to
+// handleBucketGET/handleHeadBucket regardless of the trailing slash, so
+// S3Action must authorize these as bucket-level actions, not s3:GetObject.
+func TestSigV4TrailingSlashBucketGetRequiresListBucket(t *testing.T) {
+	cfg := &server.Config{
+		Users: []server.User{
+			{AccessKeyID: "userD", SecretAccessKey: "secretD", Policy: &server.Policy{Statement: []server.Statement{
+				{Effect: "Allow", Action: []string{server.ActionGetObject}, Resource: []string{"arn:aws:s3:::bucket/*"}},
+			}}},
+		},
+	}
+	srv := &server.Server{Config: cfg}
+	handler := SigV4(noopHandler)
+
+	testCases := []struct {
+		caseName string
+		method   string
+		url      string
+	}{
+		{caseName: "GET with trailing slash", method: http.MethodGet, url: "/bucket/"},
+		{caseName: "HEAD with trailing slash", method: http.MethodHead, url: "/bucket/"},
+		{caseName: "GetBucketLocation with trailing slash", method: http.MethodGet, url: "/bucket/?location"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			r := httptest.NewRequest(tc.method, tc.url, nil)
+			r.SetPathValue("bucket", "bucket")
+			r.SetPathValue("key", "")
+			signRequest(r, "userD", "secretD")
+			w := httptest.NewRecorder()
+			handler(srv, w, r)
+
+			assert.Equal(t, http.StatusForbidden, w.Code)
+		})
+	}
+}
+
 func TestSigV4PresignedMultiUser(t *testing.T) {
 	cfg := &server.Config{
 		Users: []server.User{

--- a/server/policy.go
+++ b/server/policy.go
@@ -10,7 +10,10 @@ import (
 // S3 IAM action names, shared between S3Action and ConsoleAction so a typo
 // in one mapping can't silently drift from the other.
 const (
-	actionListAllMyBuckets = "s3:ListAllMyBuckets"
+	// ActionListAllMyBuckets is exported: HandleListBuckets (S3 API GET /)
+	// checks it explicitly via ExplicitlyDeniedListAllMyBuckets. It is not
+	// returned by S3Action itself -- see that function's doc comment.
+	ActionListAllMyBuckets = "s3:ListAllMyBuckets"
 	// ActionCreateBucket is exported: the console's handleCreateBucket
 	// checks a form-parsed bucket name directly via AllowedS3BucketAction.
 	ActionCreateBucket      = "s3:CreateBucket"
@@ -121,6 +124,20 @@ func (p *Policy) Allowed(action, resource string) bool {
 	return allowed
 }
 
+// explicitlyDenied reports whether policy has a Deny statement matching
+// action and resource, ignoring any Allow. Unlike Allowed, whose default
+// (no matching statement) is deny, the default here is "not denied" -- for
+// callers where the baseline is already permit and an explicit Deny should
+// layer a hard block on top of that baseline.
+func (p *Policy) explicitlyDenied(action, resource string) bool {
+	for _, stmt := range p.Statement {
+		if stmt.Effect == "Deny" && stmt.matches(action, resource) {
+			return true
+		}
+	}
+	return false
+}
+
 func (stmt Statement) matches(action, resource string) bool {
 	return matchAny(stmt.Action, action) && matchAny(stmt.Resource, resource)
 }
@@ -229,6 +246,49 @@ func AllowedS3Action(user *User, action, bucket, key string) bool {
 	return Authorized(user, action, objectARN(bucket, key))
 }
 
+// ExplicitlyDeniedListAllMyBuckets reports whether user has an explicit
+// Deny statement for s3:ListAllMyBuckets. A nil user or a user with no
+// Policy is never denied.
+//
+// S3Action doesn't gate GET / (ListBuckets) on s3:ListAllMyBuckets at all
+// -- it always defers to FilterBucketNames, so a policy scoped to only a
+// few buckets isn't locked out of the endpoint entirely (see S3Action's
+// doc comment). But that means an explicit Deny on s3:ListAllMyBuckets,
+// which a policy author porting an AWS-style policy would expect to hard
+// -block the endpoint, would otherwise be silently ignored. HandleListBuckets
+// calls this to layer that specific block back on top of the deferred
+// default, without requiring every caller to hold an explicit Allow.
+func ExplicitlyDeniedListAllMyBuckets(user *User) bool {
+	if user == nil || user.Policy == nil {
+		return false
+	}
+	return user.Policy.explicitlyDenied(ActionListAllMyBuckets, "arn:aws:s3:::*")
+}
+
+// DenyUnlessAllowedS3BucketAction writes a 403 Forbidden response and
+// reports false if user may not perform action on bucket; otherwise it
+// reports true and writes nothing. Consolidates the repeated
+// "if !AllowedS3BucketAction(...) { http.Error(...); return }" idiom
+// duplicated across console handlers whose resource is only known once
+// the request body/query is parsed.
+func DenyUnlessAllowedS3BucketAction(w http.ResponseWriter, user *User, action, bucket string) bool {
+	if !AllowedS3BucketAction(user, action, bucket) {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return false
+	}
+	return true
+}
+
+// DenyUnlessAllowedS3Action is DenyUnlessAllowedS3BucketAction for an
+// object-level (bucket+key) resource.
+func DenyUnlessAllowedS3Action(w http.ResponseWriter, user *User, action, bucket, key string) bool {
+	if !AllowedS3Action(user, action, bucket, key) {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return false
+	}
+	return true
+}
+
 // Authorized reports whether user may perform action on resource. A nil
 // user or a user with no Policy attached (full access, including the
 // legacy single-credential user) is always allowed.
@@ -257,15 +317,36 @@ func Authorized(user *User, action, resource string) bool {
 // bucket/key path values populated by the ServeMux before middleware runs.
 // The mapping mirrors the query-parameter dispatch already implemented in
 // server/handlers/s3api/{buckets,objects,multipart}.go.
-//
-// s3:ListAllMyBuckets has no single resource to check -- it is authorized
-// as a whole against a synthetic "arn:aws:s3:::*" resource by the caller,
-// and the returned bucket list is filtered separately via FilterBucketNames.
 func S3Action(r *http.Request, bucket, key string) (action, resource string) {
 	q := r.URL.Query()
 
 	if bucket == "" {
-		return actionListAllMyBuckets, "arn:aws:s3:::*"
+		// GET / (ListBuckets) has no single resource to gate on up front;
+		// HandleListBuckets filters the result per-bucket via
+		// FilterBucketNames, mirroring ConsoleAction's GET / handling.
+		// Hard-gating the whole request on s3:ListAllMyBuckets would lock
+		// out a user who only holds narrower per-bucket grants, even
+		// though FilterBucketNames would otherwise show them a (possibly
+		// empty) filtered list. HandleListBuckets separately layers an
+		// explicit-Deny-only check on top via
+		// ExplicitlyDeniedListAllMyBuckets, so a Deny statement targeting
+		// this action still has an effect.
+		return actionDeferred, ""
+	}
+
+	// POST with an empty key covers both "POST /{bucket}?delete" (routed
+	// bucket-level, no trailing slash) and "POST /{bucket}/?delete"
+	// (routed to "/{bucket}/{key...}" with an empty key, then delegated
+	// back to handleBucketPOST by handleObjectPOST -- see the comment on
+	// handleObjectPOST in server/handlers/s3api/multipart.go). Both forms
+	// reach handleDeleteObjects, whose affected keys are only known once
+	// the body is decoded; handleDeleteObjects checks each key via
+	// AllowedS3Action instead. Handling this before the trailing-slash
+	// check below means both URL forms defer identically, rather than the
+	// trailing-slash form falling through to the object-level switch and
+	// being checked as s3:PutObject on the wrong (empty-key) resource.
+	if key == "" && r.Method == http.MethodPost {
+		return actionDeferred, ""
 	}
 
 	// key == "" is ambiguous on its own: "DELETE /{bucket}" (truly
@@ -293,10 +374,6 @@ func S3Action(r *http.Request, bucket, key string) (action, resource string) {
 			}
 			return ActionListBucket, bucketARN(bucket)
 		}
-		// Batch delete (POST /{bucket}?delete): affected keys are only
-		// known once the body is decoded. handleDeleteObjects checks each
-		// key via AllowedS3Action instead.
-		return actionDeferred, ""
 	}
 
 	switch r.Method {

--- a/server/policy.go
+++ b/server/policy.go
@@ -197,8 +197,17 @@ func isEmptyCondition(c json.RawMessage) bool {
 	return len(m) == 0
 }
 
+// resourceARNPrefix is the ARN prefix every real S3 resource this server
+// checks a policy against (see bucketARN/objectARN) starts with.
+const resourceARNPrefix = "arn:aws:s3:::"
+
 // Validate checks the policy for obvious configuration mistakes. It does
-// not validate ARN syntax deeply.
+// not validate ARN syntax deeply -- only that each Resource entry is
+// either the bare wildcard "*" or starts with the ARN prefix this server
+// actually matches against. wildcardMatch does plain string comparison,
+// so a Resource written without that prefix (e.g. "mybucket/*" instead of
+// "arn:aws:s3:::mybucket/*") would never match anything: an intended Deny
+// would silently become a permanent no-op instead of failing to load.
 func (p *Policy) Validate() error {
 	if p.Version != "" && p.Version != "2012-10-17" {
 		return fmt.Errorf("policy: unsupported Version %q", p.Version)
@@ -212,6 +221,11 @@ func (p *Policy) Validate() error {
 		}
 		if len(stmt.Resource) == 0 {
 			return fmt.Errorf("policy: statement[%d]: Resource must not be empty", i)
+		}
+		for _, r := range stmt.Resource {
+			if r != "*" && !strings.HasPrefix(r, resourceARNPrefix) {
+				return fmt.Errorf("policy: statement[%d]: Resource %q must be %q or start with %q", i, r, "*", resourceARNPrefix)
+			}
 		}
 		if !isEmptyCondition(stmt.Condition) {
 			return fmt.Errorf("policy: statement[%d]: Condition is not supported", i)

--- a/server/policy.go
+++ b/server/policy.go
@@ -10,22 +10,36 @@ import (
 // S3 IAM action names, shared between S3Action and ConsoleAction so a typo
 // in one mapping can't silently drift from the other.
 const (
-	actionListAllMyBuckets  = "s3:ListAllMyBuckets"
-	actionCreateBucket      = "s3:CreateBucket"
+	actionListAllMyBuckets = "s3:ListAllMyBuckets"
+	// ActionCreateBucket is exported: the console's handleCreateBucket
+	// checks a form-parsed bucket name directly via AllowedS3BucketAction.
+	ActionCreateBucket      = "s3:CreateBucket"
 	actionDeleteBucket      = "s3:DeleteBucket"
-	actionListBucket        = "s3:ListBucket"
 	actionGetBucketLocation = "s3:GetBucketLocation"
-	// ActionGetObject is exported for handlers that must authorize a
-	// resource distinct from the request's own bucket/key (e.g.
-	// handleCopyObject's read of its copy-source object), which S3Action
-	// can't check generically since it only derives the destination.
+	// ActionListBucket is exported for FilterBucketNames' per-bucket check.
+	ActionListBucket = "s3:ListBucket"
+	// ActionGetObject is exported: handleCopyObject checks its copy-source
+	// object, which S3Action's destination-only mapping doesn't cover.
 	ActionGetObject = "s3:GetObject"
 	ActionPutObject = "s3:PutObject"
-	// ActionDeleteObject is exported for handlers that must authorize
-	// individual resources parsed from a request body (e.g.
-	// handleDeleteObjects' per-key batch delete), which SigV4 can't check
-	// generically since the keys aren't known until the body is decoded.
+	// ActionDeleteObject is exported for per-key checks on resources
+	// S3Action/ConsoleAction can't see up front (batch delete, recursive
+	// folder delete).
 	ActionDeleteObject = "s3:DeleteObject"
+
+	// actionSkip and actionDeferred are sentinels S3Action/ConsoleAction
+	// return instead of a bare "" when no single resource can be checked
+	// up front. Authorized passes both through; any other "" means a
+	// request matched no dispatch case, so a route added without
+	// updating either function fails closed instead of silently open.
+	//   - actionSkip: no user data, no check needed (static assets).
+	//   - actionDeferred: the resource isn't known until the handler
+	//     parses the body/prefix, or the response is filtered rather
+	//     than allow/deny'd as a whole (e.g. the console home page). The
+	//     handler checks itself via AllowedS3Action/AllowedS3BucketAction
+	//     or FilterBucketNames.
+	actionSkip     = "s2:Skip"
+	actionDeferred = "s2:Deferred"
 )
 
 // Policy is an AWS-IAM-shaped authorization policy attached to a User. It
@@ -67,6 +81,13 @@ type Statement struct {
 type stringOrSlice []string
 
 func (s *stringOrSlice) UnmarshalJSON(data []byte) error {
+	// A JSON null unmarshals into a string as a silent no-op, not an
+	// error, which would let "Action": null through as stringOrSlice{""}
+	// -- non-empty, so Validate's len check wouldn't catch it, and an
+	// inert Deny would silently never apply. Reject null explicitly.
+	if string(data) == "null" {
+		return fmt.Errorf("must not be null")
+	}
 	var single string
 	if err := json.Unmarshal(data, &single); err == nil {
 		*s = stringOrSlice{single}
@@ -189,33 +210,43 @@ func bucketARN(bucket string) string {
 
 // objectARN returns the ARN for an object-level S3 resource.
 func objectARN(bucket, key string) string {
-	return "arn:aws:s3:::" + bucket + "/" + key
+	return bucketARN(bucket) + "/" + key
 }
 
-// AllowedS3Action reports whether user may perform action on the given
-// bucket/key object resource. A nil user or a user with no Policy attached
-// (full access, including the legacy single-credential user) is always
-// allowed.
-//
-// This is for handlers that authorize a resource SigV4 couldn't check
-// generically -- e.g. batch operations where the affected keys are only
-// known after the request body is decoded, so the coarse bucket-level
-// check S3Action performs up front isn't precise enough.
+// AllowedS3BucketAction reports whether user may perform action on a
+// bucket-level resource. A nil user or a user with no Policy (full
+// access, including the legacy single-credential user) always passes.
+// For handlers authorizing a bucket name only known after parsing the
+// request body (e.g. the console's handleCreateBucket).
+func AllowedS3BucketAction(user *User, action, bucket string) bool {
+	return Authorized(user, action, bucketARN(bucket))
+}
+
+// AllowedS3Action is AllowedS3BucketAction for an object-level (bucket+key)
+// resource -- e.g. per-key checks in batch/recursive delete handlers,
+// whose affected keys S3Action/ConsoleAction can't see up front.
 func AllowedS3Action(user *User, action, bucket, key string) bool {
 	return Authorized(user, action, objectARN(bucket, key))
 }
 
 // Authorized reports whether user may perform action on resource. A nil
 // user or a user with no Policy attached (full access, including the
-// legacy single-credential user) is always allowed. An empty action means
-// S3Action/ConsoleAction couldn't determine a single resource to check up
-// front -- e.g. batch operations whose affected keys are only known once
-// the request body is decoded -- so it also passes, deferring enforcement
-// to the handler itself (see AllowedS3Action). This is the single place
-// SigV4 and BasicAuth both consult after resolving the matched user, so
-// the fail-open convention for an empty action lives in one spot.
+// legacy single-credential user) is always allowed.
+//
+// action == actionSkip or actionDeferred also passes, for the reasons
+// documented on those constants. Any other empty action is treated as
+// deny -- see the doc comment on actionSkip/actionDeferred for why an
+// unclassified action must fail closed rather than open. This is the
+// single place SigV4 and BasicAuth both consult after resolving the
+// matched user, so this convention lives in one spot.
 func Authorized(user *User, action, resource string) bool {
-	if user == nil || user.Policy == nil || action == "" {
+	if action == actionSkip || action == actionDeferred {
+		return true
+	}
+	if action == "" {
+		return false
+	}
+	if user == nil || user.Policy == nil {
 		return true
 	}
 	return user.Policy.Allowed(action, resource)
@@ -237,30 +268,35 @@ func S3Action(r *http.Request, bucket, key string) (action, resource string) {
 		return actionListAllMyBuckets, "arn:aws:s3:::*"
 	}
 
-	if key == "" {
+	// key == "" is ambiguous on its own: "DELETE /{bucket}" (truly
+	// bucket-level, no key wildcard in that pattern) and
+	// "DELETE /{bucket}/" (matches "/{bucket}/{key...}" with an empty
+	// key) both populate PathValue("key") as "". Go's ServeMux always
+	// prefers the more specific "/{bucket}/{key...}" pattern once there's
+	// a trailing slash, so a trailing-slash request is actually dispatched
+	// to the object handler (handleGetObject/handlePutObject/etc. with an
+	// empty key), not the bucket-level one -- checking it as a
+	// bucket-level action here would authorize a different operation than
+	// the one that actually runs. Only a path with no trailing slash is
+	// genuinely bucket-level.
+	if key == "" && !strings.HasSuffix(r.URL.Path, "/") {
 		switch r.Method {
 		case http.MethodPut:
-			return actionCreateBucket, bucketARN(bucket)
+			return ActionCreateBucket, bucketARN(bucket)
 		case http.MethodDelete:
 			return actionDeleteBucket, bucketARN(bucket)
 		case http.MethodHead:
-			return actionListBucket, bucketARN(bucket)
+			return ActionListBucket, bucketARN(bucket)
 		case http.MethodGet:
 			if _, ok := q["location"]; ok {
 				return actionGetBucketLocation, bucketARN(bucket)
 			}
-			return actionListBucket, bucketARN(bucket)
+			return ActionListBucket, bucketARN(bucket)
 		}
-		// Batch delete (POST /{bucket}?delete) falls through to here: the
-		// affected keys are only known once the request body is decoded,
-		// so no single resource can be checked up front -- a policy
-		// scoped to a narrower prefix than the whole bucket would
-		// otherwise be denied even for keys it does cover, since a
-		// Resource pattern only matches the literal resource it's tested
-		// against, not a broader placeholder standing in for "any key".
-		// handleDeleteObjects checks each key individually via
-		// AllowedS3Action instead.
-		return "", ""
+		// Batch delete (POST /{bucket}?delete): affected keys are only
+		// known once the body is decoded. handleDeleteObjects checks each
+		// key via AllowedS3Action instead.
+		return actionDeferred, ""
 	}
 
 	switch r.Method {
@@ -282,7 +318,7 @@ func S3Action(r *http.Request, bucket, key string) (action, resource string) {
 		// (?uploadId=...) both fall under s3:PutObject.
 		return ActionPutObject, objectARN(bucket, key)
 	}
-	return "", ""
+	return "", "" // unreachable given the registered routes; fails closed if it ever isn't.
 }
 
 // ConsoleAction derives the s3:* IAM action name and resource ARN for a Web
@@ -290,23 +326,24 @@ func S3Action(r *http.Request, bucket, key string) (action, resource string) {
 // PathValue("object") as populated by the ServeMux before middleware runs.
 // It mirrors S3Action for the console's non-S3-shaped routes (see
 // server/handlers/console/{index,buckets/objects,buckets/objects/view}.go).
-//
-// An empty action means "no authorization check applies" -- used for the
-// static asset route, which serves no user data.
+// See actionSkip/actionDeferred for what a non-normal action return means.
 func ConsoleAction(r *http.Request) (action, resource string) {
 	if strings.HasPrefix(r.URL.Path, "/static/") {
-		return "", ""
+		return actionSkip, "" // no user data
 	}
 
 	name := r.PathValue("name")
 	if name == "" {
 		if r.Method == http.MethodPost && r.URL.Path == "/buckets" {
-			// The bucket name lives in the form body, not the URL, and
-			// doesn't exist yet -- authorize against the wildcard bucket
-			// resource rather than parsing the body here.
-			return actionCreateBucket, "arn:aws:s3:::*"
+			// Bucket name lives in the form body; handleCreateBucket
+			// checks it via AllowedS3BucketAction.
+			return actionDeferred, ""
 		}
-		return actionListAllMyBuckets, "arn:aws:s3:::*"
+		// GET / is the console's only entry point (login + bucket
+		// sidebar); gating it on s3:ListAllMyBuckets would lock out any
+		// user with only narrower per-bucket grants. FilterBucketNames
+		// determines what the sidebar actually shows.
+		return actionDeferred, ""
 	}
 
 	arn := bucketARN(name)
@@ -314,31 +351,26 @@ func ConsoleAction(r *http.Request) (action, resource string) {
 
 	switch {
 	case rest == "" && r.Method == http.MethodGet:
-		return actionListBucket, arn
+		return ActionListBucket, arn
 	case rest == "" && r.Method == http.MethodDelete:
 		return actionDeleteBucket, arn
 	case rest == "/folders", rest == "/upload":
-		// The target key lives in the form body and isn't known here. A
-		// wildcard placeholder resource (bucket/*) would be wrong in both
-		// directions -- it can't see a Deny scoped to one specific key,
-		// and it doesn't match an Allow scoped to a narrower prefix than
-		// the whole bucket -- so defer entirely to the handler, which
-		// checks the real key once the body is parsed (handleCreateFolder,
-		// handleUploadFile in server/handlers/console/buckets/objects.go).
-		return "", ""
+		// Target key lives in the form body; the handler checks the real
+		// key via AllowedS3Action once parsed (handleCreateFolder,
+		// handleUploadFile).
+		return actionDeferred, ""
 	case rest == "/objects" && r.Method == http.MethodDelete:
-		// Unlike /folders and /upload, the target key is a query
-		// parameter here, so it's available without consuming the body --
+		// The key is a query param, available without parsing the body --
 		// except for a recursive folder delete (key ends in "/"), whose
-		// affected keys are only known once the handler lists the prefix;
-		// that case also defers to the handler (handleDeleteObject).
+		// affected keys are only known once handleDeleteObject lists the
+		// prefix.
 		key := r.URL.Query().Get("key")
 		if strings.HasSuffix(key, "/") {
-			return "", ""
+			return actionDeferred, ""
 		}
 		return ActionDeleteObject, objectARN(name, key)
 	case strings.HasPrefix(rest, "/view/"), strings.HasPrefix(rest, "/meta/"), strings.HasPrefix(rest, "/preview/"):
 		return ActionGetObject, objectARN(name, r.PathValue("object"))
 	}
-	return "", ""
+	return "", "" // unreachable given the registered routes; fails closed if it ever isn't.
 }

--- a/server/policy.go
+++ b/server/policy.go
@@ -349,30 +349,45 @@ func S3Action(r *http.Request, bucket, key string) (action, resource string) {
 		return actionDeferred, ""
 	}
 
-	// key == "" is ambiguous on its own: "DELETE /{bucket}" (truly
-	// bucket-level, no key wildcard in that pattern) and
-	// "DELETE /{bucket}/" (matches "/{bucket}/{key...}" with an empty
-	// key) both populate PathValue("key") as "". Go's ServeMux always
-	// prefers the more specific "/{bucket}/{key...}" pattern once there's
-	// a trailing slash, so a trailing-slash request is actually dispatched
-	// to the object handler (handleGetObject/handlePutObject/etc. with an
-	// empty key), not the bucket-level one -- checking it as a
-	// bucket-level action here would authorize a different operation than
-	// the one that actually runs. Only a path with no trailing slash is
-	// genuinely bucket-level.
+	// GET/HEAD with an empty key covers both "GET /{bucket}" (routed
+	// bucket-level, no trailing slash) and "GET /{bucket}/" (routed to
+	// "/{bucket}/{key...}" with an empty key). handleGetObject delegates
+	// key=="" straight back to handleBucketGET/handleHeadBucket regardless
+	// of the trailing slash (see the comment on handleGetObject in
+	// server/handlers/s3api/objects.go) -- it always runs ListObjectsV2,
+	// GetBucketLocation, or HeadBucket, never a GetObject read. Handling
+	// this before the trailing-slash check below means both URL forms are
+	// checked against the same bucket-level resource, rather than the
+	// trailing-slash form falling through to the object-level switch and
+	// being checked as s3:GetObject on the wrong (empty-key) resource --
+	// which would let a GetObject-only grant enumerate the whole bucket.
+	if key == "" && (r.Method == http.MethodGet || r.Method == http.MethodHead) {
+		if r.Method == http.MethodHead {
+			return ActionListBucket, bucketARN(bucket)
+		}
+		if _, ok := q["location"]; ok {
+			return actionGetBucketLocation, bucketARN(bucket)
+		}
+		return ActionListBucket, bucketARN(bucket)
+	}
+
+	// key == "" is ambiguous on its own for PUT/DELETE: "PUT /{bucket}"
+	// (truly bucket-level, no key wildcard in that pattern) and
+	// "PUT /{bucket}/" (matches "/{bucket}/{key...}" with an empty key)
+	// both populate PathValue("key") as "". Go's ServeMux always prefers
+	// the more specific "/{bucket}/{key...}" pattern once there's a
+	// trailing slash, so a trailing-slash request is actually dispatched
+	// to the object handler (handlePutObject/handleDeleteObject, neither
+	// of which delegates to a bucket-level handler for an empty key) --
+	// checking it as a bucket-level action here would authorize a
+	// different operation than the one that actually runs. Only a path
+	// with no trailing slash is genuinely bucket-level for these methods.
 	if key == "" && !strings.HasSuffix(r.URL.Path, "/") {
 		switch r.Method {
 		case http.MethodPut:
 			return ActionCreateBucket, bucketARN(bucket)
 		case http.MethodDelete:
 			return actionDeleteBucket, bucketARN(bucket)
-		case http.MethodHead:
-			return ActionListBucket, bucketARN(bucket)
-		case http.MethodGet:
-			if _, ok := q["location"]; ok {
-				return actionGetBucketLocation, bucketARN(bucket)
-			}
-			return ActionListBucket, bucketARN(bucket)
 		}
 	}
 

--- a/server/policy.go
+++ b/server/policy.go
@@ -1,0 +1,344 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// S3 IAM action names, shared between S3Action and ConsoleAction so a typo
+// in one mapping can't silently drift from the other.
+const (
+	actionListAllMyBuckets  = "s3:ListAllMyBuckets"
+	actionCreateBucket      = "s3:CreateBucket"
+	actionDeleteBucket      = "s3:DeleteBucket"
+	actionListBucket        = "s3:ListBucket"
+	actionGetBucketLocation = "s3:GetBucketLocation"
+	// ActionGetObject is exported for handlers that must authorize a
+	// resource distinct from the request's own bucket/key (e.g.
+	// handleCopyObject's read of its copy-source object), which S3Action
+	// can't check generically since it only derives the destination.
+	ActionGetObject = "s3:GetObject"
+	ActionPutObject = "s3:PutObject"
+	// ActionDeleteObject is exported for handlers that must authorize
+	// individual resources parsed from a request body (e.g.
+	// handleDeleteObjects' per-key batch delete), which SigV4 can't check
+	// generically since the keys aren't known until the body is decoded.
+	ActionDeleteObject = "s3:DeleteObject"
+)
+
+// Policy is an AWS-IAM-shaped authorization policy attached to a User. It
+// grants or denies S3 actions (e.g. "s3:GetObject") against S3 resource
+// ARNs (e.g. "arn:aws:s3:::bucket/key").
+//
+// Condition blocks are intentionally not evaluated (see Statement.Condition)
+// -- Validate rejects any statement that sets one, so a policy that appears
+// to restrict by IP/time/etc. never silently grants more than it looks like
+// it does.
+type Policy struct {
+	Version   string      `json:"Version"`
+	Statement []Statement `json:"Statement"`
+}
+
+// Statement is a single Allow/Deny rule within a Policy.
+type Statement struct {
+	// Sid is a statement identifier. Documentation-only; it has no effect
+	// on matching.
+	Sid string `json:"Sid,omitempty"`
+	// Effect is exactly "Allow" or "Deny" (case-sensitive -- Validate
+	// rejects any other value, including different casing, rather than
+	// silently normalizing it).
+	Effect string `json:"Effect"`
+	// Action is one or more "s3:*"-style action names. Wildcards ("*")
+	// are supported; no other glob syntax is.
+	Action stringOrSlice `json:"Action"`
+	// Resource is one or more "arn:aws:s3:::..."-style resource ARNs.
+	// Wildcards ("*") are supported; no other glob syntax is.
+	Resource stringOrSlice `json:"Resource"`
+	// Condition is parsed and preserved for forward compatibility but
+	// never evaluated. Validate rejects any statement that sets it.
+	Condition json.RawMessage `json:"Condition,omitempty"`
+}
+
+// stringOrSlice unmarshals from either a bare JSON string or a JSON array
+// of strings, matching the grammar AWS IAM policies actually use for
+// Action/Resource.
+type stringOrSlice []string
+
+func (s *stringOrSlice) UnmarshalJSON(data []byte) error {
+	var single string
+	if err := json.Unmarshal(data, &single); err == nil {
+		*s = stringOrSlice{single}
+		return nil
+	}
+	var multi []string
+	if err := json.Unmarshal(data, &multi); err != nil {
+		return err
+	}
+	*s = multi
+	return nil
+}
+
+// Allowed reports whether the policy permits action on resource, using
+// AWS's evaluation semantics: an explicit Deny on any matching statement
+// wins immediately; otherwise the result is true iff at least one matching
+// statement has Effect "Allow"; the default is deny.
+func (p *Policy) Allowed(action, resource string) bool {
+	allowed := false
+	for _, stmt := range p.Statement {
+		if !stmt.matches(action, resource) {
+			continue
+		}
+		if stmt.Effect == "Deny" {
+			return false
+		}
+		if stmt.Effect == "Allow" {
+			allowed = true
+		}
+	}
+	return allowed
+}
+
+func (stmt Statement) matches(action, resource string) bool {
+	return matchAny(stmt.Action, action) && matchAny(stmt.Resource, resource)
+}
+
+func matchAny(patterns []string, s string) bool {
+	for _, p := range patterns {
+		if wildcardMatch(p, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// wildcardMatch reports whether s matches pattern, where "*" in pattern
+// matches any sequence of characters (including "/" -- IAM Action/Resource
+// wildcards, unlike filepath.Match, do not stop at path separators).
+func wildcardMatch(pattern, s string) bool {
+	segments := strings.Split(pattern, "*")
+	if len(segments) == 1 {
+		return pattern == s
+	}
+	if !strings.HasPrefix(s, segments[0]) {
+		return false
+	}
+	s = s[len(segments[0]):]
+	if !strings.HasSuffix(s, segments[len(segments)-1]) {
+		return false
+	}
+	s = s[:len(s)-len(segments[len(segments)-1])]
+	for _, seg := range segments[1 : len(segments)-1] {
+		if seg == "" {
+			continue
+		}
+		idx := strings.Index(s, seg)
+		if idx < 0 {
+			return false
+		}
+		s = s[idx+len(seg):]
+	}
+	return true
+}
+
+// isEmptyCondition reports whether c represents "no condition" -- either
+// the field was absent (len 0) or it was present but semantically empty
+// (e.g. "{}" or "null", as commonly written in hand-authored policies,
+// including the example in https://github.com/mojatter/s2/issues/162).
+// Any other value, including a non-empty object, is treated as a real
+// Condition and rejected by Validate.
+func isEmptyCondition(c json.RawMessage) bool {
+	if len(c) == 0 {
+		return true
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(c, &m); err != nil {
+		return false
+	}
+	return len(m) == 0
+}
+
+// Validate checks the policy for obvious configuration mistakes. It does
+// not validate ARN syntax deeply.
+func (p *Policy) Validate() error {
+	if p.Version != "" && p.Version != "2012-10-17" {
+		return fmt.Errorf("policy: unsupported Version %q", p.Version)
+	}
+	for i, stmt := range p.Statement {
+		if stmt.Effect != "Allow" && stmt.Effect != "Deny" {
+			return fmt.Errorf("policy: statement[%d]: Effect must be %q or %q, got %q", i, "Allow", "Deny", stmt.Effect)
+		}
+		if len(stmt.Action) == 0 {
+			return fmt.Errorf("policy: statement[%d]: Action must not be empty", i)
+		}
+		if len(stmt.Resource) == 0 {
+			return fmt.Errorf("policy: statement[%d]: Resource must not be empty", i)
+		}
+		if !isEmptyCondition(stmt.Condition) {
+			return fmt.Errorf("policy: statement[%d]: Condition is not supported", i)
+		}
+	}
+	return nil
+}
+
+// bucketARN returns the ARN for a bucket-level S3 resource.
+func bucketARN(bucket string) string {
+	return "arn:aws:s3:::" + bucket
+}
+
+// objectARN returns the ARN for an object-level S3 resource.
+func objectARN(bucket, key string) string {
+	return "arn:aws:s3:::" + bucket + "/" + key
+}
+
+// AllowedS3Action reports whether user may perform action on the given
+// bucket/key object resource. A nil user or a user with no Policy attached
+// (full access, including the legacy single-credential user) is always
+// allowed.
+//
+// This is for handlers that authorize a resource SigV4 couldn't check
+// generically -- e.g. batch operations where the affected keys are only
+// known after the request body is decoded, so the coarse bucket-level
+// check S3Action performs up front isn't precise enough.
+func AllowedS3Action(user *User, action, bucket, key string) bool {
+	return Authorized(user, action, objectARN(bucket, key))
+}
+
+// Authorized reports whether user may perform action on resource. A nil
+// user or a user with no Policy attached (full access, including the
+// legacy single-credential user) is always allowed. An empty action means
+// S3Action/ConsoleAction couldn't determine a single resource to check up
+// front -- e.g. batch operations whose affected keys are only known once
+// the request body is decoded -- so it also passes, deferring enforcement
+// to the handler itself (see AllowedS3Action). This is the single place
+// SigV4 and BasicAuth both consult after resolving the matched user, so
+// the fail-open convention for an empty action lives in one spot.
+func Authorized(user *User, action, resource string) bool {
+	if user == nil || user.Policy == nil || action == "" {
+		return true
+	}
+	return user.Policy.Allowed(action, resource)
+}
+
+// S3Action derives the s3:* IAM action name and the arn:aws:s3:::bucket/key
+// resource for an S3 API request, given its already-routed method and the
+// bucket/key path values populated by the ServeMux before middleware runs.
+// The mapping mirrors the query-parameter dispatch already implemented in
+// server/handlers/s3api/{buckets,objects,multipart}.go.
+//
+// s3:ListAllMyBuckets has no single resource to check -- it is authorized
+// as a whole against a synthetic "arn:aws:s3:::*" resource by the caller,
+// and the returned bucket list is filtered separately via FilterBucketNames.
+func S3Action(r *http.Request, bucket, key string) (action, resource string) {
+	q := r.URL.Query()
+
+	if bucket == "" {
+		return actionListAllMyBuckets, "arn:aws:s3:::*"
+	}
+
+	if key == "" {
+		switch r.Method {
+		case http.MethodPut:
+			return actionCreateBucket, bucketARN(bucket)
+		case http.MethodDelete:
+			return actionDeleteBucket, bucketARN(bucket)
+		case http.MethodHead:
+			return actionListBucket, bucketARN(bucket)
+		case http.MethodGet:
+			if _, ok := q["location"]; ok {
+				return actionGetBucketLocation, bucketARN(bucket)
+			}
+			return actionListBucket, bucketARN(bucket)
+		}
+		// Batch delete (POST /{bucket}?delete) falls through to here: the
+		// affected keys are only known once the request body is decoded,
+		// so no single resource can be checked up front -- a policy
+		// scoped to a narrower prefix than the whole bucket would
+		// otherwise be denied even for keys it does cover, since a
+		// Resource pattern only matches the literal resource it's tested
+		// against, not a broader placeholder standing in for "any key".
+		// handleDeleteObjects checks each key individually via
+		// AllowedS3Action instead.
+		return "", ""
+	}
+
+	switch r.Method {
+	case http.MethodGet, http.MethodHead:
+		return ActionGetObject, objectARN(bucket, key)
+	case http.MethodPut:
+		// Plain PutObject and UploadPart (?uploadId=...&partNumber=...)
+		// share the same IAM action, matching AWS's own permission model.
+		return ActionPutObject, objectARN(bucket, key)
+	case http.MethodDelete:
+		// AbortMultipartUpload (?uploadId=...) shares s3:PutObject with the
+		// rest of the upload lifecycle; a plain delete is s3:DeleteObject.
+		if q.Get("uploadId") != "" {
+			return ActionPutObject, objectARN(bucket, key)
+		}
+		return ActionDeleteObject, objectARN(bucket, key)
+	case http.MethodPost:
+		// CreateMultipartUpload (?uploads) and CompleteMultipartUpload
+		// (?uploadId=...) both fall under s3:PutObject.
+		return ActionPutObject, objectARN(bucket, key)
+	}
+	return "", ""
+}
+
+// ConsoleAction derives the s3:* IAM action name and resource ARN for a Web
+// Console request, given its already-routed method and PathValue("name")/
+// PathValue("object") as populated by the ServeMux before middleware runs.
+// It mirrors S3Action for the console's non-S3-shaped routes (see
+// server/handlers/console/{index,buckets/objects,buckets/objects/view}.go).
+//
+// An empty action means "no authorization check applies" -- used for the
+// static asset route, which serves no user data.
+func ConsoleAction(r *http.Request) (action, resource string) {
+	if strings.HasPrefix(r.URL.Path, "/static/") {
+		return "", ""
+	}
+
+	name := r.PathValue("name")
+	if name == "" {
+		if r.Method == http.MethodPost && r.URL.Path == "/buckets" {
+			// The bucket name lives in the form body, not the URL, and
+			// doesn't exist yet -- authorize against the wildcard bucket
+			// resource rather than parsing the body here.
+			return actionCreateBucket, "arn:aws:s3:::*"
+		}
+		return actionListAllMyBuckets, "arn:aws:s3:::*"
+	}
+
+	arn := bucketARN(name)
+	rest := strings.TrimPrefix(r.URL.Path, "/buckets/"+name)
+
+	switch {
+	case rest == "" && r.Method == http.MethodGet:
+		return actionListBucket, arn
+	case rest == "" && r.Method == http.MethodDelete:
+		return actionDeleteBucket, arn
+	case rest == "/folders", rest == "/upload":
+		// The target key lives in the form body and isn't known here. A
+		// wildcard placeholder resource (bucket/*) would be wrong in both
+		// directions -- it can't see a Deny scoped to one specific key,
+		// and it doesn't match an Allow scoped to a narrower prefix than
+		// the whole bucket -- so defer entirely to the handler, which
+		// checks the real key once the body is parsed (handleCreateFolder,
+		// handleUploadFile in server/handlers/console/buckets/objects.go).
+		return "", ""
+	case rest == "/objects" && r.Method == http.MethodDelete:
+		// Unlike /folders and /upload, the target key is a query
+		// parameter here, so it's available without consuming the body --
+		// except for a recursive folder delete (key ends in "/"), whose
+		// affected keys are only known once the handler lists the prefix;
+		// that case also defers to the handler (handleDeleteObject).
+		key := r.URL.Query().Get("key")
+		if strings.HasSuffix(key, "/") {
+			return "", ""
+		}
+		return ActionDeleteObject, objectARN(name, key)
+	case strings.HasPrefix(rest, "/view/"), strings.HasPrefix(rest, "/meta/"), strings.HasPrefix(rest, "/preview/"):
+		return ActionGetObject, objectARN(name, r.PathValue("object"))
+	}
+	return "", ""
+}

--- a/server/policy_test.go
+++ b/server/policy_test.go
@@ -1,0 +1,672 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func allowStatement(action, resource string) Statement {
+	return Statement{Effect: "Allow", Action: stringOrSlice{action}, Resource: stringOrSlice{resource}}
+}
+
+func denyStatement(action, resource string) Statement {
+	return Statement{Effect: "Deny", Action: stringOrSlice{action}, Resource: stringOrSlice{resource}}
+}
+
+func TestPolicyAllowed(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		policy   Policy
+		action   string
+		resource string
+		want     bool
+	}{
+		{
+			caseName: "explicit deny beats allow",
+			policy: Policy{Statement: []Statement{
+				allowStatement("s3:*", "*"),
+				denyStatement("s3:DeleteObject", "arn:aws:s3:::bucket/*"),
+			}},
+			action:   "s3:DeleteObject",
+			resource: "arn:aws:s3:::bucket/key",
+			want:     false,
+		},
+		{
+			caseName: "deny order independent",
+			policy: Policy{Statement: []Statement{
+				denyStatement("s3:DeleteObject", "arn:aws:s3:::bucket/*"),
+				allowStatement("s3:*", "*"),
+			}},
+			action:   "s3:DeleteObject",
+			resource: "arn:aws:s3:::bucket/key",
+			want:     false,
+		},
+		{
+			caseName: "no matching statement denies",
+			policy: Policy{Statement: []Statement{
+				allowStatement("s3:GetObject", "*"),
+			}},
+			action:   "s3:PutObject",
+			resource: "arn:aws:s3:::bucket/key",
+			want:     false,
+		},
+		{
+			caseName: "empty statement list denies everything",
+			policy:   Policy{},
+			action:   "s3:GetObject",
+			resource: "arn:aws:s3:::bucket/key",
+			want:     false,
+		},
+		{
+			caseName: "action wildcard matches",
+			policy: Policy{Statement: []Statement{
+				allowStatement("s3:Get*", "*"),
+			}},
+			action:   "s3:GetObject",
+			resource: "arn:aws:s3:::bucket/key",
+			want:     true,
+		},
+		{
+			caseName: "action wildcard does not match unrelated action",
+			policy: Policy{Statement: []Statement{
+				allowStatement("s3:Get*", "*"),
+			}},
+			action:   "s3:PutObject",
+			resource: "arn:aws:s3:::bucket/key",
+			want:     false,
+		},
+		{
+			caseName: "full wildcard action",
+			policy: Policy{Statement: []Statement{
+				allowStatement("s3:*", "*"),
+			}},
+			action:   "s3:DeleteBucket",
+			resource: "arn:aws:s3:::bucket",
+			want:     true,
+		},
+		{
+			caseName: "resource bucket wildcard matches key in bucket",
+			policy: Policy{Statement: []Statement{
+				allowStatement("s3:GetObject", "arn:aws:s3:::mybucket/*"),
+			}},
+			action:   "s3:GetObject",
+			resource: "arn:aws:s3:::mybucket/foo.txt",
+			want:     true,
+		},
+		{
+			caseName: "resource bucket wildcard does not match other bucket",
+			policy: Policy{Statement: []Statement{
+				allowStatement("s3:GetObject", "arn:aws:s3:::mybucket/*"),
+			}},
+			action:   "s3:GetObject",
+			resource: "arn:aws:s3:::otherbucket/foo.txt",
+			want:     false,
+		},
+		{
+			caseName: "resource all-buckets wildcard matches any bucket",
+			policy: Policy{Statement: []Statement{
+				allowStatement("s3:ListBucket", "arn:aws:s3:::*"),
+			}},
+			action:   "s3:ListBucket",
+			resource: "arn:aws:s3:::mybucket",
+			want:     true,
+		},
+		{
+			caseName: "multiple allow statements cover different actions",
+			policy: Policy{Statement: []Statement{
+				allowStatement("s3:GetObject", "*"),
+				allowStatement("s3:ListBucket", "*"),
+			}},
+			action:   "s3:ListBucket",
+			resource: "arn:aws:s3:::bucket",
+			want:     true,
+		},
+		{
+			caseName: "multiple allow statements deny unrelated action",
+			policy: Policy{Statement: []Statement{
+				allowStatement("s3:GetObject", "*"),
+				allowStatement("s3:ListBucket", "*"),
+			}},
+			action:   "s3:DeleteObject",
+			resource: "arn:aws:s3:::bucket/key",
+			want:     false,
+		},
+		{
+			caseName: "sid does not affect matching",
+			policy: Policy{Statement: []Statement{
+				{Sid: "Anything", Effect: "Allow", Action: stringOrSlice{"s3:GetObject"}, Resource: stringOrSlice{"*"}},
+			}},
+			action:   "s3:GetObject",
+			resource: "arn:aws:s3:::bucket/key",
+			want:     true,
+		},
+		{
+			caseName: "bucket-level resource does not match object-level resource",
+			policy: Policy{Statement: []Statement{
+				allowStatement("s3:GetObject", "arn:aws:s3:::mybucket"),
+			}},
+			action:   "s3:GetObject",
+			resource: "arn:aws:s3:::mybucket/foo.txt",
+			want:     false,
+		},
+		{
+			caseName: "bucket-level resource matches bucket-level action",
+			policy: Policy{Statement: []Statement{
+				allowStatement("s3:ListBucket", "arn:aws:s3:::mybucket"),
+			}},
+			action:   "s3:ListBucket",
+			resource: "arn:aws:s3:::mybucket",
+			want:     true,
+		},
+		{
+			caseName: "multiple resource patterns: matches one of them",
+			policy: Policy{Statement: []Statement{
+				{Effect: "Allow", Action: stringOrSlice{"s3:GetObject"}, Resource: stringOrSlice{
+					"arn:aws:s3:::bucket-a/*", "arn:aws:s3:::bucket-b/*",
+				}},
+			}},
+			action:   "s3:GetObject",
+			resource: "arn:aws:s3:::bucket-b/file.txt",
+			want:     true,
+		},
+		{
+			caseName: "multiple resource patterns: matches none of them",
+			policy: Policy{Statement: []Statement{
+				{Effect: "Allow", Action: stringOrSlice{"s3:GetObject"}, Resource: stringOrSlice{
+					"arn:aws:s3:::bucket-a/*", "arn:aws:s3:::bucket-b/*",
+				}},
+			}},
+			action:   "s3:GetObject",
+			resource: "arn:aws:s3:::bucket-c/file.txt",
+			want:     false,
+		},
+		{
+			caseName: "resource pattern with multiple wildcards matches",
+			policy: Policy{Statement: []Statement{
+				allowStatement("s3:GetObject", "arn:aws:s3:::backup-*-2024/*"),
+			}},
+			action:   "s3:GetObject",
+			resource: "arn:aws:s3:::backup-jan-2024/report.pdf",
+			want:     true,
+		},
+		{
+			caseName: "resource pattern with multiple wildcards does not match wrong middle segment",
+			policy: Policy{Statement: []Statement{
+				allowStatement("s3:GetObject", "arn:aws:s3:::backup-*-2024/*"),
+			}},
+			action:   "s3:GetObject",
+			resource: "arn:aws:s3:::backup-jan-2023/report.pdf",
+			want:     false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.policy.Allowed(tc.action, tc.resource))
+		})
+	}
+}
+
+func TestAuthorized(t *testing.T) {
+	scopedUser := &User{Policy: &Policy{Statement: []Statement{
+		allowStatement("s3:GetObject", "arn:aws:s3:::bucket/*"),
+	}}}
+
+	testCases := []struct {
+		caseName string
+		user     *User
+		action   string
+		resource string
+		want     bool
+	}{
+		{caseName: "nil user is always allowed", user: nil, action: "s3:DeleteBucket", resource: "arn:aws:s3:::bucket", want: true},
+		{caseName: "user with no policy is always allowed", user: &User{}, action: "s3:DeleteBucket", resource: "arn:aws:s3:::bucket", want: true},
+		{caseName: "empty action skips the check even for a restrictive policy", user: scopedUser, action: "", resource: "", want: true},
+		{caseName: "scoped policy allows a matching action/resource", user: scopedUser, action: "s3:GetObject", resource: "arn:aws:s3:::bucket/key", want: true},
+		{caseName: "scoped policy denies a non-matching action", user: scopedUser, action: "s3:DeleteObject", resource: "arn:aws:s3:::bucket/key", want: false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			assert.Equal(t, tc.want, Authorized(tc.user, tc.action, tc.resource))
+		})
+	}
+}
+
+func TestAllowedS3Action(t *testing.T) {
+	scopedUser := &User{Policy: &Policy{Statement: []Statement{
+		allowStatement(ActionDeleteObject, "arn:aws:s3:::bucket/tmp/*"),
+	}}}
+
+	testCases := []struct {
+		caseName string
+		user     *User
+		action   string
+		bucket   string
+		key      string
+		want     bool
+	}{
+		{caseName: "nil user is always allowed", user: nil, action: ActionDeleteObject, bucket: "bucket", key: "tmp/a.txt", want: true},
+		{caseName: "user with no policy is always allowed", user: &User{}, action: ActionDeleteObject, bucket: "bucket", key: "anything", want: true},
+		{caseName: "scoped policy allows a matching key", user: scopedUser, action: ActionDeleteObject, bucket: "bucket", key: "tmp/a.txt", want: true},
+		{caseName: "scoped policy denies a non-matching key", user: scopedUser, action: ActionDeleteObject, bucket: "bucket", key: "keep/b.txt", want: false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			assert.Equal(t, tc.want, AllowedS3Action(tc.user, tc.action, tc.bucket, tc.key))
+		})
+	}
+}
+
+func TestPolicyValidate(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		policy   Policy
+		wantErr  bool
+	}{
+		{
+			caseName: "valid minimal policy",
+			policy: Policy{
+				Version:   "2012-10-17",
+				Statement: []Statement{allowStatement("s3:GetObject", "*")},
+			},
+			wantErr: false,
+		},
+		{
+			caseName: "empty version accepted",
+			policy: Policy{
+				Statement: []Statement{allowStatement("s3:GetObject", "*")},
+			},
+			wantErr: false,
+		},
+		{
+			caseName: "unsupported version rejected",
+			policy: Policy{
+				Version:   "2020-01-01",
+				Statement: []Statement{allowStatement("s3:GetObject", "*")},
+			},
+			wantErr: true,
+		},
+		{
+			caseName: "lowercase effect rejected",
+			policy: Policy{
+				Statement: []Statement{{Effect: "allow", Action: stringOrSlice{"s3:GetObject"}, Resource: stringOrSlice{"*"}}},
+			},
+			wantErr: true,
+		},
+		{
+			caseName: "unknown effect rejected",
+			policy: Policy{
+				Statement: []Statement{{Effect: "Maybe", Action: stringOrSlice{"s3:GetObject"}, Resource: stringOrSlice{"*"}}},
+			},
+			wantErr: true,
+		},
+		{
+			caseName: "empty action rejected",
+			policy: Policy{
+				Statement: []Statement{{Effect: "Allow", Resource: stringOrSlice{"*"}}},
+			},
+			wantErr: true,
+		},
+		{
+			caseName: "empty resource rejected",
+			policy: Policy{
+				Statement: []Statement{{Effect: "Allow", Action: stringOrSlice{"s3:GetObject"}}},
+			},
+			wantErr: true,
+		},
+		{
+			caseName: "non-empty condition rejected",
+			policy: Policy{
+				Statement: []Statement{{
+					Effect:    "Allow",
+					Action:    stringOrSlice{"s3:GetObject"},
+					Resource:  stringOrSlice{"*"},
+					Condition: json.RawMessage(`{"IpAddress":{"aws:SourceIp":"10.0.0.0/8"}}`),
+				}},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			err := tc.policy.Validate()
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestStringOrSliceUnmarshalJSON(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		input    string
+		want     stringOrSlice
+	}{
+		{caseName: "bare string", input: `"s3:GetObject"`, want: stringOrSlice{"s3:GetObject"}},
+		{caseName: "array", input: `["s3:GetObject", "s3:ListBucket"]`, want: stringOrSlice{"s3:GetObject", "s3:ListBucket"}},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			var got stringOrSlice
+			require.NoError(t, json.Unmarshal([]byte(tc.input), &got))
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestWildcardMatch(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		pattern  string
+		s        string
+		want     bool
+	}{
+		{caseName: "exact match", pattern: "s3:GetObject", s: "s3:GetObject", want: true},
+		{caseName: "exact mismatch", pattern: "s3:GetObject", s: "s3:PutObject", want: false},
+		{caseName: "trailing wildcard", pattern: "s3:Get*", s: "s3:GetObject", want: true},
+		{caseName: "trailing wildcard mismatch", pattern: "s3:Get*", s: "s3:PutObject", want: false},
+		{caseName: "full wildcard", pattern: "*", s: "anything", want: true},
+		{caseName: "middle wildcard resource", pattern: "arn:aws:s3:::bucket/*", s: "arn:aws:s3:::bucket/foo/bar.txt", want: true},
+		{caseName: "wildcard does not stop at slash", pattern: "arn:aws:s3:::*", s: "arn:aws:s3:::bucket/foo/bar.txt", want: true},
+		{caseName: "multiple wildcards, middle segment matches", pattern: "arn:aws:s3:::my-*-bucket/*", s: "arn:aws:s3:::my-prod-bucket/foo/bar.txt", want: true},
+		{caseName: "multiple wildcards, middle segment absent", pattern: "arn:aws:s3:::my-*-bucket/*", s: "arn:aws:s3:::my-prod-other/foo.txt", want: false},
+		{caseName: "multiple wildcards, three segments", pattern: "a*b*c", s: "aXXbYYc", want: true},
+		{caseName: "multiple wildcards, middle segment out of order", pattern: "a*b*c", s: "acXXbYY", want: false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			assert.Equal(t, tc.want, wildcardMatch(tc.pattern, tc.s))
+		})
+	}
+}
+
+func TestS3Action(t *testing.T) {
+	testCases := []struct {
+		caseName     string
+		method       string
+		url          string
+		bucket       string
+		key          string
+		wantAction   string
+		wantResource string
+	}{
+		{
+			caseName:     "list all my buckets",
+			method:       http.MethodGet,
+			url:          "/",
+			wantAction:   "s3:ListAllMyBuckets",
+			wantResource: "arn:aws:s3:::*",
+		},
+		{
+			caseName:     "create bucket",
+			method:       http.MethodPut,
+			url:          "/mybucket",
+			bucket:       "mybucket",
+			wantAction:   "s3:CreateBucket",
+			wantResource: "arn:aws:s3:::mybucket",
+		},
+		{
+			caseName:     "delete bucket",
+			method:       http.MethodDelete,
+			url:          "/mybucket",
+			bucket:       "mybucket",
+			wantAction:   "s3:DeleteBucket",
+			wantResource: "arn:aws:s3:::mybucket",
+		},
+		{
+			caseName:     "head bucket",
+			method:       http.MethodHead,
+			url:          "/mybucket",
+			bucket:       "mybucket",
+			wantAction:   "s3:ListBucket",
+			wantResource: "arn:aws:s3:::mybucket",
+		},
+		{
+			caseName:     "get bucket location",
+			method:       http.MethodGet,
+			url:          "/mybucket?location",
+			bucket:       "mybucket",
+			wantAction:   "s3:GetBucketLocation",
+			wantResource: "arn:aws:s3:::mybucket",
+		},
+		{
+			caseName:     "list objects",
+			method:       http.MethodGet,
+			url:          "/mybucket",
+			bucket:       "mybucket",
+			wantAction:   "s3:ListBucket",
+			wantResource: "arn:aws:s3:::mybucket",
+		},
+		{
+			caseName:     "list multipart uploads",
+			method:       http.MethodGet,
+			url:          "/mybucket?uploads",
+			bucket:       "mybucket",
+			wantAction:   "s3:ListBucket",
+			wantResource: "arn:aws:s3:::mybucket",
+		},
+		{
+			caseName: "batch delete objects has no single up-front resource",
+			method:   http.MethodPost,
+			url:      "/mybucket?delete",
+			bucket:   "mybucket",
+			// The affected keys are only known once the handler decodes
+			// the request body, so S3Action defers entirely to
+			// handleDeleteObjects' per-key AllowedS3Action checks.
+			wantAction:   "",
+			wantResource: "",
+		},
+		{
+			caseName:     "get object",
+			method:       http.MethodGet,
+			url:          "/mybucket/key.txt",
+			bucket:       "mybucket",
+			key:          "key.txt",
+			wantAction:   "s3:GetObject",
+			wantResource: "arn:aws:s3:::mybucket/key.txt",
+		},
+		{
+			caseName:     "head object",
+			method:       http.MethodHead,
+			url:          "/mybucket/key.txt",
+			bucket:       "mybucket",
+			key:          "key.txt",
+			wantAction:   "s3:GetObject",
+			wantResource: "arn:aws:s3:::mybucket/key.txt",
+		},
+		{
+			caseName:     "put object",
+			method:       http.MethodPut,
+			url:          "/mybucket/key.txt",
+			bucket:       "mybucket",
+			key:          "key.txt",
+			wantAction:   "s3:PutObject",
+			wantResource: "arn:aws:s3:::mybucket/key.txt",
+		},
+		{
+			caseName:     "upload part",
+			method:       http.MethodPut,
+			url:          "/mybucket/key.txt?uploadId=abc&partNumber=1",
+			bucket:       "mybucket",
+			key:          "key.txt",
+			wantAction:   "s3:PutObject",
+			wantResource: "arn:aws:s3:::mybucket/key.txt",
+		},
+		{
+			caseName:     "delete object",
+			method:       http.MethodDelete,
+			url:          "/mybucket/key.txt",
+			bucket:       "mybucket",
+			key:          "key.txt",
+			wantAction:   "s3:DeleteObject",
+			wantResource: "arn:aws:s3:::mybucket/key.txt",
+		},
+		{
+			caseName:     "abort multipart upload",
+			method:       http.MethodDelete,
+			url:          "/mybucket/key.txt?uploadId=abc",
+			bucket:       "mybucket",
+			key:          "key.txt",
+			wantAction:   "s3:PutObject",
+			wantResource: "arn:aws:s3:::mybucket/key.txt",
+		},
+		{
+			caseName:     "create multipart upload",
+			method:       http.MethodPost,
+			url:          "/mybucket/key.txt?uploads",
+			bucket:       "mybucket",
+			key:          "key.txt",
+			wantAction:   "s3:PutObject",
+			wantResource: "arn:aws:s3:::mybucket/key.txt",
+		},
+		{
+			caseName:     "complete multipart upload",
+			method:       http.MethodPost,
+			url:          "/mybucket/key.txt?uploadId=abc",
+			bucket:       "mybucket",
+			key:          "key.txt",
+			wantAction:   "s3:PutObject",
+			wantResource: "arn:aws:s3:::mybucket/key.txt",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			r := httptest.NewRequest(tc.method, tc.url, nil)
+			action, resource := S3Action(r, tc.bucket, tc.key)
+			assert.Equal(t, tc.wantAction, action)
+			assert.Equal(t, tc.wantResource, resource)
+		})
+	}
+}
+
+func TestConsoleAction(t *testing.T) {
+	testCases := []struct {
+		caseName     string
+		method       string
+		url          string
+		pathValues   map[string]string
+		wantAction   string
+		wantResource string
+	}{
+		{
+			caseName:     "index bucket list",
+			method:       http.MethodGet,
+			url:          "/",
+			wantAction:   "s3:ListAllMyBuckets",
+			wantResource: "arn:aws:s3:::*",
+		},
+		{
+			caseName:     "create bucket",
+			method:       http.MethodPost,
+			url:          "/buckets",
+			wantAction:   "s3:CreateBucket",
+			wantResource: "arn:aws:s3:::*",
+		},
+		{
+			caseName:     "delete bucket",
+			method:       http.MethodDelete,
+			url:          "/buckets/mybucket",
+			pathValues:   map[string]string{"name": "mybucket"},
+			wantAction:   "s3:DeleteBucket",
+			wantResource: "arn:aws:s3:::mybucket",
+		},
+		{
+			caseName:     "list objects",
+			method:       http.MethodGet,
+			url:          "/buckets/mybucket",
+			pathValues:   map[string]string{"name": "mybucket"},
+			wantAction:   "s3:ListBucket",
+			wantResource: "arn:aws:s3:::mybucket",
+		},
+		{
+			// The target key is only known once handleCreateFolder parses
+			// the form body, so ConsoleAction defers entirely; the handler
+			// checks the real key itself via AllowedS3Action.
+			caseName:     "create folder has no single up-front resource",
+			method:       http.MethodPost,
+			url:          "/buckets/mybucket/folders",
+			pathValues:   map[string]string{"name": "mybucket"},
+			wantAction:   "",
+			wantResource: "",
+		},
+		{
+			// Same as create folder: the filename is only known once
+			// handleUploadFile parses the multipart body.
+			caseName:     "upload file has no single up-front resource",
+			method:       http.MethodPost,
+			url:          "/buckets/mybucket/upload",
+			pathValues:   map[string]string{"name": "mybucket"},
+			wantAction:   "",
+			wantResource: "",
+		},
+		{
+			caseName:     "delete object",
+			method:       http.MethodDelete,
+			url:          "/buckets/mybucket/objects?key=foo.txt",
+			pathValues:   map[string]string{"name": "mybucket"},
+			wantAction:   "s3:DeleteObject",
+			wantResource: "arn:aws:s3:::mybucket/foo.txt",
+		},
+		{
+			// A recursive folder delete's affected keys are only known
+			// once handleDeleteObject lists the prefix, so ConsoleAction
+			// defers entirely rather than checking the bare prefix (which
+			// would miss a Deny scoped to one descendant key).
+			caseName:     "delete folder has no single up-front resource",
+			method:       http.MethodDelete,
+			url:          "/buckets/mybucket/objects?key=folder/",
+			pathValues:   map[string]string{"name": "mybucket"},
+			wantAction:   "",
+			wantResource: "",
+		},
+		{
+			caseName:     "view object",
+			method:       http.MethodGet,
+			url:          "/buckets/mybucket/view/foo.txt",
+			pathValues:   map[string]string{"name": "mybucket", "object": "foo.txt"},
+			wantAction:   "s3:GetObject",
+			wantResource: "arn:aws:s3:::mybucket/foo.txt",
+		},
+		{
+			caseName:     "meta object",
+			method:       http.MethodGet,
+			url:          "/buckets/mybucket/meta/foo.txt",
+			pathValues:   map[string]string{"name": "mybucket", "object": "foo.txt"},
+			wantAction:   "s3:GetObject",
+			wantResource: "arn:aws:s3:::mybucket/foo.txt",
+		},
+		{
+			caseName:     "preview object",
+			method:       http.MethodGet,
+			url:          "/buckets/mybucket/preview/foo.txt",
+			pathValues:   map[string]string{"name": "mybucket", "object": "foo.txt"},
+			wantAction:   "s3:GetObject",
+			wantResource: "arn:aws:s3:::mybucket/foo.txt",
+		},
+		{
+			caseName:     "static asset bypasses check",
+			method:       http.MethodGet,
+			url:          "/static/app.css",
+			wantAction:   "",
+			wantResource: "",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			r := httptest.NewRequest(tc.method, tc.url, nil)
+			for k, v := range tc.pathValues {
+				r.SetPathValue(k, v)
+			}
+			action, resource := ConsoleAction(r)
+			assert.Equal(t, tc.wantAction, action)
+			assert.Equal(t, tc.wantResource, resource)
+		})
+	}
+}

--- a/server/policy_test.go
+++ b/server/policy_test.go
@@ -505,13 +505,36 @@ func TestS3Action(t *testing.T) {
 			wantResource: "arn:aws:s3:::mybucket/",
 		},
 		{
-			caseName:     "get with trailing slash routes to object handler, not bucket handler",
+			// Unlike DELETE/PUT, handleGetObject delegates key=="" back to
+			// handleBucketGET regardless of the trailing slash, so this
+			// must be checked as a bucket-level action -- classifying it
+			// as GetObject would let a GetObject-only grant enumerate the
+			// whole bucket via ListObjectsV2.
+			caseName:     "get with trailing slash still routes to the bucket handler",
 			method:       http.MethodGet,
 			url:          "/mybucket/",
 			bucket:       "mybucket",
 			key:          "",
-			wantAction:   "s3:GetObject",
-			wantResource: "arn:aws:s3:::mybucket/",
+			wantAction:   "s3:ListBucket",
+			wantResource: "arn:aws:s3:::mybucket",
+		},
+		{
+			caseName:     "head with trailing slash still routes to the bucket handler",
+			method:       http.MethodHead,
+			url:          "/mybucket/",
+			bucket:       "mybucket",
+			key:          "",
+			wantAction:   "s3:ListBucket",
+			wantResource: "arn:aws:s3:::mybucket",
+		},
+		{
+			caseName:     "get bucket location with trailing slash still routes to the bucket handler",
+			method:       http.MethodGet,
+			url:          "/mybucket/?location",
+			bucket:       "mybucket",
+			key:          "",
+			wantAction:   "s3:GetBucketLocation",
+			wantResource: "arn:aws:s3:::mybucket",
 		},
 		{
 			caseName:     "put with trailing slash routes to object handler, not bucket handler",

--- a/server/policy_test.go
+++ b/server/policy_test.go
@@ -264,6 +264,31 @@ func TestAllowedS3Action(t *testing.T) {
 	}
 }
 
+func TestExplicitlyDeniedListAllMyBuckets(t *testing.T) {
+	deniedUser := &User{Policy: &Policy{Statement: []Statement{
+		denyStatement(ActionListAllMyBuckets, "arn:aws:s3:::*"),
+	}}}
+	scopedUser := &User{Policy: &Policy{Statement: []Statement{
+		allowStatement(ActionListBucket, "arn:aws:s3:::mybucket"),
+	}}}
+
+	testCases := []struct {
+		caseName string
+		user     *User
+		want     bool
+	}{
+		{caseName: "nil user is never denied", user: nil, want: false},
+		{caseName: "user with no policy is never denied", user: &User{}, want: false},
+		{caseName: "explicit Deny on the action blocks it", user: deniedUser, want: true},
+		{caseName: "a policy with no matching statement at all is not denied", user: scopedUser, want: false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			assert.Equal(t, tc.want, ExplicitlyDeniedListAllMyBuckets(tc.user))
+		})
+	}
+}
+
 func TestPolicyValidate(t *testing.T) {
 	testCases := []struct {
 		caseName string
@@ -431,11 +456,14 @@ func TestS3Action(t *testing.T) {
 		wantResource string
 	}{
 		{
-			caseName:     "list all my buckets",
-			method:       http.MethodGet,
-			url:          "/",
-			wantAction:   "s3:ListAllMyBuckets",
-			wantResource: "arn:aws:s3:::*",
+			caseName: "list all my buckets",
+			method:   http.MethodGet,
+			url:      "/",
+			// HandleListBuckets filters the result per-bucket via
+			// FilterBucketNames instead of gating the whole request on a
+			// single up-front resource, mirroring ConsoleAction's GET /.
+			wantAction:   actionDeferred,
+			wantResource: "",
 		},
 		{
 			caseName:     "create bucket",
@@ -526,6 +554,19 @@ func TestS3Action(t *testing.T) {
 			// The affected keys are only known once the handler decodes
 			// the request body, so S3Action defers entirely to
 			// handleDeleteObjects' per-key AllowedS3Action checks.
+			wantAction:   actionDeferred,
+			wantResource: "",
+		},
+		{
+			caseName: "batch delete objects via trailing-slash bucket URL",
+			method:   http.MethodPost,
+			url:      "/mybucket/?delete",
+			bucket:   "mybucket",
+			// "POST /{bucket}/?delete" routes to "/{bucket}/{key...}" with
+			// an empty key and is delegated back to handleBucketPOST /
+			// handleDeleteObjects (see handleObjectPOST). It must defer
+			// identically to the no-trailing-slash form above rather than
+			// being checked as s3:PutObject on the empty-key resource.
 			wantAction:   actionDeferred,
 			wantResource: "",
 		},

--- a/server/policy_test.go
+++ b/server/policy_test.go
@@ -225,7 +225,10 @@ func TestAuthorized(t *testing.T) {
 	}{
 		{caseName: "nil user is always allowed", user: nil, action: "s3:DeleteBucket", resource: "arn:aws:s3:::bucket", want: true},
 		{caseName: "user with no policy is always allowed", user: &User{}, action: "s3:DeleteBucket", resource: "arn:aws:s3:::bucket", want: true},
-		{caseName: "empty action skips the check even for a restrictive policy", user: scopedUser, action: "", resource: "", want: true},
+		{caseName: "actionSkip passes even for a restrictive policy", user: scopedUser, action: actionSkip, resource: "", want: true},
+		{caseName: "actionDeferred passes even for a restrictive policy", user: scopedUser, action: actionDeferred, resource: "", want: true},
+		{caseName: "unclassified empty action is denied, not treated as skip/defer", user: scopedUser, action: "", resource: "", want: false},
+		{caseName: "unclassified empty action is denied even for a full-access user", user: nil, action: "", resource: "", want: false},
 		{caseName: "scoped policy allows a matching action/resource", user: scopedUser, action: "s3:GetObject", resource: "arn:aws:s3:::bucket/key", want: true},
 		{caseName: "scoped policy denies a non-matching action", user: scopedUser, action: "s3:DeleteObject", resource: "arn:aws:s3:::bucket/key", want: false},
 	}
@@ -361,6 +364,36 @@ func TestStringOrSliceUnmarshalJSON(t *testing.T) {
 	}
 }
 
+// TestStringOrSliceUnmarshalJSONRejectsNull guards against "Action": null
+// (or Resource) producing stringOrSlice{""} -- a one-element slice with an
+// empty string, which Validate's len(...) == 0 check wouldn't catch,
+// silently making an inert Deny statement never apply.
+func TestStringOrSliceUnmarshalJSONRejectsNull(t *testing.T) {
+	var got stringOrSlice
+	err := json.Unmarshal([]byte(`null`), &got)
+	assert.Error(t, err)
+}
+
+// TestPolicyValidateRejectsNullActionOrResource is the end-to-end version
+// of TestStringOrSliceUnmarshalJSONRejectsNull: a full policy document
+// with "Action": null must fail to even parse (and therefore fail
+// Config.LoadFile), not silently validate as an inert statement.
+func TestPolicyValidateRejectsNullActionOrResource(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		input    string
+	}{
+		{caseName: "null action", input: `{"Statement":[{"Effect":"Deny","Action":null,"Resource":"arn:aws:s3:::secret/*"}]}`},
+		{caseName: "null resource", input: `{"Statement":[{"Effect":"Deny","Action":"s3:GetObject","Resource":null}]}`},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			var p Policy
+			assert.Error(t, json.Unmarshal([]byte(tc.input), &p))
+		})
+	}
+}
+
 func TestWildcardMatch(t *testing.T) {
 	testCases := []struct {
 		caseName string
@@ -429,6 +462,39 @@ func TestS3Action(t *testing.T) {
 			wantResource: "arn:aws:s3:::mybucket",
 		},
 		{
+			// A trailing slash matches Go ServeMux's "/{bucket}/{key...}"
+			// pattern with an empty key (handleDeleteObject), not the
+			// bucket-level "/{bucket}" pattern (handleDeleteBucket) --
+			// even though PathValue("key") is "" either way. Classifying
+			// this as DeleteBucket would authorize a different operation
+			// than the one that actually runs.
+			caseName:     "delete with trailing slash routes to object handler, not bucket handler",
+			method:       http.MethodDelete,
+			url:          "/mybucket/",
+			bucket:       "mybucket",
+			key:          "",
+			wantAction:   "s3:DeleteObject",
+			wantResource: "arn:aws:s3:::mybucket/",
+		},
+		{
+			caseName:     "get with trailing slash routes to object handler, not bucket handler",
+			method:       http.MethodGet,
+			url:          "/mybucket/",
+			bucket:       "mybucket",
+			key:          "",
+			wantAction:   "s3:GetObject",
+			wantResource: "arn:aws:s3:::mybucket/",
+		},
+		{
+			caseName:     "put with trailing slash routes to object handler, not bucket handler",
+			method:       http.MethodPut,
+			url:          "/mybucket/",
+			bucket:       "mybucket",
+			key:          "",
+			wantAction:   "s3:PutObject",
+			wantResource: "arn:aws:s3:::mybucket/",
+		},
+		{
 			caseName:     "get bucket location",
 			method:       http.MethodGet,
 			url:          "/mybucket?location",
@@ -460,7 +526,7 @@ func TestS3Action(t *testing.T) {
 			// The affected keys are only known once the handler decodes
 			// the request body, so S3Action defers entirely to
 			// handleDeleteObjects' per-key AllowedS3Action checks.
-			wantAction:   "",
+			wantAction:   actionDeferred,
 			wantResource: "",
 		},
 		{
@@ -556,18 +622,25 @@ func TestConsoleAction(t *testing.T) {
 		wantResource string
 	}{
 		{
-			caseName:     "index bucket list",
+			// GET / is the console's only entry point (login landing
+			// page + bucket sidebar data source), so it must never be
+			// blocked by a policy check -- FilterBucketNames handles
+			// visibility instead. See ConsoleAction's doc comment.
+			caseName:     "index bucket list has no single up-front resource",
 			method:       http.MethodGet,
 			url:          "/",
-			wantAction:   "s3:ListAllMyBuckets",
-			wantResource: "arn:aws:s3:::*",
+			wantAction:   actionDeferred,
+			wantResource: "",
 		},
 		{
-			caseName:     "create bucket",
+			// The bucket name lives in the form body, not the URL, so
+			// ConsoleAction defers to handleCreateBucket's
+			// AllowedS3BucketAction check on the real name.
+			caseName:     "create bucket has no single up-front resource",
 			method:       http.MethodPost,
 			url:          "/buckets",
-			wantAction:   "s3:CreateBucket",
-			wantResource: "arn:aws:s3:::*",
+			wantAction:   actionDeferred,
+			wantResource: "",
 		},
 		{
 			caseName:     "delete bucket",
@@ -593,7 +666,7 @@ func TestConsoleAction(t *testing.T) {
 			method:       http.MethodPost,
 			url:          "/buckets/mybucket/folders",
 			pathValues:   map[string]string{"name": "mybucket"},
-			wantAction:   "",
+			wantAction:   actionDeferred,
 			wantResource: "",
 		},
 		{
@@ -603,7 +676,7 @@ func TestConsoleAction(t *testing.T) {
 			method:       http.MethodPost,
 			url:          "/buckets/mybucket/upload",
 			pathValues:   map[string]string{"name": "mybucket"},
-			wantAction:   "",
+			wantAction:   actionDeferred,
 			wantResource: "",
 		},
 		{
@@ -623,7 +696,7 @@ func TestConsoleAction(t *testing.T) {
 			method:       http.MethodDelete,
 			url:          "/buckets/mybucket/objects?key=folder/",
 			pathValues:   map[string]string{"name": "mybucket"},
-			wantAction:   "",
+			wantAction:   actionDeferred,
 			wantResource: "",
 		},
 		{
@@ -654,7 +727,7 @@ func TestConsoleAction(t *testing.T) {
 			caseName:     "static asset bypasses check",
 			method:       http.MethodGet,
 			url:          "/static/app.css",
-			wantAction:   "",
+			wantAction:   actionSkip,
 			wantResource: "",
 		},
 	}

--- a/server/policy_test.go
+++ b/server/policy_test.go
@@ -358,6 +358,43 @@ func TestPolicyValidate(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			caseName: "resource without the arn:aws:s3::: prefix rejected",
+			policy: Policy{
+				// A common typo: the author meant to scope this to
+				// "arn:aws:s3:::secret-bucket/*" but dropped the ARN
+				// prefix. wildcardMatch would never match this against a
+				// real "arn:aws:s3:::..." resource, silently turning an
+				// intended Deny into a permanent no-op.
+				Statement: []Statement{denyStatement("s3:GetObject", "secret-bucket/*")},
+			},
+			wantErr: true,
+		},
+		{
+			caseName: "bare wildcard resource accepted",
+			policy: Policy{
+				Statement: []Statement{allowStatement("s3:GetObject", "*")},
+			},
+			wantErr: false,
+		},
+		{
+			caseName: "arn-prefixed resource accepted",
+			policy: Policy{
+				Statement: []Statement{allowStatement("s3:GetObject", "arn:aws:s3:::mybucket/*")},
+			},
+			wantErr: false,
+		},
+		{
+			caseName: "one bad resource among several rejected",
+			policy: Policy{
+				Statement: []Statement{{
+					Effect:   "Allow",
+					Action:   stringOrSlice{"s3:GetObject"},
+					Resource: stringOrSlice{"arn:aws:s3:::mybucket/*", "otherbucket/*"},
+				}},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.caseName, func(t *testing.T) {

--- a/server/s3api.go
+++ b/server/s3api.go
@@ -1,10 +1,45 @@
 package server
 
 import (
+	"encoding/xml"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"time"
 )
+
+// S3ErrorResponse is the XML response body for an S3 API error, shared by
+// both server/handlers/s3api (application-level errors) and
+// server/middleware (SigV4 authentication/authorization errors) so the
+// two don't drift into subtly different error shapes.
+type S3ErrorResponse struct {
+	XMLName   xml.Name `xml:"Error"`
+	Code      string   `xml:"Code"`
+	Message   string   `xml:"Message"`
+	Resource  string   `xml:"Resource"`
+	RequestID string   `xml:"RequestId"`
+}
+
+// WriteS3Error writes code/message as an S3ErrorResponse with the given
+// HTTP status.
+func WriteS3Error(w http.ResponseWriter, r *http.Request, code, message string, status int) {
+	WriteXML(w, status, S3ErrorResponse{
+		Code:      code,
+		Message:   message,
+		Resource:  r.URL.Path,
+		RequestID: "s2-request-id",
+	})
+}
+
+// WriteXML writes v as an XML response body with the given HTTP status.
+func WriteXML(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(status)
+	_, _ = fmt.Fprint(w, xml.Header)
+	if err := xml.NewEncoder(w).Encode(v); err != nil {
+		slog.Error("Failed to encode XML", "error", err)
+	}
+}
 
 // s3Handlers holds the routes registered via RegisterS3HandleFunc,
 // served by S3Handler().

--- a/server/user.go
+++ b/server/user.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"crypto/subtle"
 )
 
 // User is one configured principal: a credential pair plus the policy that
@@ -19,13 +18,18 @@ type User struct {
 // first and falling back to the legacy single User/Password fields
 // (synthesized as a full-access User with a nil Policy) if no Users entry
 // matches. It returns nil if accessKeyID matches neither.
+//
+// accessKeyID is compared with plain == rather than constant-time
+// comparison: it's a public identifier, not a secret -- it travels
+// unencrypted in the SigV4 Authorization header/query string. The actual
+// secret (password/signature) is compared in constant time downstream.
 func (cfg *Config) LookupUser(accessKeyID string) *User {
 	for i := range cfg.Users {
-		if subtle.ConstantTimeCompare([]byte(cfg.Users[i].AccessKeyID), []byte(accessKeyID)) == 1 {
+		if cfg.Users[i].AccessKeyID == accessKeyID {
 			return &cfg.Users[i]
 		}
 	}
-	if cfg.User != "" && subtle.ConstantTimeCompare([]byte(cfg.User), []byte(accessKeyID)) == 1 {
+	if cfg.User != "" && cfg.User == accessKeyID {
 		return &User{AccessKeyID: cfg.User, SecretAccessKey: cfg.Password}
 	}
 	return nil
@@ -47,7 +51,7 @@ func FilterBucketNames(user *User, names []string) []string {
 	}
 	out := make([]string, 0, len(names))
 	for _, name := range names {
-		if user.Policy.Allowed("s3:ListBucket", bucketARN(name)) {
+		if user.Policy.Allowed(ActionListBucket, bucketARN(name)) {
 			out = append(out, name)
 		}
 	}

--- a/server/user.go
+++ b/server/user.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"context"
+	"crypto/subtle"
+)
+
+// User is one configured principal: a credential pair plus the policy that
+// governs what it may do. A nil Policy means "no policy attached" -- full
+// access, matching the legacy single-credential behavior. A non-nil but
+// empty Policy denies everything.
+type User struct {
+	AccessKeyID     string  `json:"access_key_id"`
+	SecretAccessKey string  `json:"secret_access_key"`
+	Policy          *Policy `json:"policy,omitempty"`
+}
+
+// LookupUser returns the User matching accessKeyID, checking cfg.Users
+// first and falling back to the legacy single User/Password fields
+// (synthesized as a full-access User with a nil Policy) if no Users entry
+// matches. It returns nil if accessKeyID matches neither.
+func (cfg *Config) LookupUser(accessKeyID string) *User {
+	for i := range cfg.Users {
+		if subtle.ConstantTimeCompare([]byte(cfg.Users[i].AccessKeyID), []byte(accessKeyID)) == 1 {
+			return &cfg.Users[i]
+		}
+	}
+	if cfg.User != "" && subtle.ConstantTimeCompare([]byte(cfg.User), []byte(accessKeyID)) == 1 {
+		return &User{AccessKeyID: cfg.User, SecretAccessKey: cfg.Password}
+	}
+	return nil
+}
+
+// AuthEnabled reports whether any credential is configured, legacy or
+// multi-user. SigV4 and BasicAuth skip authentication entirely when false.
+func (cfg *Config) AuthEnabled() bool {
+	return cfg.User != "" || len(cfg.Users) > 0
+}
+
+// FilterBucketNames returns the subset of names that user is allowed to
+// list (s3:ListBucket on the bucket's ARN). A nil Policy (full access,
+// including the legacy single-credential user) passes every name through
+// unfiltered.
+func FilterBucketNames(user *User, names []string) []string {
+	if user == nil || user.Policy == nil {
+		return names
+	}
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		if user.Policy.Allowed("s3:ListBucket", bucketARN(name)) {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// userContextKey is an unexported type so context values set by this
+// package can't collide with keys set elsewhere.
+type userContextKey struct{}
+
+// WithUser returns a copy of ctx carrying user, retrievable via
+// UserFromContext. Used by SigV4/BasicAuth to pass the authenticated
+// principal to handlers that need to filter results by policy (e.g.
+// ListBuckets).
+func WithUser(ctx context.Context, user *User) context.Context {
+	return context.WithValue(ctx, userContextKey{}, user)
+}
+
+// UserFromContext returns the User stashed by WithUser, or nil if none was
+// set (including when auth is disabled).
+func UserFromContext(ctx context.Context) *User {
+	user, _ := ctx.Value(userContextKey{}).(*User)
+	return user
+}

--- a/server/user_test.go
+++ b/server/user_test.go
@@ -1,0 +1,88 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigLookupUser(t *testing.T) {
+	cfg := &Config{
+		User:     "root",
+		Password: "rootsecret",
+		Users: []User{
+			{AccessKeyID: "userA", SecretAccessKey: "secretA"},
+			{AccessKeyID: "userB", SecretAccessKey: "secretB", Policy: &Policy{}},
+		},
+	}
+
+	testCases := []struct {
+		caseName    string
+		accessKeyID string
+		wantNil     bool
+		wantSecret  string
+		wantPolicy  bool
+	}{
+		{caseName: "finds multi-user entry", accessKeyID: "userA", wantSecret: "secretA"},
+		{caseName: "finds multi-user entry with policy", accessKeyID: "userB", wantSecret: "secretB", wantPolicy: true},
+		{caseName: "falls back to legacy user", accessKeyID: "root", wantSecret: "rootsecret"},
+		{caseName: "unknown access key returns nil", accessKeyID: "nope", wantNil: true},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			u := cfg.LookupUser(tc.accessKeyID)
+			if tc.wantNil {
+				assert.Nil(t, u)
+				return
+			}
+			if assert.NotNil(t, u) {
+				assert.Equal(t, tc.wantSecret, u.SecretAccessKey)
+				assert.Equal(t, tc.wantPolicy, u.Policy != nil)
+			}
+		})
+	}
+}
+
+func TestConfigLookupUserNoLegacy(t *testing.T) {
+	cfg := &Config{Users: []User{{AccessKeyID: "userA", SecretAccessKey: "secretA"}}}
+	assert.Nil(t, cfg.LookupUser("unknown"))
+}
+
+func TestConfigAuthEnabled(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		cfg      *Config
+		want     bool
+	}{
+		{caseName: "nothing configured", cfg: &Config{}, want: false},
+		{caseName: "legacy user set", cfg: &Config{User: "root"}, want: true},
+		{caseName: "users set", cfg: &Config{Users: []User{{AccessKeyID: "a", SecretAccessKey: "b"}}}, want: true},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.cfg.AuthEnabled())
+		})
+	}
+}
+
+func TestFilterBucketNames(t *testing.T) {
+	names := []string{"public", "private", "other"}
+	restricted := &User{Policy: &Policy{Statement: []Statement{
+		allowStatement("s3:ListBucket", "arn:aws:s3:::public"),
+	}}}
+
+	testCases := []struct {
+		caseName string
+		user     *User
+		want     []string
+	}{
+		{caseName: "nil user passes through unfiltered", user: nil, want: names},
+		{caseName: "nil policy passes through unfiltered", user: &User{}, want: names},
+		{caseName: "restrictive policy filters", user: restricted, want: []string{"public"}},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			assert.Equal(t, tc.want, FilterBucketNames(tc.user, names))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- s2 previously supported a single Access Key ID / Secret Access Key pair (`User`/`Password`) shared by both the S3 API (SigV4) and the Web Console (Basic Auth), with no authorization concept beyond "valid credential = full access".
- Adds a `Users` config list where each principal has its own Access Key ID/Secret and an optional AWS-IAM-shaped `Policy` (`Version`/`Statement` with `Effect`/`Action`/`Resource`, `*` wildcards). SigV4 and BasicAuth both check the matched user's policy after verifying the credential; a `nil` Policy (including the legacy single-credential user) means unrestricted access, matching today's behavior.
- Console access mirrors MinIO: any configured user can log in, but every console action is authorized against the same policy via a parallel `ConsoleAction` mapping.
- Bucket listing (`ListBuckets`, and the console's bucket sidebar) is filtered per-user via `FilterBucketNames`.
- Batch/recursive operations whose affected resources aren't known until the request body is parsed (S3 `POST /{bucket}?delete`, console folder upload/create, recursive folder delete) defer to a precise per-key check in the handler instead of a single up-front resource check, so a policy scoped to a sub-prefix -- or an explicit `Deny` on one specific key -- is honored correctly.
- `CopyObject` now authorizes its copy-source object separately from the destination, closing a path where a `PutObject`-only policy could otherwise be used to read arbitrary objects.
- `Condition` blocks are parsed but rejected at config-load time if non-empty (fail loud, not silently ignored) since they aren't evaluated yet.
- Addresses #162.

## Non-goals
- Named/reusable policies, bucket-level (resource-attached) policies, `Condition` evaluation, and env-var config for `Users` are intentionally out of scope for this first pass.

## Test plan
- [x] `go test ./...` (server module)
- [x] `golangci-lint run ./...`
- [x] `make test-e2e` -- added a `s2-users` scenario exercising a root (full-access) user and a read-only user against the read-only policy example from #162