### PR TITLE
chore: Bump intra-repo deps to v0.14.0

### DIFF
--- a/azblob/go.mod
+++ b/azblob/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.23.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0
-	github.com/mojatter/s2 v0.13.0
+	github.com/mojatter/s2 v0.14.0
 	github.com/stretchr/testify v1.12.1
 )
 

--- a/gcs/go.mod
+++ b/gcs/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	cloud.google.com/go/storage v1.65.0
-	github.com/mojatter/s2 v0.13.0
+	github.com/mojatter/s2 v0.14.0
 	github.com/stretchr/testify v1.12.1
 	google.golang.org/api v0.293.0
 )

--- a/s2env/go.mod
+++ b/s2env/go.mod
@@ -3,10 +3,10 @@ module github.com/mojatter/s2/s2env
 go 1.25.8
 
 require (
-	github.com/mojatter/s2 v0.13.0
-	github.com/mojatter/s2/azblob v0.13.0
-	github.com/mojatter/s2/gcs v0.13.0
-	github.com/mojatter/s2/s3 v0.13.0
+	github.com/mojatter/s2 v0.14.0
+	github.com/mojatter/s2/azblob v0.14.0
+	github.com/mojatter/s2/gcs v0.14.0
+	github.com/mojatter/s2/s3 v0.14.0
 	github.com/stretchr/testify v1.12.1
 )
 

--- a/s3/go.mod
+++ b/s3/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.38
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.107.3
 	github.com/aws/smithy-go v1.27.9
-	github.com/mojatter/s2 v0.13.0
+	github.com/mojatter/s2 v0.14.0
 	github.com/stretchr/testify v1.12.1
 )
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.37
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.107.3
 	github.com/chromedp/chromedp v0.16.0
-	github.com/mojatter/s2 v0.13.0
+	github.com/mojatter/s2 v0.14.0
 	github.com/stretchr/testify v1.12.1
 )
 


### PR DESCRIPTION
## Summary
- Bumps the intra-repo `github.com/mojatter/s2*` require lines in the five replace-modules (`s3`, `gcs`, `azblob`, `server`, `s2env`) to v0.14.0, ahead of tagging.
- `cmd/s2-server` is intentionally excluded -- it has no `replace` directive, so it can only require v0.14.0 after that version's tags are published (see docs/releasing.md).
- Covers #187, #189, #193 (anonymous public read access, including `s3:ListBucket`, plus Content-Type capture/return on PutObject/GetObject).

## Test plan
- [x] `go vet ./...` and `go test ./...` (root + every submodule) under `GOTOOLCHAIN=go1.26.0` (matches `go.work`'s `go` directive)
- [x] `GOWORK=off go build .` in `cmd/s2-server` (still resolves against the previous, published v0.13.0)
- [x] `GOWORK=off go build ./...` in `server`
- [x] `GOWORK=off go test -tags integtest -c` in `s3` (compiles)
- [x] `goreleaser release --snapshot --clean --skip=publish --skip=docker` (workspace-mode build, the same Go-version gate the real release workflow hits)