### PR TITLE
test(console): Widen chromedp timeout to 30s in gallery view test

### DIFF
--- a/server/handlers/console/buckets/objects_test.go
+++ b/server/handlers/console/buckets/objects_test.go
@@ -402,9 +402,10 @@ func (s *ObjectsTestSuite) TestGalleryView_ThumbnailAndPersistenceAcrossReload()
 
 	browserCtx, cancel := chromedp.NewContext(allocCtx)
 	defer cancel()
-	// CI runners need headroom for a cold Chrome start; 5s was enough
-	// locally but flaked in CI with "chrome failed to start".
-	browserCtx, cancelTimeout := context.WithTimeout(browserCtx, 15*time.Second)
+	// This deadline covers the whole test (both s.Run subtests share
+	// browserCtx). 15s was enough locally but flaked in CI with "chrome
+	// failed to start: context deadline exceeded" on a busy runner.
+	browserCtx, cancelTimeout := context.WithTimeout(browserCtx, 30*time.Second)
 	defer cancelTimeout()
 
 	pageURL := ts.URL + "/buckets/gallery?prefix="


### PR DESCRIPTION
## Summary
- CI job https://github.com/mojatter/s2/actions/runs/33194216755/job/98928081851 failed with `chrome failed to start: context deadline exceeded` after exactly 15s, the full duration of the shared `browserCtx` deadline.
- The 15s budget covers Chrome startup plus every `chromedp.Run` call across both subtests, so a slower CI runner has no headroom. Widened to 30s and corrected the comment to describe the deadline's actual scope.

## Test plan
- [ ] CI run passes the browser test consistently