### PR TITLE
fix(fs): Correct List pagination for recursive listings

### DIFF
--- a/fs/storage.go
+++ b/fs/storage.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"net/url"
 	"path"
+	"sort"
 	"strings"
 
 	"github.com/mojatter/s2"
@@ -143,6 +144,7 @@ func (s *storage) listFlat(prefix, after string, limit int) (s2.ListResult, erro
 		res.Objects = append(res.Objects, newObjectFileInfo(s.fsys, name, info))
 		limit--
 		if limit <= 0 {
+			res.NextAfter = name
 			break
 		}
 	}
@@ -150,7 +152,13 @@ func (s *storage) listFlat(prefix, after string, limit int) (s2.ListResult, erro
 }
 
 func (s *storage) listRecursive(prefix, after string, limit int) (s2.ListResult, error) {
-	res := s2.ListResult{Objects: make([]s2.Object, 0, limit)}
+	// fs.WalkDir's visit order is pre-order by directory, not lexicographic
+	// by full path (e.g. "backup/2024.log" is visited before sibling file
+	// "backup-old.txt", even though "backup-old.txt" sorts first as a full
+	// path). Collect everything first and sort below, rather than capping
+	// at limit mid-walk, which could return objects out of order and,
+	// combined with an after cursor, permanently skip unvisited ones.
+	var objs []s2.Object
 	err := fs.WalkDir(s.fsys, ".", func(name string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -174,15 +182,18 @@ func (s *storage) listRecursive(prefix, after string, limit int) (s2.ListResult,
 		if isTempFile(d.Name()) {
 			return nil
 		}
-		res.Objects = append(res.Objects, newObjectFileInfo(s.fsys, name, info))
-		limit--
-		if limit <= 0 {
-			return fs.SkipDir
-		}
+		objs = append(objs, newObjectFileInfo(s.fsys, name, info))
 		return nil
 	})
 	if err != nil {
 		return s2.ListResult{}, err
+	}
+	sort.Slice(objs, func(i, j int) bool { return objs[i].Name() < objs[j].Name() })
+
+	res := s2.ListResult{Objects: objs}
+	if len(objs) > limit {
+		res.Objects = objs[:limit]
+		res.NextAfter = res.Objects[limit-1].Name()
 	}
 	return res, nil
 }

--- a/fs/storage_test.go
+++ b/fs/storage_test.go
@@ -367,6 +367,87 @@ func (s *StorageTestSuite) TestListRecursiveAfter() {
 	}
 }
 
+// TestListNextAfter verifies that List sets NextAfter when a Limit
+// truncates the result, for both flat and recursive listings, and that
+// following NextAfter across pages yields every object exactly once with
+// no duplicates or gaps.
+func (s *StorageTestSuite) TestListNextAfter() {
+	testCases := []struct {
+		caseName  string
+		recursive bool
+		want      []string
+	}{
+		{caseName: "flat", recursive: false, want: []string{"a.txt", "b.txt"}},
+		{caseName: "recursive", recursive: true, want: []string{"a.txt", "b.txt", "cc/c1.txt", "cc/c2.txt"}},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			strg := &storage{fsys: s.testMemFS()}
+			ctx := context.Background()
+
+			// Limit: 1 forces a new page per object, so a flat listing's
+			// final page (which only has the "cc" CommonPrefix left, no
+			// more Objects) is expected to come back empty before
+			// NextAfter finally goes empty too.
+			var got []string
+			after := ""
+			pages := 0
+			for {
+				res, err := strg.List(ctx, s2.ListOptions{Limit: 1, After: after, Recursive: tc.recursive})
+				s.Require().NoError(err)
+				for _, obj := range res.Objects {
+					got = append(got, obj.Name())
+				}
+				pages++
+				s.Require().Less(pages, 10, "pagination did not terminate")
+				if res.NextAfter == "" {
+					break
+				}
+				after = res.NextAfter
+			}
+			s.Equal(tc.want, got)
+		})
+	}
+}
+
+// TestListRecursivePaginationOrder guards against fs.WalkDir's traversal
+// order being mistaken for lexicographic order: WalkDir descends into a
+// directory's full subtree before moving to the next sibling, so a
+// directory name that sorts before a sibling file (e.g. "backup" <
+// "backup-old.txt") gets its entire contents visited before that sibling,
+// even though as full paths the sibling sorts first ("backup-old.txt" <
+// "backup/2024-01-01.log", since '-' < '/'). Pagination that trusted
+// WalkDir's raw visit order for NextAfter would permanently skip
+// "backup-old.txt" once the walk reached "backup"'s contents first.
+func (s *StorageTestSuite) TestListRecursivePaginationOrder() {
+	fsys := memfs.New()
+	_, err := fsys.WriteFile("backup-old.txt", []byte("x"), fs.ModePerm)
+	s.Require().NoError(err)
+	_, err = fsys.WriteFile("backup/2024-01-01.log", []byte("y"), fs.ModePerm)
+	s.Require().NoError(err)
+
+	strg := &storage{fsys: fsys}
+	ctx := context.Background()
+
+	var got []string
+	after := ""
+	pages := 0
+	for {
+		res, err := strg.List(ctx, s2.ListOptions{Limit: 1, After: after, Recursive: true})
+		s.Require().NoError(err)
+		for _, obj := range res.Objects {
+			got = append(got, obj.Name())
+		}
+		pages++
+		s.Require().Less(pages, 10, "pagination did not terminate")
+		if res.NextAfter == "" {
+			break
+		}
+		after = res.NextAfter
+	}
+	s.Equal([]string{"backup-old.txt", "backup/2024-01-01.log"}, got)
+}
+
 // TestListRecursiveAfter_WalkDirError verifies that an error passed to the
 // WalkDir callback (e.g. a failed ReadDir on a subdirectory) is propagated
 // instead of being silently ignored. This covers the err != nil guard added
@@ -417,7 +498,6 @@ func (s *StorageTestSuite) TestGet() {
 		})
 	}
 }
-
 
 func (s *StorageTestSuite) TestPut() {
 	testCases := []struct {
@@ -776,7 +856,7 @@ func benchGetObject(b *testing.B, typ s2.Type) {
 // rotating-key writes. s2's atomicWrite always fsyncs before rename;
 // see BenchmarkPutObjectMemFS for numbers that exclude the durability
 // cost.
-func BenchmarkPutObject(b *testing.B)    { benchPutObject(b, s2.TypeOSFS) }
-func BenchmarkGetObject(b *testing.B)    { benchGetObject(b, s2.TypeOSFS) }
+func BenchmarkPutObject(b *testing.B)      { benchPutObject(b, s2.TypeOSFS) }
+func BenchmarkGetObject(b *testing.B)      { benchGetObject(b, s2.TypeOSFS) }
 func BenchmarkPutObjectMemFS(b *testing.B) { benchPutObject(b, s2.TypeMemFS) }
 func BenchmarkGetObjectMemFS(b *testing.B) { benchGetObject(b, s2.TypeMemFS) }


### PR DESCRIPTION
## Summary
- `Storage.List` never set `ListResult.NextAfter` when a `Limit` truncated the result, so callers had no way to detect a page was incomplete.
- `listRecursive`'s truncation branch returned `fs.SkipDir` from a non-directory entry, which per `fs.WalkDir`'s documented semantics only skips the rest of the *current* directory, not the whole walk -- so the walk could keep descending into sibling directories past the requested limit.
- `fs.WalkDir` visits a directory's entire subtree before moving to the next sibling (pre-order), which is not the same as lexicographic order of full paths (e.g. a directory named `backup` sorts before sibling file `backup-old.txt`, but everything under `backup/` sorts *after* `backup-old.txt` as a full path). Capping a page mid-walk on that raw visit order could return objects out of the lexicographic order `ListResult` documents, and combined with an `After` cursor from a truncated page, permanently skip objects the walk simply hadn't reached yet.

## Fix
- `listRecursive` now collects the full matching subtree, sorts by path, then slices to `Limit` and sets `NextAfter` from the true lexicographic boundary.
- `listFlat` now also sets `NextAfter` when its (already-sorted) page is truncated.

## Test plan
- [x] `go test ./fs/...`
- [x] Added `TestListNextAfter` (flat + recursive pagination round-trips with no gaps/duplicates)
- [x] Added `TestListRecursivePaginationOrder`, reproducing the `backup` / `backup-old.txt` ordering bug directly