### PR TITLE
feat(server): Support anonymous public read access via a "*" principal

### DIFF
--- a/docs/users-policy.md
+++ b/docs/users-policy.md
@@ -35,7 +35,7 @@ Each entry:
 
 | Field | Description |
 |-------|-------------|
-| `access_key_id` | SigV4 Access Key ID / Basic Auth username |
+| `access_key_id` | SigV4 Access Key ID / Basic Auth username. `"*"` is reserved for the anonymous principal (see [below](#anonymous-public-read-access)) |
 | `secret_access_key` | SigV4 Secret Access Key / Basic Auth password |
 | `policy` | Optional. Omit for full access (see below) |
 
@@ -110,6 +110,39 @@ A principal with **no `policy` field** (or the legacy `user`/`password` pair) ha
 ```
 
 This grants read access to the whole `uploads` bucket, write/delete access scoped to `uploads/incoming/`, and carves out one file that can never be deleted regardless of the broader `Allow` above (an explicit `Deny` always wins).
+
+## Anonymous public read access
+
+A `users` entry whose `access_key_id` is exactly `"*"` is the anonymous principal. S3 API requests that carry neither an `Authorization` header nor presigned-URL query parameters are evaluated against this entry's `policy` instead of being rejected — the same `Allowed`/`Authorized` check used for every other principal.
+
+```json
+{
+  "users": [
+    {
+      "access_key_id": "*",
+      "policy": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::public-assets/*"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+There is no separate "public bucket" flag — the presence of a `"*"` entry is itself the toggle, and `Resource` scoping controls which buckets/prefixes are public, exactly like any other principal's policy.
+
+Constraints specific to this entry, enforced at config-load time:
+
+- `secret_access_key` must be empty — anonymous requests never present a secret.
+- `policy` is required (the usual "no `policy` = full access" convention does not apply to `"*"`, since that would turn one config line into an all-buckets, all-actions public grant).
+- Every `Action` in the policy must be `s3:GetObject`. `s3:ListBucket` (directory-listing-style enumeration) and write/delete actions are not supported for the anonymous principal.
+- The Web Console (Basic Auth) never consults this entry — anonymous browsing of the bucket sidebar is out of scope. Anonymous access only applies to the S3 API.
 
 ## Known gaps and quirks
 

--- a/server/config.go
+++ b/server/config.go
@@ -78,6 +78,13 @@ type Config struct {
 	// Password pair above; each entry's Policy (if set) governs what that
 	// principal may do. Config-file only -- there is no environment
 	// variable equivalent.
+	//
+	// An entry whose AccessKeyID is AnonymousAccessKeyID ("*") is the
+	// anonymous principal: SigV4 falls back to it for S3 API requests that
+	// carry no Authorization header and no presigned-URL query parameters,
+	// instead of rejecting them outright. BasicAuth (the Web Console) never
+	// consults it -- anonymous browsing of the bucket sidebar is out of
+	// scope. See Config.Validate for the constraints placed on this entry.
 	Users []User `json:"users,omitempty"`
 	// Buckets is a list of bucket names to create on startup if they don't already exist.
 	Buckets []string `json:"buckets"`
@@ -132,6 +139,10 @@ func (cfg *Config) Validate() error {
 		}
 	}
 
+	if cfg.User == AnonymousAccessKeyID {
+		return fmt.Errorf("server: User must not be %q; the anonymous principal is only configurable via a Users entry, which enforces the GetObject-only restriction", AnonymousAccessKeyID)
+	}
+
 	seen := make(map[string]bool, len(cfg.Users)+1)
 	if cfg.User != "" {
 		seen[cfg.User] = true
@@ -140,7 +151,15 @@ func (cfg *Config) Validate() error {
 		if u.AccessKeyID == "" {
 			return fmt.Errorf("server: users[%d]: access_key_id must not be empty", i)
 		}
-		if u.SecretAccessKey == "" {
+		isAnonymous := u.AccessKeyID == AnonymousAccessKeyID
+		if isAnonymous {
+			if u.SecretAccessKey != "" {
+				return fmt.Errorf("server: users[%d] (%s): secret_access_key must be empty for the anonymous principal", i, u.AccessKeyID)
+			}
+			if u.Policy == nil {
+				return fmt.Errorf("server: users[%d] (%s): policy is required for the anonymous principal", i, u.AccessKeyID)
+			}
+		} else if u.SecretAccessKey == "" {
 			return fmt.Errorf("server: users[%d] (%s): secret_access_key must not be empty", i, u.AccessKeyID)
 		}
 		if seen[u.AccessKeyID] {
@@ -150,6 +169,27 @@ func (cfg *Config) Validate() error {
 		if u.Policy != nil {
 			if err := u.Policy.Validate(); err != nil {
 				return fmt.Errorf("server: users[%d] (%s): %w", i, u.AccessKeyID, err)
+			}
+			if isAnonymous {
+				if err := validateAnonymousPolicyActions(u.Policy); err != nil {
+					return fmt.Errorf("server: users[%d] (%s): %w", i, u.AccessKeyID, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// validateAnonymousPolicyActions restricts the anonymous principal's policy
+// to s3:GetObject, so a "*" entry can only ever grant unauthenticated read
+// access. Without this, the existing "nil Policy = full access" convention
+// combined with a permissive Action wildcard could turn a single Users
+// entry into an all-buckets, all-actions public grant.
+func validateAnonymousPolicyActions(p *Policy) error {
+	for i, stmt := range p.Statement {
+		for _, action := range stmt.Action {
+			if action != ActionGetObject {
+				return fmt.Errorf("policy: statement[%d]: anonymous principal only supports Action %q, got %q", i, ActionGetObject, action)
 			}
 		}
 	}

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -260,6 +260,87 @@ func TestConfigValidateUsers(t *testing.T) {
 			}(),
 			wantErr: true,
 		},
+		{
+			caseName: "valid anonymous principal accepted",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.Users = []User{{
+					AccessKeyID: AnonymousAccessKeyID,
+					Policy: &Policy{
+						Statement: []Statement{allowStatement("s3:GetObject", "arn:aws:s3:::public/*")},
+					},
+				}}
+				return c
+			}(),
+			wantErr: false,
+		},
+		{
+			caseName: "anonymous principal with secret_access_key rejected",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.Users = []User{{
+					AccessKeyID:     AnonymousAccessKeyID,
+					SecretAccessKey: "shouldnotbeset",
+					Policy: &Policy{
+						Statement: []Statement{allowStatement("s3:GetObject", "*")},
+					},
+				}}
+				return c
+			}(),
+			wantErr: true,
+		},
+		{
+			caseName: "anonymous principal without policy rejected",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.Users = []User{{AccessKeyID: AnonymousAccessKeyID}}
+				return c
+			}(),
+			wantErr: true,
+		},
+		{
+			caseName: "anonymous principal with non-GetObject action rejected",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.Users = []User{{
+					AccessKeyID: AnonymousAccessKeyID,
+					Policy: &Policy{
+						Statement: []Statement{allowStatement("s3:ListBucket", "*")},
+					},
+				}}
+				return c
+			}(),
+			wantErr: true,
+		},
+		{
+			caseName: "anonymous principal with wildcard action rejected",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.Users = []User{{
+					AccessKeyID: AnonymousAccessKeyID,
+					Policy: &Policy{
+						Statement: []Statement{allowStatement("*", "*")},
+					},
+				}}
+				return c
+			}(),
+			wantErr: true,
+		},
+		{
+			// A legacy User set to "*" would resolve through LookupUser's
+			// fallback to a full-access (nil-Policy) User, bypassing the
+			// GetObject-only restriction the anonymous principal is meant to
+			// enforce -- see server.LookupUser and the Users-entry cases
+			// above for the restriction this must not be allowed to skip.
+			caseName: "legacy User set to the anonymous access key id rejected",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.User = AnonymousAccessKeyID
+				c.Password = "somesecret"
+				return c
+			}(),
+			wantErr: true,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.caseName, func(t *testing.T) {

--- a/server/middleware/basicauth.go
+++ b/server/middleware/basicauth.go
@@ -16,6 +16,13 @@ import (
 // ConsoleAction, and the matched user is stashed on the request context
 // (server.WithUser) so handlers such as the bucket-list page can filter
 // their results by the same policy.
+//
+// The anonymous principal (server.AnonymousAccessKeyID) never matches here,
+// even if a client sends it as the Basic Auth username with an empty
+// password (which would otherwise compare equal, since the anonymous entry
+// carries no SecretAccessKey by construction -- see Config.Validate).
+// Anonymous access is an S3-API-only concept; the Web Console always
+// requires a real credential.
 func BasicAuth(next server.HandlerFunc) server.HandlerFunc {
 	return func(srv *server.Server, w http.ResponseWriter, r *http.Request) {
 		if !srv.Config.AuthEnabled() {
@@ -24,7 +31,7 @@ func BasicAuth(next server.HandlerFunc) server.HandlerFunc {
 		}
 		user, pass, ok := r.BasicAuth()
 		u := srv.Config.LookupUser(user)
-		if !ok || u == nil || subtle.ConstantTimeCompare([]byte(pass), []byte(u.SecretAccessKey)) != 1 {
+		if !ok || u == nil || u.AccessKeyID == server.AnonymousAccessKeyID || subtle.ConstantTimeCompare([]byte(pass), []byte(u.SecretAccessKey)) != 1 {
 			w.Header().Set("WWW-Authenticate", `Basic realm="s2"`)
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return

--- a/server/middleware/basicauth_test.go
+++ b/server/middleware/basicauth_test.go
@@ -96,11 +96,15 @@ func TestBasicAuthMultiUser(t *testing.T) {
 	noListAllBucketsPolicy := &server.Policy{Statement: []server.Statement{
 		{Effect: "Allow", Action: []string{"s3:ListBucket", "s3:GetObject"}, Resource: []string{"arn:aws:s3:::visible"}},
 	}}
+	anonymousPolicy := &server.Policy{Statement: []server.Statement{
+		{Effect: "Allow", Action: []string{"s3:GetObject"}, Resource: []string{"arn:aws:s3:::*"}},
+	}}
 	cfg := &server.Config{
 		Users: []server.User{
 			{AccessKeyID: "userA", SecretAccessKey: "secretA"},
 			{AccessKeyID: "userB", SecretAccessKey: "secretB", Policy: readOnlyPolicy},
 			{AccessKeyID: "userC", SecretAccessKey: "secretC", Policy: noListAllBucketsPolicy},
+			{AccessKeyID: server.AnonymousAccessKeyID, Policy: anonymousPolicy},
 		},
 	}
 
@@ -163,6 +167,18 @@ func TestBasicAuthMultiUser(t *testing.T) {
 			authUser:   "userC",
 			authPass:   "secretC",
 			wantStatus: http.StatusOK,
+		},
+		{
+			// The anonymous entry carries no SecretAccessKey by construction,
+			// so a client sending "*" with an empty password would otherwise
+			// compare equal -- BasicAuth must reject it explicitly rather
+			// than let the empty-secret match log it into the console.
+			caseName:   "anonymous principal rejected even with matching empty secret",
+			method:     http.MethodGet,
+			url:        "/",
+			authUser:   server.AnonymousAccessKeyID,
+			authPass:   "",
+			wantStatus: http.StatusUnauthorized,
 		},
 	}
 	for _, tc := range testCases {

--- a/server/middleware/sigv4.go
+++ b/server/middleware/sigv4.go
@@ -32,6 +32,11 @@ const (
 // SignatureDoesNotMatch used for verification failures. The matched User is
 // stashed on the request context (server.WithUser) so handlers such as
 // HandleListBuckets can filter their results by the same policy.
+//
+// A request with neither an Authorization header nor presigned-URL query
+// parameters falls back to the anonymous principal (server.AnonymousAccessKeyID)
+// when one is configured, rather than being rejected outright; its Policy is
+// then checked exactly like any other matched User's.
 func SigV4(next server.HandlerFunc) server.HandlerFunc {
 	return func(srv *server.Server, w http.ResponseWriter, r *http.Request) {
 		if !srv.Config.AuthEnabled() {
@@ -45,12 +50,16 @@ func SigV4(next server.HandlerFunc) server.HandlerFunc {
 		}
 
 		// AWS prefers the Authorization header when both are present.
-		// Fall back to query-string (presigned URL) verification when the header is absent.
+		// Fall back to query-string (presigned URL) verification, then to
+		// the anonymous principal, when the header is absent.
 		var matched *server.User
 		var err error
-		if r.Header.Get("Authorization") == "" && r.URL.Query().Get("X-Amz-Algorithm") != "" {
+		switch authHeader := r.Header.Get("Authorization"); {
+		case authHeader == "" && r.URL.Query().Get("X-Amz-Algorithm") != "":
 			matched, err = verifyPresignedV4(r, lookup, time.Now().UTC())
-		} else {
+		case authHeader == "":
+			matched, err = anonymousUser(lookup)
+		default:
 			matched, err = verifySignatureV4(r, lookup)
 		}
 		if err != nil {
@@ -75,6 +84,20 @@ func writeS3AuthError(w http.ResponseWriter, r *http.Request, message string) {
 
 func writeS3AccessDeniedError(w http.ResponseWriter, r *http.Request) {
 	server.WriteS3Error(w, r, "AccessDenied", "Access Denied", http.StatusForbidden)
+}
+
+// anonymousUser resolves the unauthenticated fallback: a request with
+// neither an Authorization header nor presigned-URL query parameters
+// matches server.AnonymousAccessKeyID ("*") if one is configured, without
+// any signature verification. It returns the same "missing Authorization
+// header" error as before when no such entry exists, so behavior is
+// unchanged for configs that don't opt in.
+func anonymousUser(lookup func(accessKeyID string) (user *server.User, ok bool)) (*server.User, error) {
+	user, ok := lookup(server.AnonymousAccessKeyID)
+	if !ok {
+		return nil, fmt.Errorf("missing Authorization header")
+	}
+	return user, nil
 }
 
 // verifySignatureV4 verifies the AWS Signature Version 4 of an HTTP request.

--- a/server/middleware/sigv4_test.go
+++ b/server/middleware/sigv4_test.go
@@ -346,6 +346,85 @@ func TestSigV4MultiUser(t *testing.T) {
 	}
 }
 
+func TestSigV4Anonymous(t *testing.T) {
+	anonymousPolicy := &server.Policy{Statement: []server.Statement{
+		{Effect: "Allow", Action: []string{"s3:GetObject"}, Resource: []string{"arn:aws:s3:::public/*"}},
+	}}
+	cfg := &server.Config{
+		Users: []server.User{
+			{AccessKeyID: "userA", SecretAccessKey: "secretA"},
+			{AccessKeyID: server.AnonymousAccessKeyID, Policy: anonymousPolicy},
+		},
+	}
+
+	testCases := []struct {
+		caseName   string
+		method     string
+		url        string
+		bucket     string
+		key        string
+		wantStatus int
+	}{
+		{
+			caseName:   "unsigned request within the anonymous policy's scope passes",
+			method:     http.MethodGet,
+			url:        "/public/key.txt",
+			bucket:     "public",
+			key:        "key.txt",
+			wantStatus: http.StatusOK,
+		},
+		{
+			caseName:   "unsigned request outside the anonymous policy's scope is denied",
+			method:     http.MethodGet,
+			url:        "/private/key.txt",
+			bucket:     "private",
+			key:        "key.txt",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			caseName:   "unsigned write is denied even within the public prefix",
+			method:     http.MethodPut,
+			url:        "/public/key.txt",
+			bucket:     "public",
+			key:        "key.txt",
+			wantStatus: http.StatusForbidden,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			srv := &server.Server{Config: cfg}
+			handler := SigV4(noopHandler)
+
+			r := httptest.NewRequest(tc.method, tc.url, nil)
+			r.SetPathValue("bucket", tc.bucket)
+			r.SetPathValue("key", tc.key)
+			w := httptest.NewRecorder()
+			handler(srv, w, r)
+
+			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
+}
+
+// TestSigV4NoAnonymousPrincipalStillRejectsUnsignedRequests verifies that
+// configs without a "*" Users entry keep rejecting unauthenticated requests
+// outright, matching pre-anonymous-principal behavior.
+func TestSigV4NoAnonymousPrincipalStillRejectsUnsignedRequests(t *testing.T) {
+	cfg := &server.Config{
+		Users: []server.User{{AccessKeyID: "userA", SecretAccessKey: "secretA"}},
+	}
+	srv := &server.Server{Config: cfg}
+	handler := SigV4(noopHandler)
+
+	r := httptest.NewRequest(http.MethodGet, "/bucket/key", nil)
+	r.SetPathValue("bucket", "bucket")
+	r.SetPathValue("key", "key")
+	w := httptest.NewRecorder()
+	handler(srv, w, r)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
 func TestSigV4MultiUserAccessDeniedDistinctFromSignatureError(t *testing.T) {
 	cfg := &server.Config{
 		Users: []server.User{

--- a/server/user.go
+++ b/server/user.go
@@ -14,6 +14,14 @@ type User struct {
 	Policy          *Policy `json:"policy,omitempty"`
 }
 
+// AnonymousAccessKeyID is the access_key_id value that marks a Users entry
+// as the anonymous principal: S3 API requests that carry neither an
+// Authorization header nor presigned-URL query parameters are evaluated
+// against this entry's Policy instead of being rejected outright. See
+// Config.Validate for the extra constraints placed on this entry (no
+// secret, Policy required, s3:GetObject only).
+const AnonymousAccessKeyID = "*"
+
 // LookupUser returns the User matching accessKeyID, checking cfg.Users
 // first and falling back to the legacy single User/Password fields
 // (synthesized as a full-access User with a nil Policy) if no Users entry


### PR DESCRIPTION
## Summary
- s2's multi-user auth (#177) had no way to serve objects to unauthenticated clients — any S3 API request without a valid SigV4 signature was rejected outright.
- Adds an anonymous principal: a `users` entry whose `access_key_id` is exactly `"*"`. SigV4 falls back to it for requests that carry neither an `Authorization` header nor presigned-URL query parameters, instead of rejecting them; the entry's `Policy` is then checked exactly like any other matched user's via the existing `Authorized`/`Allowed` machinery.
- No new config field or "public bucket" flag — the presence of a `"*"` entry is itself the toggle, and `Resource` scoping in its `Policy` controls which buckets/prefixes are public.
- The anonymous entry is deliberately narrow, enforced at config-load time: `secret_access_key` must be empty, `policy` is required (the usual "no policy = full access" convention does not apply to `"*"`), and every `Action` in the policy must be `s3:GetObject` — `s3:ListBucket` and write/delete actions are not supported yet.
- A legacy `user` set to `"*"` is rejected by `Config.Validate`, closing a path where it would otherwise resolve through the full-access legacy fallback instead of the restricted anonymous entry.
- `BasicAuth` (Web Console) explicitly refuses the anonymous entry, even if a client sends `"*"` as the username with an empty password — anonymous access only applies to the S3 API.
- Addresses #162 and closes #184.

## Related
- While manually verifying anonymous `GetObject` against a real server, noticed `GetObject` never returns a `Content-Type` header (nor does `PutObject` capture one) — filed as #186, unrelated to this PR's scope but worth flagging for anyone testing this against a browser.

## Non-goals
- `s3:ListBucket` (anonymous directory-listing) — tracked separately in #185.
- Write/delete actions for the anonymous principal.
- Static website hosting (index/error document resolution, redirect rules) — out of scope, see #184.

## Test plan
- [x] `go test ./...` (root + server module)
- [x] `go vet ./...`
- [x] Manual smoke test: built `s2-server`, ran it with an osfs backend and a `"*"` policy scoped to one bucket/prefix, confirmed unauthenticated `GET` on an allowed object succeeds, `GET` on the bucket listing / other buckets / `PUT` all return 403, and Web Console login as `"*"` is rejected.
- [x] `golangci-lint run ./...` — could not run locally (unrelated Go 1.27 toolchain panic in this environment; confirmed the same panic occurs on `main`)