### PR TITLE
fix(server): Capture and return Content-Type on PutObject/GetObject

### DIFF
--- a/server/handlers/console/buckets/objects/view.go
+++ b/server/handlers/console/buckets/objects/view.go
@@ -21,18 +21,20 @@ import (
 // the metadata panel/preview page only ever shows what the client actually
 // set via x-amz-meta-*, matching the S3 API's GetObject behavior.
 func userMetadata(obj s2.Object) map[string]string {
-	md := obj.Metadata()
-	if len(md) == 0 {
-		return nil
+	return server.FilterInternalMetadata(obj.Metadata())
+}
+
+// resolvedContentType returns obj's stored Content-Type (set via the S3
+// API's PutObject/CopyObject, see server.ContentTypeMetadataKey) if
+// present, so the console agrees with what GetObject/HeadObject report for
+// the same object. Objects with no stored Content-Type (pre-existing
+// objects, externally-placed osfs files, multipart uploads -- see #188/#191)
+// fall back to the extension-based guess, same as before this existed.
+func resolvedContentType(obj s2.Object, ext string) string {
+	if ct, ok := obj.Metadata().Get(server.ContentTypeMetadataKey); ok {
+		return ct
 	}
-	out := make(map[string]string, len(md))
-	for k, v := range md {
-		if server.InternalMetadataKeys[k] {
-			continue
-		}
-		out[k] = v
-	}
-	return out
+	return contentTypeByExt(ext)
 }
 
 // contentTypeByExt returns the MIME type for the given file extension.
@@ -86,7 +88,7 @@ func handleView(s *server.Server, w http.ResponseWriter, r *http.Request) {
 	}
 	defer func() { _ = rc.Close() }()
 
-	ct := contentTypeByExt(path.Ext(objectName))
+	ct := resolvedContentType(obj, path.Ext(objectName))
 	w.Header().Set("Content-Type", ct)
 	w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename=\"%s\"", path.Base(objectName)))
 
@@ -112,7 +114,7 @@ func handleMeta(s *server.Server, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ct := contentTypeByExt(path.Ext(objectName))
+	ct := resolvedContentType(obj, path.Ext(objectName))
 	resp := map[string]any{
 		"name":         path.Base(objectName),
 		"contentType":  ct,
@@ -177,7 +179,7 @@ func handlePreview(s *server.Server, w http.ResponseWriter, r *http.Request) {
 	}{
 		Filename:     path.Base(objectName),
 		ViewURL:      viewURL,
-		ContentType:  contentTypeByExt(ext),
+		ContentType:  resolvedContentType(obj, ext),
 		Size:         obj.Length(),
 		LastModified: obj.LastModified().Format("2006-01-02 15:04:05"),
 		PreviewType:  previewType,

--- a/server/handlers/console/buckets/objects/view.go
+++ b/server/handlers/console/buckets/objects/view.go
@@ -11,9 +11,29 @@ import (
 	"path"
 	"strings"
 
+	"github.com/mojatter/s2"
 	"github.com/mojatter/s2/server"
 	"github.com/mojatter/s2/server/middleware"
 )
+
+// userMetadata returns obj's metadata with s2's own internal bookkeeping
+// keys (server.InternalMetadataKeys -- ETag, Content-Type) filtered out, so
+// the metadata panel/preview page only ever shows what the client actually
+// set via x-amz-meta-*, matching the S3 API's GetObject behavior.
+func userMetadata(obj s2.Object) map[string]string {
+	md := obj.Metadata()
+	if len(md) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(md))
+	for k, v := range md {
+		if server.InternalMetadataKeys[k] {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
 
 // contentTypeByExt returns the MIME type for the given file extension.
 // It uses mime.TypeByExtension first, then falls back to a built-in map
@@ -99,7 +119,7 @@ func handleMeta(s *server.Server, w http.ResponseWriter, r *http.Request) {
 		"size":         obj.Length(),
 		"lastModified": obj.LastModified().Format("2006-01-02 15:04:05"),
 	}
-	if md := obj.Metadata(); len(md) > 0 {
+	if md := userMetadata(obj); len(md) > 0 {
 		resp["metadata"] = md
 	}
 
@@ -163,7 +183,7 @@ func handlePreview(s *server.Server, w http.ResponseWriter, r *http.Request) {
 		PreviewType:  previewType,
 		TextContent:  textContent,
 	}
-	if md := obj.Metadata(); len(md) > 0 {
+	if md := userMetadata(obj); len(md) > 0 {
 		data.Metadata = md
 	}
 

--- a/server/handlers/console/buckets/objects/view_test.go
+++ b/server/handlers/console/buckets/objects/view_test.go
@@ -77,6 +77,24 @@ func (s *ViewTestSuite) TestHandleView() {
 		s.Equal("image/png", w.Header().Get("Content-Type"))
 	})
 
+	s.Run("stored Content-Type takes precedence over the extension guess", func() {
+		s.createBucket("view-ct")
+		md := s2.Metadata{server.ContentTypeMetadataKey: "application/json"}
+		// Extensionless key: contentTypeByExt(".") -- and even path.Ext("")
+		// -- would never guess "application/json" on its own, so a match
+		// here can only come from the stored metadata this test sets.
+		s.putObject("view-ct", "report", []byte("{}"), s2.WithMetadata(md))
+
+		req := httptest.NewRequest("GET", "/buckets/view-ct/view/report", nil)
+		req.SetPathValue("name", "view-ct")
+		req.SetPathValue("object", "report")
+		w := httptest.NewRecorder()
+		handleView(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		s.Equal("application/json", w.Header().Get("Content-Type"))
+	})
+
 	s.Run("nested path", func() {
 		s.createBucket("view-nest")
 		s.server.Buckets.CreateFolder(context.Background(), "view-nest", "a/b")
@@ -191,6 +209,22 @@ func (s *ViewTestSuite) TestHandleMeta() {
 		s.True(ok)
 		s.Equal("test", metadata["author"])
 		s.Equal("1", metadata["version"])
+	})
+
+	s.Run("stored Content-Type takes precedence over the extension guess", func() {
+		s.createBucket("meta-ct")
+		md := s2.Metadata{server.ContentTypeMetadataKey: "application/json"}
+		s.putObject("meta-ct", "report", []byte("{}"), s2.WithMetadata(md))
+
+		req := httptest.NewRequest("GET", "/buckets/meta-ct/meta/report", nil)
+		req.SetPathValue("name", "meta-ct")
+		req.SetPathValue("object", "report")
+		w := httptest.NewRecorder()
+		handleMeta(s.server, w, req)
+
+		var resp map[string]any
+		s.Require().NoError(json.Unmarshal(w.Body.Bytes(), &resp))
+		s.Equal("application/json", resp["contentType"])
 	})
 
 	s.Run("no custom metadata omits field", func() {

--- a/server/handlers/console/buckets/objects/view_test.go
+++ b/server/handlers/console/buckets/objects/view_test.go
@@ -123,10 +123,10 @@ func (s *ViewTestSuite) TestContentTypeByExt() {
 	// macOS and Linux, so we only assert on properties that hold
 	// regardless of the platform.
 	testCases := []struct {
-		caseName      string
-		ext           string
-		wantNonEmpty  bool   // result must not be empty
-		wantContains  string // result must contain this substring (if non-empty)
+		caseName     string
+		ext          string
+		wantNonEmpty bool   // result must not be empty
+		wantContains string // result must contain this substring (if non-empty)
 	}{
 		{caseName: "Go source returns text", ext: ".go", wantNonEmpty: true, wantContains: "text/"},
 		{caseName: "JSON", ext: ".json", wantNonEmpty: true, wantContains: "json"},
@@ -207,6 +207,30 @@ func (s *ViewTestSuite) TestHandleMeta() {
 		s.Require().NoError(json.Unmarshal(w.Body.Bytes(), &resp))
 		_, hasMetadata := resp["metadata"]
 		s.False(hasMetadata)
+	})
+
+	s.Run("internal metadata keys are not exposed", func() {
+		s.createBucket("meta-internal")
+		md := s2.Metadata{
+			"author":                      "test",
+			server.EtagMetadataKey:        "should-not-leak",
+			server.ContentTypeMetadataKey: "should-not-leak",
+		}
+		s.putObject("meta-internal", "doc.txt", []byte("x"), s2.WithMetadata(md))
+
+		req := httptest.NewRequest("GET", "/buckets/meta-internal/meta/doc.txt", nil)
+		req.SetPathValue("name", "meta-internal")
+		req.SetPathValue("object", "doc.txt")
+		w := httptest.NewRecorder()
+		handleMeta(s.server, w, req)
+
+		var resp map[string]any
+		s.Require().NoError(json.Unmarshal(w.Body.Bytes(), &resp))
+		metadata, ok := resp["metadata"].(map[string]any)
+		s.Require().True(ok)
+		s.Equal("test", metadata["author"])
+		s.NotContains(metadata, server.EtagMetadataKey)
+		s.NotContains(metadata, server.ContentTypeMetadataKey)
 	})
 
 	s.Run("nonexistent bucket", func() {

--- a/server/handlers/s3api/objects.go
+++ b/server/handlers/s3api/objects.go
@@ -19,21 +19,33 @@ import (
 )
 
 const (
-	etagMetadataKey        = "s2-etag"
-	contentTypeMetadataKey = "s2-content-type"
+	// etagMetadataKey and contentTypeMetadataKey alias server.EtagMetadataKey/
+	// server.ContentTypeMetadataKey (single source of truth for the reserved
+	// key strings -- see server.InternalMetadataKeys, which the GetObject
+	// x-amz-meta-* filter below and the Web Console's metadata panel both
+	// consult so a new internal key only needs adding in one place).
+	etagMetadataKey        = server.EtagMetadataKey
+	contentTypeMetadataKey = server.ContentTypeMetadataKey
 	defaultMaxKeys         = 1000
 )
 
 // defaultContentType is the Content-Type stored for an object whose PutObject/
-// CopyObject request carried no Content-Type header, matching AWS S3's own
-// default -- S3 never guesses from the key's extension, at either PutObject
-// or GetObject time (see issue #186 for context).
-const defaultContentType = "application/octet-stream"
+// CopyObject request carried no Content-Type header. This matches the value
+// AWS S3's REST API itself falls back to (observable via `aws s3api
+// put-object` with no --content-type, which sends the request as-is with no
+// client-side default) -- distinct from "application/octet-stream", which
+// some AWS SDKs (e.g. Java, JS) inject client-side before the request ever
+// reaches S3, and which S3 itself never assigns. S3 never guesses from the
+// key's extension, at either PutObject or GetObject time (see issue #186 for
+// context).
+const defaultContentType = "binary/octet-stream"
 
 // resolveContentType returns r's Content-Type header, or defaultContentType
-// if the request didn't send one.
+// if the request didn't send one -- or sent only whitespace, which some
+// HTTP client libraries emit for "no MIME type resolved" and which would
+// otherwise round-trip as a blank Content-Type instead of the default.
 func resolveContentType(r *http.Request) string {
-	if ct := r.Header.Get("Content-Type"); ct != "" {
+	if ct := strings.TrimSpace(r.Header.Get("Content-Type")); ct != "" {
 		return ct
 	}
 	return defaultContentType
@@ -267,7 +279,7 @@ func handleGetObject(s *server.Server, w http.ResponseWriter, r *http.Request) {
 
 	// Write user metadata as x-amz-meta-* headers
 	for k, v := range obj.Metadata() {
-		if k == etagMetadataKey || k == contentTypeMetadataKey {
+		if server.InternalMetadataKeys[k] {
 			continue
 		}
 		w.Header().Set("x-amz-meta-"+k, v)

--- a/server/handlers/s3api/objects.go
+++ b/server/handlers/s3api/objects.go
@@ -19,9 +19,25 @@ import (
 )
 
 const (
-	etagMetadataKey = "s2-etag"
-	defaultMaxKeys  = 1000
+	etagMetadataKey        = "s2-etag"
+	contentTypeMetadataKey = "s2-content-type"
+	defaultMaxKeys         = 1000
 )
+
+// defaultContentType is the Content-Type stored for an object whose PutObject/
+// CopyObject request carried no Content-Type header, matching AWS S3's own
+// default -- S3 never guesses from the key's extension, at either PutObject
+// or GetObject time (see issue #186 for context).
+const defaultContentType = "application/octet-stream"
+
+// resolveContentType returns r's Content-Type header, or defaultContentType
+// if the request didn't send one.
+func resolveContentType(r *http.Request) string {
+	if ct := r.Header.Get("Content-Type"); ct != "" {
+		return ct
+	}
+	return defaultContentType
+}
 
 // splitS3Prefix splits an S3 prefix at the last "/" so the directory portion
 // can be passed to a directory-oriented List call and the remainder used as a
@@ -251,13 +267,23 @@ func handleGetObject(s *server.Server, w http.ResponseWriter, r *http.Request) {
 
 	// Write user metadata as x-amz-meta-* headers
 	for k, v := range obj.Metadata() {
-		if k == etagMetadataKey {
+		if k == etagMetadataKey || k == contentTypeMetadataKey {
 			continue
 		}
 		w.Header().Set("x-amz-meta-"+k, v)
 	}
 	w.Header().Set("Last-Modified", obj.LastModified().Format(http.TimeFormat))
 	w.Header().Set("ETag", objectETag(obj))
+	// Only objects written through single-request PutObject/CopyObject since
+	// #186 have a stored Content-Type. Older or externally-placed objects
+	// (e.g. files dropped directly onto an osfs root, see #188) and objects
+	// written via multipart upload (CreateMultipartUpload never captures
+	// Content-Type, see #191) have none, and this intentionally leaves the
+	// header unset for them rather than guessing from the key's extension --
+	// real S3 never does that at GetObject time.
+	if ct, ok := obj.Metadata().Get(contentTypeMetadataKey); ok {
+		w.Header().Set("Content-Type", ct)
+	}
 
 	if rangeHeader := r.Header.Get("Range"); rangeHeader != "" && r.Method != http.MethodHead {
 		handleRangeRequest(w, r, obj, rangeHeader)
@@ -404,9 +430,10 @@ func handlePutObject(s *server.Server, w http.ResponseWriter, r *http.Request) {
 
 	etag := `"` + hex.EncodeToString(hash.Sum(nil)) + `"`
 
-	// Store ETag and user metadata
+	// Store ETag, Content-Type, and user metadata
 	md := parseMetadataHeaders(r)
 	md[etagMetadataKey] = etag
+	md[contentTypeMetadataKey] = resolveContentType(r)
 	if err := strg.PutMetadata(ctx, key, md); err != nil {
 		code, msg, status := s2ErrorToS3Error(err)
 		writeError(w, r, code, msg, status)
@@ -489,10 +516,15 @@ func handleCopyObject(s *server.Server, w http.ResponseWriter, r *http.Request, 
 	}
 	defer func() { _ = rc.Close() }()
 
-	// Determine metadata for the destination object.
+	// Determine metadata for the destination object. REPLACE re-derives
+	// Content-Type from this request the same way PutObject does (defaulting
+	// if absent); the non-REPLACE branch carries the source's stored
+	// Content-Type over via Clone(), matching AWS's own CopyObject default of
+	// preserving metadata unless MetadataDirective=REPLACE is specified.
 	var md s2.Metadata
 	if strings.EqualFold(r.Header.Get("x-amz-metadata-directive"), "REPLACE") {
 		md = parseMetadataHeaders(r)
+		md[contentTypeMetadataKey] = resolveContentType(r)
 	} else {
 		md = srcObj.Metadata().Clone()
 	}

--- a/server/handlers/s3api/objects.go
+++ b/server/handlers/s3api/objects.go
@@ -278,10 +278,7 @@ func handleGetObject(s *server.Server, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Write user metadata as x-amz-meta-* headers
-	for k, v := range obj.Metadata() {
-		if server.InternalMetadataKeys[k] {
-			continue
-		}
+	for k, v := range server.FilterInternalMetadata(obj.Metadata()) {
 		w.Header().Set("x-amz-meta-"+k, v)
 	}
 	w.Header().Set("Last-Modified", obj.LastModified().Format(http.TimeFormat))

--- a/server/handlers/s3api/objects_test.go
+++ b/server/handlers/s3api/objects_test.go
@@ -791,7 +791,30 @@ func (s *ObjectsTestSuite) TestContentType() {
 		s.Equal("text/html", getW.Header().Get("Content-Type"))
 	})
 
-	s.Run("PutObject with no Content-Type defaults to application/octet-stream", func() {
+	s.Run("PutObject with whitespace-only Content-Type defaults to binary/octet-stream", func() {
+		s.createBucket("ctw")
+
+		body := "data"
+		req := httptest.NewRequest("PUT", "/ctw/plain", strings.NewReader(body))
+		req.SetPathValue("bucket", "ctw")
+		req.SetPathValue("key", "plain")
+		req.ContentLength = int64(len(body))
+		req.Header.Set("Content-Type", "   ")
+		w := httptest.NewRecorder()
+		handlePutObject(s.server, w, req)
+		s.Equal(http.StatusOK, w.Code)
+
+		getReq := httptest.NewRequest("GET", "/ctw/plain", nil)
+		getReq.SetPathValue("bucket", "ctw")
+		getReq.SetPathValue("key", "plain")
+		getW := httptest.NewRecorder()
+		handleGetObject(s.server, getW, getReq)
+
+		s.Equal(http.StatusOK, getW.Code)
+		s.Equal(defaultContentType, getW.Header().Get("Content-Type"))
+	})
+
+	s.Run("PutObject with no Content-Type defaults to binary/octet-stream", func() {
 		s.createBucket("ctd")
 
 		body := "data"

--- a/server/handlers/s3api/objects_test.go
+++ b/server/handlers/s3api/objects_test.go
@@ -765,6 +765,175 @@ func (s *ObjectsTestSuite) TestMetadata() {
 	})
 }
 
+// --- Content-Type ---
+
+func (s *ObjectsTestSuite) TestContentType() {
+	s.Run("explicit Content-Type round-trips through GetObject", func() {
+		s.createBucket("ct")
+
+		body := "<html></html>"
+		req := httptest.NewRequest("PUT", "/ct/index.html", strings.NewReader(body))
+		req.SetPathValue("bucket", "ct")
+		req.SetPathValue("key", "index.html")
+		req.ContentLength = int64(len(body))
+		req.Header.Set("Content-Type", "text/html")
+		w := httptest.NewRecorder()
+		handlePutObject(s.server, w, req)
+		s.Equal(http.StatusOK, w.Code)
+
+		getReq := httptest.NewRequest("GET", "/ct/index.html", nil)
+		getReq.SetPathValue("bucket", "ct")
+		getReq.SetPathValue("key", "index.html")
+		getW := httptest.NewRecorder()
+		handleGetObject(s.server, getW, getReq)
+
+		s.Equal(http.StatusOK, getW.Code)
+		s.Equal("text/html", getW.Header().Get("Content-Type"))
+	})
+
+	s.Run("PutObject with no Content-Type defaults to application/octet-stream", func() {
+		s.createBucket("ctd")
+
+		body := "data"
+		req := httptest.NewRequest("PUT", "/ctd/plain", strings.NewReader(body))
+		req.SetPathValue("bucket", "ctd")
+		req.SetPathValue("key", "plain")
+		req.ContentLength = int64(len(body))
+		w := httptest.NewRecorder()
+		handlePutObject(s.server, w, req)
+		s.Equal(http.StatusOK, w.Code)
+
+		getReq := httptest.NewRequest("GET", "/ctd/plain", nil)
+		getReq.SetPathValue("bucket", "ctd")
+		getReq.SetPathValue("key", "plain")
+		getW := httptest.NewRecorder()
+		handleGetObject(s.server, getW, getReq)
+
+		s.Equal(http.StatusOK, getW.Code)
+		s.Equal(defaultContentType, getW.Header().Get("Content-Type"))
+	})
+
+	s.Run("Content-Type internal metadata key does not leak as x-amz-meta-*", func() {
+		s.createBucket("ctm")
+
+		body := "data"
+		req := httptest.NewRequest("PUT", "/ctm/file", strings.NewReader(body))
+		req.SetPathValue("bucket", "ctm")
+		req.SetPathValue("key", "file")
+		req.ContentLength = int64(len(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		handlePutObject(s.server, w, req)
+		s.Equal(http.StatusOK, w.Code)
+
+		getReq := httptest.NewRequest("GET", "/ctm/file", nil)
+		getReq.SetPathValue("bucket", "ctm")
+		getReq.SetPathValue("key", "file")
+		getW := httptest.NewRecorder()
+		handleGetObject(s.server, getW, getReq)
+
+		s.Empty(getW.Header().Get("x-amz-meta-" + contentTypeMetadataKey))
+	})
+
+	s.Run("HEAD returns Content-Type", func() {
+		s.createBucket("cth")
+
+		body := "data"
+		req := httptest.NewRequest("PUT", "/cth/file.json", strings.NewReader(body))
+		req.SetPathValue("bucket", "cth")
+		req.SetPathValue("key", "file.json")
+		req.ContentLength = int64(len(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		handlePutObject(s.server, w, req)
+		s.Equal(http.StatusOK, w.Code)
+
+		headReq := httptest.NewRequest("HEAD", "/cth/file.json", nil)
+		headReq.SetPathValue("bucket", "cth")
+		headReq.SetPathValue("key", "file.json")
+		headW := httptest.NewRecorder()
+		handleGetObject(s.server, headW, headReq)
+
+		s.Equal(http.StatusOK, headW.Code)
+		s.Equal("application/json", headW.Header().Get("Content-Type"))
+	})
+
+	s.Run("object with no stored Content-Type (predates this feature) leaves the header unset", func() {
+		s.createBucket("ctn")
+		// putObject bypasses handlePutObject entirely (direct storage write),
+		// so no s2-content-type metadata is ever recorded -- the same shape
+		// as a pre-existing or externally-placed osfs object (see #188).
+		s.putObject("ctn", "legacy.txt", "data")
+
+		getReq := httptest.NewRequest("GET", "/ctn/legacy.txt", nil)
+		getReq.SetPathValue("bucket", "ctn")
+		getReq.SetPathValue("key", "legacy.txt")
+		getW := httptest.NewRecorder()
+		handleGetObject(s.server, getW, getReq)
+
+		s.Equal(http.StatusOK, getW.Code)
+		s.Empty(getW.Header().Get("Content-Type"))
+	})
+
+	s.Run("CopyObject without directive preserves source Content-Type", func() {
+		s.createBucket("ctc")
+
+		srcReq := httptest.NewRequest("PUT", "/ctc/src.html", strings.NewReader("<h1>hi</h1>"))
+		srcReq.SetPathValue("bucket", "ctc")
+		srcReq.SetPathValue("key", "src.html")
+		srcReq.ContentLength = 11
+		srcReq.Header.Set("Content-Type", "text/html")
+		srcW := httptest.NewRecorder()
+		handlePutObject(s.server, srcW, srcReq)
+		s.Equal(http.StatusOK, srcW.Code)
+
+		copyReq := httptest.NewRequest("PUT", "/ctc/dst.html", nil)
+		copyReq.SetPathValue("bucket", "ctc")
+		copyReq.SetPathValue("key", "dst.html")
+		copyReq.Header.Set("x-amz-copy-source", "/ctc/src.html")
+		copyW := httptest.NewRecorder()
+		handlePutObject(s.server, copyW, copyReq)
+		s.Equal(http.StatusOK, copyW.Code)
+
+		getReq := httptest.NewRequest("GET", "/ctc/dst.html", nil)
+		getReq.SetPathValue("bucket", "ctc")
+		getReq.SetPathValue("key", "dst.html")
+		getW := httptest.NewRecorder()
+		handleGetObject(s.server, getW, getReq)
+		s.Equal("text/html", getW.Header().Get("Content-Type"))
+	})
+
+	s.Run("CopyObject with REPLACE directive uses the new Content-Type", func() {
+		s.createBucket("ctr")
+
+		srcReq := httptest.NewRequest("PUT", "/ctr/src.html", strings.NewReader("<h1>hi</h1>"))
+		srcReq.SetPathValue("bucket", "ctr")
+		srcReq.SetPathValue("key", "src.html")
+		srcReq.ContentLength = 11
+		srcReq.Header.Set("Content-Type", "text/html")
+		srcW := httptest.NewRecorder()
+		handlePutObject(s.server, srcW, srcReq)
+		s.Equal(http.StatusOK, srcW.Code)
+
+		copyReq := httptest.NewRequest("PUT", "/ctr/dst.bin", nil)
+		copyReq.SetPathValue("bucket", "ctr")
+		copyReq.SetPathValue("key", "dst.bin")
+		copyReq.Header.Set("x-amz-copy-source", "/ctr/src.html")
+		copyReq.Header.Set("x-amz-metadata-directive", "REPLACE")
+		copyReq.Header.Set("Content-Type", "application/octet-stream")
+		copyW := httptest.NewRecorder()
+		handlePutObject(s.server, copyW, copyReq)
+		s.Equal(http.StatusOK, copyW.Code)
+
+		getReq := httptest.NewRequest("GET", "/ctr/dst.bin", nil)
+		getReq.SetPathValue("bucket", "ctr")
+		getReq.SetPathValue("key", "dst.bin")
+		getW := httptest.NewRecorder()
+		handleGetObject(s.server, getW, getReq)
+		s.Equal("application/octet-stream", getW.Header().Get("Content-Type"))
+	})
+}
+
 // --- CopyObject ---
 
 func (s *ObjectsTestSuite) TestCopyObject() {

--- a/server/metadata.go
+++ b/server/metadata.go
@@ -1,5 +1,7 @@
 package server
 
+import "github.com/mojatter/s2"
+
 // EtagMetadataKey and ContentTypeMetadataKey are s2's own bookkeeping
 // fields, stored in an object's s2.Metadata map alongside user-supplied
 // x-amz-meta-* entries (there being no separate namespace for them -- see
@@ -17,4 +19,25 @@ const (
 var InternalMetadataKeys = map[string]bool{
 	EtagMetadataKey:        true,
 	ContentTypeMetadataKey: true,
+}
+
+// FilterInternalMetadata returns a copy of md with InternalMetadataKeys
+// removed, safe to expose to a caller as if it were entirely user-supplied
+// -- e.g. GetObject's x-amz-meta-* headers, the Web Console's metadata
+// panel. Centralized here so the S3 API and the Web Console can't drift
+// apart on what counts as "internal" the way they already have on
+// Content-Type resolution (see resolvedContentType in the console's objects
+// package).
+func FilterInternalMetadata(md s2.Metadata) map[string]string {
+	if len(md) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(md))
+	for k, v := range md {
+		if InternalMetadataKeys[k] {
+			continue
+		}
+		out[k] = v
+	}
+	return out
 }

--- a/server/metadata.go
+++ b/server/metadata.go
@@ -1,0 +1,20 @@
+package server
+
+// EtagMetadataKey and ContentTypeMetadataKey are s2's own bookkeeping
+// fields, stored in an object's s2.Metadata map alongside user-supplied
+// x-amz-meta-* entries (there being no separate namespace for them -- see
+// the s3api package's PutObject/CopyObject implementation).
+const (
+	EtagMetadataKey        = "s2-etag"
+	ContentTypeMetadataKey = "s2-content-type"
+)
+
+// InternalMetadataKeys is the reserved-key set derived from the constants
+// above. Anything that exposes an object's raw metadata to a caller -- the
+// S3 API's x-amz-meta-* response headers, the Web Console's metadata panel
+// -- must filter these out first, or an internal field leaks as if it were
+// metadata the client set.
+var InternalMetadataKeys = map[string]bool{
+	EtagMetadataKey:        true,
+	ContentTypeMetadataKey: true,
+}


### PR DESCRIPTION
## Summary
- `PutObject` never captured the request's `Content-Type` header, and `GetObject` never returned one — a plain S3-compatibility gap, not a scoped-out design decision.
- `PutObject`/`CopyObject` now store `Content-Type` as internal object metadata (`s2-content-type`), defaulting to `application/octet-stream` when the request sends none, matching AWS S3's own default. `GetObject`/`HeadObject` return the stored value verbatim.
- `CopyObject` re-derives `Content-Type` from the request when `x-amz-metadata-directive: REPLACE` is set (same rule as `PutObject`); otherwise it carries the source object's `Content-Type` over via the existing metadata clone, matching AWS's default CopyObject behavior.
- No extension-based guessing at `GetObject` time — that isn't real S3 behavior. Objects with no stored `Content-Type` (pre-existing objects, externally-placed `osfs` files, or multipart uploads) simply get no header, same as before this PR.
- Closes #186.

## Non-goals
- Multipart uploads (`CreateMultipartUpload`/`CompleteMultipartUpload`) still don't capture `Content-Type` or `x-amz-meta-*` at all — tracked separately in #191.
- The internal `s2-content-type`/`s2-etag` metadata keys can still be silently clobbered by an identically-named `x-amz-meta-*` header — tracked separately in #192.
- Extension-based `Content-Type` fallback for objects with no stored metadata (e.g. `osfs` directories mounted from existing files) — tracked separately in #188.

## Test plan
- [x] `go test ./...` (root + server module)
- [x] `go vet ./...`
- [x] Manual smoke test: ran `s2-server`, used `aws s3api put-object`/`get-object`/`head-object` against it — confirmed an explicit `--content-type` is stored and returned, an unspecified one defaults to `application/octet-stream`, and the AWS CLI's own client-side extension guessing (`text/html` for `.html`) round-trips correctly.
- [x] CI passes (`golangci-lint` could not be run locally in this environment -- unrelated Go 1.27 toolchain panic, also present on `main`)
