### PR TITLE
chore: Bump intra-repo deps to v0.13.0

### DIFF
--- a/azblob/go.mod
+++ b/azblob/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.23.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0
-	github.com/mojatter/s2 v0.12.7
+	github.com/mojatter/s2 v0.13.0
 	github.com/stretchr/testify v1.12.1
 )
 

--- a/gcs/go.mod
+++ b/gcs/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	cloud.google.com/go/storage v1.65.0
-	github.com/mojatter/s2 v0.12.7
+	github.com/mojatter/s2 v0.13.0
 	github.com/stretchr/testify v1.12.1
 	google.golang.org/api v0.293.0
 )

--- a/s2env/go.mod
+++ b/s2env/go.mod
@@ -3,10 +3,10 @@ module github.com/mojatter/s2/s2env
 go 1.25.8
 
 require (
-	github.com/mojatter/s2 v0.12.7
-	github.com/mojatter/s2/azblob v0.12.7
-	github.com/mojatter/s2/gcs v0.12.7
-	github.com/mojatter/s2/s3 v0.12.7
+	github.com/mojatter/s2 v0.13.0
+	github.com/mojatter/s2/azblob v0.13.0
+	github.com/mojatter/s2/gcs v0.13.0
+	github.com/mojatter/s2/s3 v0.13.0
 	github.com/stretchr/testify v1.12.1
 )
 

--- a/s3/go.mod
+++ b/s3/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.38
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.107.3
 	github.com/aws/smithy-go v1.27.9
-	github.com/mojatter/s2 v0.12.7
+	github.com/mojatter/s2 v0.13.0
 	github.com/stretchr/testify v1.12.1
 )
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.37
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.107.3
 	github.com/chromedp/chromedp v0.16.0
-	github.com/mojatter/s2 v0.12.7
+	github.com/mojatter/s2 v0.13.0
 	github.com/stretchr/testify v1.12.1
 )
 


### PR DESCRIPTION
## Summary
Bump the intra-repo `github.com/mojatter/s2*` require lines in the five replace-modules (s3, gcs, azblob, server, s2env) to v0.13.0, ahead of tagging the v0.13.0 release. `cmd/s2-server` is intentionally excluded — its require bump lands in a follow-up PR after the new submodule tags are published.

## Test plan
- [x] `go vet ./...` (workspace)
- [x] `go test ./...` (root)
- [x] `go test ./...` in each of s3, gcs, azblob, s2env, server, cmd/s2-server
- [x] `GOWORK=off go build .` in cmd/s2-server (resolves to previous published version)
- [x] `GOWORK=off go build ./...` in server
- [x] `GOWORK=off go test -tags integtest -c` in s3
- [x] `goreleaser release --snapshot --clean --skip=publish --skip=docker`