### PR TITLE
feat(server): Allow s3:ListBucket in the anonymous principal's policy

### DIFF
--- a/docs/users-policy.md
+++ b/docs/users-policy.md
@@ -141,8 +141,37 @@ Constraints specific to this entry, enforced at config-load time:
 
 - `secret_access_key` must be empty — anonymous requests never present a secret.
 - `policy` is required (the usual "no `policy` = full access" convention does not apply to `"*"`, since that would turn one config line into an all-buckets, all-actions public grant).
-- Every `Action` in the policy must be `s3:GetObject`. `s3:ListBucket` (directory-listing-style enumeration) and write/delete actions are not supported for the anonymous principal.
+- Every `Action` in the policy must be `s3:GetObject` or `s3:ListBucket`. Write/delete actions are not supported for the anonymous principal.
 - The Web Console (Basic Auth) never consults this entry — anonymous browsing of the bucket sidebar is out of scope. Anonymous access only applies to the S3 API.
+
+### Allowing anonymous directory listing
+
+`s3:ListBucket` reveals every key, size, and timestamp under a bucket — a materially different exposure than `s3:GetObject`, which requires knowing a key in advance. It's opt-in per statement: omit it and the anonymous principal can only fetch objects whose key it already knows.
+
+`s3:ListBucket` and `s3:GetObject` also check different `Resource` ARNs — a bucket-level ARN (no trailing `/*`) for `ListBucket`, an object-level ARN (`bucket/*`) for `GetObject` — so granting one does not implicitly grant the other, and a policy needs both `Resource` forms to allow both actions:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:ListBucket"],
+      "Resource": ["arn:aws:s3:::public-assets/*", "arn:aws:s3:::public-assets"]
+    }
+  ]
+}
+```
+
+**Granting `s3:ListBucket` also exposes the bucket's name and creation date via unauthenticated `GET /`.** `GET /` (ListBuckets) is filtered per-bucket by the same `s3:ListBucket` check (see [below](#s3listallmybuckets-is-not-a-full-gate)), and this applies to the anonymous principal too: once any bucket is anonymously listable, anyone can discover it exists — without knowing its name in advance — by hitting the bucket-less root endpoint. If you want per-bucket listing without that root-level disclosure, add an explicit `Deny` on `s3:ListAllMyBuckets` (this is the one exception to the `s3:GetObject`/`s3:ListBucket`-only restriction above — it's permitted specifically so it can be denied):
+
+```json
+{
+  "Effect": "Deny",
+  "Action": "s3:ListAllMyBuckets",
+  "Resource": "arn:aws:s3:::*"
+}
+```
 
 ## Known gaps and quirks
 

--- a/server/config.go
+++ b/server/config.go
@@ -84,7 +84,8 @@ type Config struct {
 	// carry no Authorization header and no presigned-URL query parameters,
 	// instead of rejecting them outright. BasicAuth (the Web Console) never
 	// consults it -- anonymous browsing of the bucket sidebar is out of
-	// scope. See Config.Validate for the constraints placed on this entry.
+	// scope. See Config.Validate and anonymousAllowedActions for the
+	// constraints placed on this entry.
 	Users []User `json:"users,omitempty"`
 	// Buckets is a list of bucket names to create on startup if they don't already exist.
 	Buckets []string `json:"buckets"`
@@ -140,7 +141,7 @@ func (cfg *Config) Validate() error {
 	}
 
 	if cfg.User == AnonymousAccessKeyID {
-		return fmt.Errorf("server: User must not be %q; the anonymous principal is only configurable via a Users entry, which enforces the GetObject-only restriction", AnonymousAccessKeyID)
+		return fmt.Errorf("server: User must not be %q; the anonymous principal is only configurable via a Users entry, which enforces the read-only action restriction", AnonymousAccessKeyID)
 	}
 
 	seen := make(map[string]bool, len(cfg.Users)+1)
@@ -180,16 +181,39 @@ func (cfg *Config) Validate() error {
 	return nil
 }
 
+// anonymousAllowedActions is the fixed set of s3:* actions permitted in an
+// anonymous principal's policy: read-only object access, listing, and
+// s3:ListAllMyBuckets (needed to Deny it -- see the doc comment below).
+// Write and delete are never allowed, regardless of what the policy's
+// Statement list contains.
+var anonymousAllowedActions = map[string]bool{
+	ActionGetObject:        true,
+	ActionListBucket:       true,
+	ActionListAllMyBuckets: true,
+}
+
 // validateAnonymousPolicyActions restricts the anonymous principal's policy
-// to s3:GetObject, so a "*" entry can only ever grant unauthenticated read
-// access. Without this, the existing "nil Policy = full access" convention
-// combined with a permissive Action wildcard could turn a single Users
-// entry into an all-buckets, all-actions public grant.
+// to anonymousAllowedActions, so a "*" entry can only ever grant
+// unauthenticated read/list access. Without this, the existing "nil Policy =
+// full access" convention combined with a permissive Action wildcard could
+// turn a single Users entry into an all-buckets, all-actions public grant.
+//
+// s3:ListAllMyBuckets is allowed here even though it grants nothing on its
+// own (S3Action always defers GET / to FilterBucketNames -- see its doc
+// comment) so that an anonymous policy can carry an explicit Deny on it.
+// Once s3:ListBucket became grantable to "*", FilterBucketNames -- shared by
+// every principal -- started including anonymously-listable buckets in
+// unauthenticated GET / (name + creation date), which was previously
+// impossible since "*" could never hold s3:ListBucket. A Deny here is the
+// same documented escape hatch other principals already have (see
+// ExplicitlyDeniedListAllMyBuckets and "Known gaps and quirks" in
+// docs/users-policy.md) to hard-block that endpoint while still allowing
+// per-bucket listing.
 func validateAnonymousPolicyActions(p *Policy) error {
 	for i, stmt := range p.Statement {
 		for _, action := range stmt.Action {
-			if action != ActionGetObject {
-				return fmt.Errorf("policy: statement[%d]: anonymous principal only supports Action %q, got %q", i, ActionGetObject, action)
+			if !anonymousAllowedActions[action] {
+				return fmt.Errorf("policy: statement[%d]: anonymous principal only supports Action %q, %q, or %q, got %q", i, ActionGetObject, ActionListBucket, ActionListAllMyBuckets, action)
 			}
 		}
 	}

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -299,13 +299,50 @@ func TestConfigValidateUsers(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			caseName: "anonymous principal with non-GetObject action rejected",
+			caseName: "anonymous principal with s3:ListBucket accepted",
 			cfg: func() *Config {
 				c := DefaultConfig()
 				c.Users = []User{{
 					AccessKeyID: AnonymousAccessKeyID,
 					Policy: &Policy{
-						Statement: []Statement{allowStatement("s3:ListBucket", "*")},
+						Statement: []Statement{allowStatement("s3:ListBucket", "arn:aws:s3:::public")},
+					},
+				}}
+				return c
+			}(),
+			wantErr: false,
+		},
+		{
+			// s3:ListAllMyBuckets grants nothing on its own (S3Action always
+			// defers GET / to FilterBucketNames), but a Deny on it is the
+			// documented escape hatch to hard-block unauthenticated root
+			// bucket enumeration once s3:ListBucket is anonymously grantable
+			// -- see the "Allowing anonymous directory listing" section of
+			// docs/users-policy.md.
+			caseName: "anonymous principal with Deny s3:ListAllMyBuckets accepted",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.Users = []User{{
+					AccessKeyID: AnonymousAccessKeyID,
+					Policy: &Policy{
+						Statement: []Statement{
+							allowStatement("s3:ListBucket", "arn:aws:s3:::public"),
+							denyStatement("s3:ListAllMyBuckets", "arn:aws:s3:::*"),
+						},
+					},
+				}}
+				return c
+			}(),
+			wantErr: false,
+		},
+		{
+			caseName: "anonymous principal with write action rejected",
+			cfg: func() *Config {
+				c := DefaultConfig()
+				c.Users = []User{{
+					AccessKeyID: AnonymousAccessKeyID,
+					Policy: &Policy{
+						Statement: []Statement{allowStatement("s3:PutObject", "*")},
 					},
 				}}
 				return c
@@ -329,8 +366,8 @@ func TestConfigValidateUsers(t *testing.T) {
 		{
 			// A legacy User set to "*" would resolve through LookupUser's
 			// fallback to a full-access (nil-Policy) User, bypassing the
-			// GetObject-only restriction the anonymous principal is meant to
-			// enforce -- see server.LookupUser and the Users-entry cases
+			// read-only action restriction the anonymous principal is meant
+			// to enforce -- see server.LookupUser and the Users-entry cases
 			// above for the restriction this must not be allowed to skip.
 			caseName: "legacy User set to the anonymous access key id rejected",
 			cfg: func() *Config {

--- a/server/handlers/s3api/buckets_test.go
+++ b/server/handlers/s3api/buckets_test.go
@@ -90,6 +90,55 @@ func (s *BucketsTestSuite) TestListBuckets() {
 		s.Equal(http.StatusForbidden, w.Code)
 		s.Contains(w.Body.String(), "AccessDenied")
 	})
+
+	// Once s3:ListBucket became grantable to the anonymous ("*") principal
+	// (see server.AnonymousAccessKeyID), FilterBucketNames -- shared by every
+	// principal -- started including anonymously-listable buckets in
+	// unauthenticated GET / too. These two cases pin that behavior down
+	// explicitly for the anonymous principal, plus the Deny s3:ListAllMyBuckets
+	// escape hatch documented in docs/users-policy.md's "Allowing anonymous
+	// directory listing" section.
+	s.Run("anonymous principal's ListBucket grant is disclosed via GET /", func() {
+		s.createBucket("anon-visible")
+
+		anon := &server.User{
+			AccessKeyID: server.AnonymousAccessKeyID,
+			Policy: &server.Policy{Statement: []server.Statement{
+				{Effect: "Allow", Action: []string{"s3:ListBucket"}, Resource: []string{"arn:aws:s3:::anon-visible"}},
+			}},
+		}
+
+		req := httptest.NewRequest("GET", "/", nil)
+		req = req.WithContext(server.WithUser(req.Context(), anon))
+		w := httptest.NewRecorder()
+		HandleListBuckets(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		var result ListAllMyBucketsResult
+		s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &result))
+		s.Len(result.Buckets, 1)
+		s.Equal("anon-visible", result.Buckets[0].Name)
+	})
+
+	s.Run("Deny s3:ListAllMyBuckets suppresses that disclosure for the anonymous principal", func() {
+		s.createBucket("anon-visible2")
+
+		anon := &server.User{
+			AccessKeyID: server.AnonymousAccessKeyID,
+			Policy: &server.Policy{Statement: []server.Statement{
+				{Effect: "Allow", Action: []string{"s3:ListBucket"}, Resource: []string{"arn:aws:s3:::anon-visible2"}},
+				{Effect: "Deny", Action: []string{"s3:ListAllMyBuckets"}, Resource: []string{"arn:aws:s3:::*"}},
+			}},
+		}
+
+		req := httptest.NewRequest("GET", "/", nil)
+		req = req.WithContext(server.WithUser(req.Context(), anon))
+		w := httptest.NewRecorder()
+		HandleListBuckets(s.server, w, req)
+
+		s.Equal(http.StatusForbidden, w.Code)
+		s.Contains(w.Body.String(), "AccessDenied")
+	})
 }
 
 // --- CreateBucket ---

--- a/server/middleware/sigv4_test.go
+++ b/server/middleware/sigv4_test.go
@@ -406,6 +406,84 @@ func TestSigV4Anonymous(t *testing.T) {
 	}
 }
 
+// TestSigV4AnonymousListBucket verifies that s3:ListBucket and s3:GetObject
+// are authorized independently for the anonymous principal, matching their
+// different Resource ARNs (bucket-level vs. object-level, see S3Action) --
+// granting one must not implicitly grant the other.
+func TestSigV4AnonymousListBucket(t *testing.T) {
+	testCases := []struct {
+		caseName        string
+		anonymousPolicy *server.Policy
+		method          string
+		url             string
+		bucket          string
+		key             string
+		wantStatus      int
+	}{
+		{
+			caseName: "GetObject-only policy denies unsigned bucket listing",
+			anonymousPolicy: &server.Policy{Statement: []server.Statement{
+				{Effect: "Allow", Action: []string{"s3:GetObject"}, Resource: []string{"arn:aws:s3:::public/*"}},
+			}},
+			method:     http.MethodGet,
+			url:        "/public",
+			bucket:     "public",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			caseName: "ListBucket-only policy denies unsigned GetObject",
+			anonymousPolicy: &server.Policy{Statement: []server.Statement{
+				{Effect: "Allow", Action: []string{"s3:ListBucket"}, Resource: []string{"arn:aws:s3:::public"}},
+			}},
+			method:     http.MethodGet,
+			url:        "/public/key.txt",
+			bucket:     "public",
+			key:        "key.txt",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			caseName: "policy granting both allows unsigned bucket listing",
+			anonymousPolicy: &server.Policy{Statement: []server.Statement{
+				{Effect: "Allow", Action: []string{"s3:GetObject", "s3:ListBucket"}, Resource: []string{"arn:aws:s3:::public/*", "arn:aws:s3:::public"}},
+			}},
+			method:     http.MethodGet,
+			url:        "/public",
+			bucket:     "public",
+			wantStatus: http.StatusOK,
+		},
+		{
+			caseName: "policy granting both allows unsigned GetObject",
+			anonymousPolicy: &server.Policy{Statement: []server.Statement{
+				{Effect: "Allow", Action: []string{"s3:GetObject", "s3:ListBucket"}, Resource: []string{"arn:aws:s3:::public/*", "arn:aws:s3:::public"}},
+			}},
+			method:     http.MethodGet,
+			url:        "/public/key.txt",
+			bucket:     "public",
+			key:        "key.txt",
+			wantStatus: http.StatusOK,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			cfg := &server.Config{
+				Users: []server.User{
+					{AccessKeyID: server.AnonymousAccessKeyID, Policy: tc.anonymousPolicy},
+				},
+			}
+			srv := &server.Server{Config: cfg}
+			handler := SigV4(noopHandler)
+
+			r := httptest.NewRequest(tc.method, tc.url, nil)
+			r.SetPathValue("bucket", tc.bucket)
+			r.SetPathValue("key", tc.key)
+			w := httptest.NewRecorder()
+			handler(srv, w, r)
+
+			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
+}
+
 // TestSigV4NoAnonymousPrincipalStillRejectsUnsignedRequests verifies that
 // configs without a "*" Users entry keep rejecting unauthenticated requests
 // outright, matching pre-anonymous-principal behavior.

--- a/server/user.go
+++ b/server/user.go
@@ -19,7 +19,8 @@ type User struct {
 // Authorization header nor presigned-URL query parameters are evaluated
 // against this entry's Policy instead of being rejected outright. See
 // Config.Validate for the extra constraints placed on this entry (no
-// secret, Policy required, s3:GetObject only).
+// secret, Policy required, see anonymousAllowedActions for the permitted
+// action set).
 const AnonymousAccessKeyID = "*"
 
 // LookupUser returns the User matching accessKeyID, checking cfg.Users


### PR DESCRIPTION
## Summary
- Follow-up to #187 (#184). Extends the anonymous (`"*"`) principal's allowed policy actions from `s3:GetObject`-only to `{s3:GetObject, s3:ListBucket}`, so an operator can let unauthenticated clients enumerate a bucket's contents, not just fetch objects whose key they already know.
- `s3:ListBucket` and `s3:GetObject` check different `Resource` ARNs (bucket-level vs. `bucket/*`) — granting one does not implicitly grant the other; a policy needs both ARN forms to allow both actions.
- Granting `s3:ListBucket` to `"*"` also makes that bucket reachable through `FilterBucketNames`, which every principal's `GET /` (ListBuckets) already goes through — so a bucket scoped for anonymous per-bucket listing also has its name and creation date disclosed via the unauthenticated root endpoint. `s3:ListAllMyBuckets` is now allowed in an anonymous policy specifically so it can carry an explicit `Deny`, the existing documented escape hatch (see "Known gaps and quirks" in `docs/users-policy.md`) that hard-blocks the root endpoint while still allowing per-bucket listing.
- Write/delete actions remain rejected at config-load time, unchanged from #187.
- Closes #185.

## Non-goals
- Write/delete actions for the anonymous principal remain out of scope, as in #187.

## Test plan
- [x] `go test ./...` (root + server module)
- [x] `go vet ./...`
- [x] Manual smoke test: ran `s2-server` with an osfs backend and a `"*"` policy granting `GetObject`+`ListBucket` on one bucket; confirmed unauthenticated `GET /{bucket}` lists objects, `GET /{bucket}/{key}` fetches them, `PUT` is still denied, and unauthenticated `GET /` lists the bucket.
- [x] `golangci-lint run ./...` — could not run locally (unrelated Go 1.27 toolchain panic in this environment; same panic occurs on `main`)