### PR TITLE
fix(server): Guess Content-Type for objects s2 did not write

### DIFF
--- a/server/contenttype.go
+++ b/server/contenttype.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"mime"
+	"strings"
+)
+
+// DefaultContentType is what s2 stores and answers with when no
+// Content-Type is known, matching S3's own default.
+const DefaultContentType = "binary/octet-stream"
+
+// ContentTypeByExt returns the MIME type for the given file extension,
+// or "" when nothing recognizes it. It consults mime.TypeByExtension
+// first, then a built-in table for common types the OS mime database may
+// not cover.
+func ContentTypeByExt(ext string) string {
+	if ext == "" {
+		return ""
+	}
+	if ct := mime.TypeByExtension(ext); ct != "" {
+		return ct
+	}
+	// The switch is a fallback: mime.TypeByExtension varies by host and Go version.
+	switch strings.ToLower(ext) {
+	case ".md", ".log", ".cfg", ".conf", ".ini",
+		".go", ".py", ".rb", ".rs", ".java", ".c", ".h", ".cpp", ".ts",
+		".sh", ".makefile", ".dockerfile":
+		return "text/plain; charset=utf-8"
+	case ".webp":
+		return "image/webp"
+	case ".flac":
+		return "audio/flac"
+	case ".wasm":
+		return "application/wasm"
+	}
+	return ""
+}

--- a/server/contenttype_test.go
+++ b/server/contenttype_test.go
@@ -12,9 +12,8 @@ func TestContentTypeByExt(t *testing.T) {
 	// macOS and Linux, so we only assert on properties that hold
 	// regardless of the platform.
 	//
-	// The empty result for an unrecognized extension is what lets the S3
-	// API answer with no Content-Type at all (see setContentType in the
-	// s3api package).
+	// The empty result for an unrecognized extension is what sends a
+	// caller on to its own fallback.
 	testCases := []struct {
 		caseName     string
 		ext          string

--- a/server/contenttype_test.go
+++ b/server/contenttype_test.go
@@ -1,0 +1,44 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContentTypeByExt(t *testing.T) {
+	// ContentTypeByExt tries mime.TypeByExtension first, then falls
+	// back to a built-in switch. The OS MIME database differs between
+	// macOS and Linux, so we only assert on properties that hold
+	// regardless of the platform.
+	//
+	// The empty result for an unrecognized extension is what lets the S3
+	// API answer with no Content-Type at all (see setContentType in the
+	// s3api package).
+	testCases := []struct {
+		caseName     string
+		ext          string
+		wantEmpty    bool   // extension is not recognized at all
+		wantContains string // result must contain this substring otherwise
+	}{
+		{caseName: "Go source returns text", ext: ".go", wantContains: "text/"},
+		{caseName: "JSON", ext: ".json", wantContains: "json"},
+		{caseName: "CSS", ext: ".css", wantContains: "css"},
+		{caseName: "PNG image", ext: ".png", wantContains: "image/png"},
+		{caseName: "WebP image", ext: ".webp", wantContains: "image/webp"},
+		{caseName: "Wasm binary", ext: ".wasm", wantContains: "wasm"},
+		{caseName: "unknown extension", ext: ".nopesuchtype", wantEmpty: true},
+		{caseName: "empty extension", ext: "", wantEmpty: true},
+		{caseName: "bare dot", ext: ".", wantEmpty: true},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			got := ContentTypeByExt(tc.ext)
+			if tc.wantEmpty {
+				assert.Empty(t, got)
+				return
+			}
+			assert.Contains(t, got, tc.wantContains)
+		})
+	}
+}

--- a/server/handlers/console/buckets/objects.go
+++ b/server/handlers/console/buckets/objects.go
@@ -3,7 +3,11 @@ package buckets
 import (
 	"bytes"
 	"context"
+	"crypto/md5" // #nosec G501 -- MD5 is required for S3-compatible ETag
+	"encoding/hex"
 	"fmt"
+	"io"
+	"mime/multipart"
 	"net/http"
 	"path"
 	"strings"
@@ -146,6 +150,24 @@ func handleCreateFolder(s *server.Server, w http.ResponseWriter, r *http.Request
 	writeObjectsFragment(ctx, w, s, name, prefix, "")
 }
 
+// uploadContentType returns the Content-Type to store for an uploaded
+// part. Browsers fill the part header from File.type, which is empty for
+// any extension the OS does not know (.log, .go, .conf) and reaches us as
+// a generic octet-stream; the key's extension is the better answer there.
+func uploadContentType(header *multipart.FileHeader, key string) string {
+	ct := strings.TrimSpace(header.Header.Get("Content-Type"))
+	if ct != "" && ct != "application/octet-stream" && ct != server.DefaultContentType {
+		return ct
+	}
+	if byExt := server.ContentTypeByExt(path.Ext(key)); byExt != "" {
+		return byExt
+	}
+	if ct != "" {
+		return ct
+	}
+	return server.DefaultContentType
+}
+
 func handleUploadFile(s *server.Server, w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	name := r.PathValue("name")
@@ -175,8 +197,20 @@ func handleUploadFile(s *server.Server, w http.ResponseWriter, r *http.Request) 
 	if !server.DenyUnlessAllowedS3Action(w, server.UserFromContext(ctx), server.ActionPutObject, name, key) {
 		return
 	}
-	obj := s2.NewObjectReader(key, file, s2.MustUint64(header.Size))
-	if err := strg.Put(ctx, obj); err != nil {
+	// Record what PutObject records: no metadata at all means "placed in
+	// the storage root from outside" to GetObject (#188).
+	hash := md5.New() // #nosec G401 -- MD5 is required for S3-compatible ETag
+	body := io.NopCloser(io.TeeReader(file, hash))
+	if err := strg.Put(ctx, s2.NewObjectReader(key, body, s2.MustUint64(header.Size))); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	contentType := uploadContentType(header, key)
+	md := s2.Metadata{
+		server.EtagMetadataKey:        `"` + hex.EncodeToString(hash.Sum(nil)) + `"`,
+		server.ContentTypeMetadataKey: contentType,
+	}
+	if err := strg.PutMetadata(ctx, key, md); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/server/handlers/console/buckets/objects/view.go
+++ b/server/handlers/console/buckets/objects/view.go
@@ -63,6 +63,9 @@ func handleView(s *server.Server, w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", resolvedContentType(obj, objectName))
 	w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename=\"%s\"", path.Base(objectName)))
+	// The type served here is the uploader's, so an object stored as
+	// text/html would otherwise run on the console origin (#199).
+	w.Header().Set("Content-Security-Policy", "sandbox")
 
 	if _, err := io.Copy(w, rc); err != nil {
 		slog.Error("Failed to copy object content", "error", err)

--- a/server/handlers/console/buckets/objects/view.go
+++ b/server/handlers/console/buckets/objects/view.go
@@ -24,9 +24,8 @@ func userMetadata(obj s2.Object) map[string]string {
 }
 
 // resolvedContentType returns obj's stored Content-Type, else a guess
-// from the key's extension. Unlike the S3 API (see setContentType in the
-// s3api package) it always ends with a concrete type: a browser renders
-// this response, and no Content-Type turns a preview into a download.
+// from the key's extension, else server.DefaultContentType. It guesses
+// more readily than the S3 API because a browser renders this response.
 func resolvedContentType(obj s2.Object, name string) string {
 	if ct, ok := obj.Metadata().Get(server.ContentTypeMetadataKey); ok {
 		return ct
@@ -34,7 +33,7 @@ func resolvedContentType(obj s2.Object, name string) string {
 	if ct := server.ContentTypeByExt(path.Ext(name)); ct != "" {
 		return ct
 	}
-	return "application/octet-stream"
+	return server.DefaultContentType
 }
 
 func handleView(s *server.Server, w http.ResponseWriter, r *http.Request) {

--- a/server/handlers/console/buckets/objects/view.go
+++ b/server/handlers/console/buckets/objects/view.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"mime"
 	"net/http"
 	"path"
 	"strings"
@@ -24,42 +23,16 @@ func userMetadata(obj s2.Object) map[string]string {
 	return server.FilterInternalMetadata(obj.Metadata())
 }
 
-// resolvedContentType returns obj's stored Content-Type (set via the S3
-// API's PutObject/CopyObject, see server.ContentTypeMetadataKey) if
-// present, so the console agrees with what GetObject/HeadObject report for
-// the same object. Objects with no stored Content-Type (pre-existing
-// objects, externally-placed osfs files, multipart uploads -- see #188/#191)
-// fall back to the extension-based guess, same as before this existed.
-func resolvedContentType(obj s2.Object, ext string) string {
+// resolvedContentType returns obj's stored Content-Type, else a guess
+// from the key's extension. Unlike the S3 API (see setContentType in the
+// s3api package) it always ends with a concrete type: a browser renders
+// this response, and no Content-Type turns a preview into a download.
+func resolvedContentType(obj s2.Object, name string) string {
 	if ct, ok := obj.Metadata().Get(server.ContentTypeMetadataKey); ok {
 		return ct
 	}
-	return contentTypeByExt(ext)
-}
-
-// contentTypeByExt returns the MIME type for the given file extension.
-// It uses mime.TypeByExtension first, then falls back to a built-in map
-// for common types that the OS mime database may not cover.
-func contentTypeByExt(ext string) string {
-	if ct := mime.TypeByExtension(ext); ct != "" {
+	if ct := server.ContentTypeByExt(path.Ext(name)); ct != "" {
 		return ct
-	}
-	ext = strings.ToLower(ext)
-	switch ext {
-	case ".md":
-		return "text/plain; charset=utf-8"
-	case ".log", ".cfg", ".conf", ".ini":
-		return "text/plain; charset=utf-8"
-	case ".go", ".py", ".rb", ".rs", ".java", ".c", ".h", ".cpp", ".ts":
-		return "text/plain; charset=utf-8"
-	case ".sh", ".makefile", ".dockerfile":
-		return "text/plain; charset=utf-8"
-	case ".webp":
-		return "image/webp"
-	case ".flac":
-		return "audio/flac"
-	case ".wasm":
-		return "application/wasm"
 	}
 	return "application/octet-stream"
 }
@@ -88,8 +61,7 @@ func handleView(s *server.Server, w http.ResponseWriter, r *http.Request) {
 	}
 	defer func() { _ = rc.Close() }()
 
-	ct := resolvedContentType(obj, path.Ext(objectName))
-	w.Header().Set("Content-Type", ct)
+	w.Header().Set("Content-Type", resolvedContentType(obj, objectName))
 	w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename=\"%s\"", path.Base(objectName)))
 
 	if _, err := io.Copy(w, rc); err != nil {
@@ -114,7 +86,7 @@ func handleMeta(s *server.Server, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ct := resolvedContentType(obj, path.Ext(objectName))
+	ct := resolvedContentType(obj, objectName)
 	resp := map[string]any{
 		"name":         path.Base(objectName),
 		"contentType":  ct,
@@ -179,7 +151,7 @@ func handlePreview(s *server.Server, w http.ResponseWriter, r *http.Request) {
 	}{
 		Filename:     path.Base(objectName),
 		ViewURL:      viewURL,
-		ContentType:  resolvedContentType(obj, ext),
+		ContentType:  resolvedContentType(obj, objectName),
 		Size:         obj.Length(),
 		LastModified: obj.LastModified().Format("2006-01-02 15:04:05"),
 		PreviewType:  previewType,

--- a/server/handlers/console/buckets/objects/view_test.go
+++ b/server/handlers/console/buckets/objects/view_test.go
@@ -80,9 +80,9 @@ func (s *ViewTestSuite) TestHandleView() {
 	s.Run("stored Content-Type takes precedence over the extension guess", func() {
 		s.createBucket("view-ct")
 		md := s2.Metadata{server.ContentTypeMetadataKey: "application/json"}
-		// Extensionless key: contentTypeByExt(".") -- and even path.Ext("")
-		// -- would never guess "application/json" on its own, so a match
-		// here can only come from the stored metadata this test sets.
+		// Neither the extension table nor a sniff of "{}" would ever
+		// answer "application/json" on its own, so a match here can only
+		// come from the stored metadata this test sets.
 		s.putObject("view-ct", "report", []byte("{}"), s2.WithMetadata(md))
 
 		req := httptest.NewRequest("GET", "/buckets/view-ct/view/report", nil)
@@ -93,6 +93,22 @@ func (s *ViewTestSuite) TestHandleView() {
 
 		s.Equal(http.StatusOK, w.Code)
 		s.Equal("application/json", w.Header().Get("Content-Type"))
+	})
+
+	s.Run("unrecognized extension resolves to octet-stream", func() {
+		// The console must hand the browser a type even when the
+		// extension says nothing, unlike the S3 API which stays silent.
+		s.createBucket("view-unk")
+		s.putObject("view-unk", "notes.nopesuchtype", []byte("plain words"))
+
+		req := httptest.NewRequest("GET", "/buckets/view-unk/view/notes.nopesuchtype", nil)
+		req.SetPathValue("name", "view-unk")
+		req.SetPathValue("object", "notes.nopesuchtype")
+		w := httptest.NewRecorder()
+		handleView(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		s.Equal("application/octet-stream", w.Header().Get("Content-Type"))
 	})
 
 	s.Run("nested path", func() {
@@ -131,39 +147,6 @@ func (s *ViewTestSuite) TestHandleView() {
 
 		s.Equal(http.StatusNotFound, w.Code)
 	})
-}
-
-// --- contentTypeByExt ---
-
-func (s *ViewTestSuite) TestContentTypeByExt() {
-	// contentTypeByExt tries mime.TypeByExtension first, then falls
-	// back to a built-in switch. The OS MIME database differs between
-	// macOS and Linux, so we only assert on properties that hold
-	// regardless of the platform.
-	testCases := []struct {
-		caseName     string
-		ext          string
-		wantNonEmpty bool   // result must not be empty
-		wantContains string // result must contain this substring (if non-empty)
-	}{
-		{caseName: "Go source returns text", ext: ".go", wantNonEmpty: true, wantContains: "text/"},
-		{caseName: "JSON", ext: ".json", wantNonEmpty: true, wantContains: "json"},
-		{caseName: "CSS", ext: ".css", wantNonEmpty: true, wantContains: "css"},
-		{caseName: "PNG image", ext: ".png", wantNonEmpty: true, wantContains: "image/png"},
-		{caseName: "WebP image", ext: ".webp", wantNonEmpty: true, wantContains: "image/webp"},
-		{caseName: "Wasm binary", ext: ".wasm", wantNonEmpty: true, wantContains: "wasm"},
-	}
-	for _, tc := range testCases {
-		s.Run(tc.caseName, func() {
-			got := contentTypeByExt(tc.ext)
-			if tc.wantNonEmpty {
-				s.NotEmpty(got)
-			}
-			if tc.wantContains != "" {
-				s.Contains(got, tc.wantContains)
-			}
-		})
-	}
 }
 
 // --- GET /buckets/{name}/meta/{object...} ---

--- a/server/handlers/console/buckets/objects/view_test.go
+++ b/server/handlers/console/buckets/objects/view_test.go
@@ -95,9 +95,9 @@ func (s *ViewTestSuite) TestHandleView() {
 		s.Equal("application/json", w.Header().Get("Content-Type"))
 	})
 
-	s.Run("unrecognized extension resolves to octet-stream", func() {
+	s.Run("unrecognized extension resolves to the default", func() {
 		// The console must hand the browser a type even when the
-		// extension says nothing, unlike the S3 API which stays silent.
+		// extension says nothing.
 		s.createBucket("view-unk")
 		s.putObject("view-unk", "notes.nopesuchtype", []byte("plain words"))
 
@@ -108,7 +108,7 @@ func (s *ViewTestSuite) TestHandleView() {
 		handleView(s.server, w, req)
 
 		s.Equal(http.StatusOK, w.Code)
-		s.Equal("application/octet-stream", w.Header().Get("Content-Type"))
+		s.Equal(server.DefaultContentType, w.Header().Get("Content-Type"))
 	})
 
 	s.Run("served objects are sandboxed", func() {

--- a/server/handlers/console/buckets/objects/view_test.go
+++ b/server/handlers/console/buckets/objects/view_test.go
@@ -111,6 +111,22 @@ func (s *ViewTestSuite) TestHandleView() {
 		s.Equal("application/octet-stream", w.Header().Get("Content-Type"))
 	})
 
+	s.Run("served objects are sandboxed", func() {
+		// The stored Content-Type is the uploader's, and the preview
+		// modal links straight here (#199).
+		s.createBucket("view-csp")
+		s.putObject("view-csp", "page.html", []byte("<h1>hi</h1>"))
+
+		req := httptest.NewRequest("GET", "/buckets/view-csp/view/page.html", nil)
+		req.SetPathValue("name", "view-csp")
+		req.SetPathValue("object", "page.html")
+		w := httptest.NewRecorder()
+		handleView(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+		s.Equal("sandbox", w.Header().Get("Content-Security-Policy"))
+	})
+
 	s.Run("nested path", func() {
 		s.createBucket("view-nest")
 		s.server.Buckets.CreateFolder(context.Background(), "view-nest", "a/b")

--- a/server/handlers/console/buckets/objects_test.go
+++ b/server/handlers/console/buckets/objects_test.go
@@ -3,10 +3,12 @@ package buckets
 import (
 	"bytes"
 	"context"
+	"crypto/md5" // #nosec G501 -- MD5 is required for S3-compatible ETag
 	"fmt"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/textproto"
 	"net/url"
 	"os/exec"
 	"strings"
@@ -332,6 +334,80 @@ func (s *ObjectsTestSuite) TestHandleUploadFile() {
 			}
 		})
 	}
+
+	s.Run("upload records the ETag and Content-Type the S3 API would", func() {
+		// Without these, a console upload is indistinguishable from a
+		// file placed in the storage root from outside, which GetObject
+		// answers for by guessing from the extension (see #188).
+		s.createBucket("upm")
+		content := []byte("<h1>hi</h1>")
+
+		body := &bytes.Buffer{}
+		mw := multipart.NewWriter(body)
+		s.Require().NoError(mw.WriteField("prefix", ""))
+		hdr := make(textproto.MIMEHeader)
+		hdr.Set("Content-Disposition", `form-data; name="file"; filename="page.html"`)
+		hdr.Set("Content-Type", "text/html")
+		fw, err := mw.CreatePart(hdr)
+		s.Require().NoError(err)
+		_, err = fw.Write(content)
+		s.Require().NoError(err)
+		s.Require().NoError(mw.Close())
+
+		req := httptest.NewRequest("POST", "/buckets/upm/upload", body)
+		req.Header.Set("Content-Type", mw.FormDataContentType())
+		req.SetPathValue("name", "upm")
+		w := httptest.NewRecorder()
+		handleUploadFile(s.server, w, req)
+		s.Equal(http.StatusOK, w.Code)
+
+		strg, err := s.server.Buckets.Get(context.Background(), "upm")
+		s.Require().NoError(err)
+		obj, err := strg.Get(context.Background(), "page.html")
+		s.Require().NoError(err)
+
+		ct, ok := obj.Metadata().Get(server.ContentTypeMetadataKey)
+		s.True(ok)
+		s.Equal("text/html", ct)
+		etag, ok := obj.Metadata().Get(server.EtagMetadataKey)
+		s.True(ok)
+		s.Equal(fmt.Sprintf("%q", fmt.Sprintf("%x", md5.Sum(content))), etag)
+	})
+
+	s.Run("generic part Content-Type falls back to the extension", func() {
+		// Browsers send application/octet-stream for any extension the
+		// OS does not know, which would otherwise be stored verbatim and
+		// make the object download instead of open.
+		s.createBucket("upg")
+
+		body := &bytes.Buffer{}
+		mw := multipart.NewWriter(body)
+		s.Require().NoError(mw.WriteField("prefix", ""))
+		hdr := make(textproto.MIMEHeader)
+		hdr.Set("Content-Disposition", `form-data; name="file"; filename="app.log"`)
+		hdr.Set("Content-Type", "application/octet-stream")
+		fw, err := mw.CreatePart(hdr)
+		s.Require().NoError(err)
+		_, err = fw.Write([]byte("log line"))
+		s.Require().NoError(err)
+		s.Require().NoError(mw.Close())
+
+		req := httptest.NewRequest("POST", "/buckets/upg/upload", body)
+		req.Header.Set("Content-Type", mw.FormDataContentType())
+		req.SetPathValue("name", "upg")
+		w := httptest.NewRecorder()
+		handleUploadFile(s.server, w, req)
+		s.Equal(http.StatusOK, w.Code)
+
+		strg, err := s.server.Buckets.Get(context.Background(), "upg")
+		s.Require().NoError(err)
+		obj, err := strg.Get(context.Background(), "app.log")
+		s.Require().NoError(err)
+
+		ct, ok := obj.Metadata().Get(server.ContentTypeMetadataKey)
+		s.True(ok)
+		s.Contains(ct, "text/plain")
+	})
 
 	s.Run("explicit deny on the exact filename is not bypassed by a wildcard allow", func() {
 		s.createBucket("upd")

--- a/server/handlers/console/buckets/objects_test.go
+++ b/server/handlers/console/buckets/objects_test.go
@@ -406,7 +406,11 @@ func (s *ObjectsTestSuite) TestHandleUploadFile() {
 
 		ct, ok := obj.Metadata().Get(server.ContentTypeMetadataKey)
 		s.True(ok)
-		s.Contains(ct, "text/plain")
+		// The exact type depends on the host mime database (text/plain on
+		// a machine with no .log entry, text/x-log on one with it), so
+		// assert only that the extension, not the part header, decided.
+		s.NotEqual("application/octet-stream", ct)
+		s.Equal(server.ContentTypeByExt(".log"), ct)
 	})
 
 	s.Run("explicit deny on the exact filename is not bypassed by a wildcard allow", func() {

--- a/server/handlers/s3api/objects.go
+++ b/server/handlers/s3api/objects.go
@@ -235,20 +235,25 @@ func isFSBackend(typ s2.Type) bool {
 	return typ == s2.TypeOSFS || typ == s2.TypeMemFS
 }
 
+// guessedContentType returns a Content-Type derived from key's extension,
+// and "" unless the object is one placed into a filesystem backend's root
+// from outside s2 -- the only kind s2 guesses about (#188).
+func guessedContentType(strg s2.Storage, obj s2.Object, key string) string {
+	if len(obj.Metadata()) > 0 || !isFSBackend(strg.Type()) {
+		return ""
+	}
+	return server.ContentTypeByExt(path.Ext(key))
+}
+
 // objectContentType returns the Content-Type GetObject/HeadObject answers
-// with for obj. Anything s2 wrote answers with its stored value (#186),
-// or with defaultContentType when it stored none, as real S3 does. Only
-// a file placed into a filesystem backend's root from outside carries no
-// metadata at all, and its extension answers instead (#188).
+// with for obj: its stored value if s2 recorded one (#186), else the
+// extension guess, else defaultContentType, as real S3 does.
 func objectContentType(strg s2.Storage, obj s2.Object, key string) string {
-	md := obj.Metadata()
-	if ct, ok := md.Get(contentTypeMetadataKey); ok {
+	if ct, ok := obj.Metadata().Get(contentTypeMetadataKey); ok {
 		return ct
 	}
-	if len(md) == 0 && isFSBackend(strg.Type()) {
-		if ct := server.ContentTypeByExt(path.Ext(key)); ct != "" {
-			return ct
-		}
+	if ct := guessedContentType(strg, obj, key); ct != "" {
+		return ct
 	}
 	return defaultContentType
 }
@@ -541,11 +546,10 @@ func handleCopyObject(s *server.Server, w http.ResponseWriter, r *http.Request, 
 		if md == nil {
 			md = make(s2.Metadata)
 		}
-		if _, ok := md.Get(contentTypeMetadataKey); !ok {
-			// The source may be answering with a guess from its key
-			// (#188). The copy carries an ETag, so it would never
-			// qualify for that guess; record the answer instead.
-			md[contentTypeMetadataKey] = objectContentType(srcStrg, srcObj, srcKey)
+		// The copy carries an ETag, so it can never qualify for the
+		// guess itself; keep the source's answer.
+		if ct := guessedContentType(srcStrg, srcObj, srcKey); ct != "" {
+			md[contentTypeMetadataKey] = ct
 		}
 	}
 

--- a/server/handlers/s3api/objects.go
+++ b/server/handlers/s3api/objects.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -26,19 +27,9 @@ const (
 	// consult so a new internal key only needs adding in one place).
 	etagMetadataKey        = server.EtagMetadataKey
 	contentTypeMetadataKey = server.ContentTypeMetadataKey
+	defaultContentType     = server.DefaultContentType
 	defaultMaxKeys         = 1000
 )
-
-// defaultContentType is the Content-Type stored for an object whose PutObject/
-// CopyObject request carried no Content-Type header. This matches the value
-// AWS S3's REST API itself falls back to (observable via `aws s3api
-// put-object` with no --content-type, which sends the request as-is with no
-// client-side default) -- distinct from "application/octet-stream", which
-// some AWS SDKs (e.g. Java, JS) inject client-side before the request ever
-// reaches S3, and which S3 itself never assigns. S3 never guesses from the
-// key's extension, at either PutObject or GetObject time (see issue #186 for
-// context).
-const defaultContentType = "binary/octet-stream"
 
 // resolveContentType returns r's Content-Type header, or defaultContentType
 // if the request didn't send one -- or sent only whitespace, which some
@@ -242,6 +233,30 @@ func handleListObjects(s *server.Server, w http.ResponseWriter, r *http.Request)
 	writeXML(w, http.StatusOK, buildListBucketResult(p, objs, prefixes, nextToken, isTruncated))
 }
 
+// isFSBackend reports whether storage type typ is one of the filesystem
+// backends, whose root can hold files that never went through s2.
+func isFSBackend(typ s2.Type) bool {
+	return typ == s2.TypeOSFS || typ == s2.TypeMemFS
+}
+
+// objectContentType returns the Content-Type GetObject/HeadObject answers
+// with for obj. Anything s2 wrote answers with its stored value (#186),
+// or with defaultContentType when it stored none, as real S3 does. Only
+// a file placed into a filesystem backend's root from outside carries no
+// metadata at all, and its extension answers instead (#188).
+func objectContentType(strg s2.Storage, obj s2.Object, key string) string {
+	md := obj.Metadata()
+	if ct, ok := md.Get(contentTypeMetadataKey); ok {
+		return ct
+	}
+	if len(md) == 0 && isFSBackend(strg.Type()) {
+		if ct := server.ContentTypeByExt(path.Ext(key)); ct != "" {
+			return ct
+		}
+	}
+	return defaultContentType
+}
+
 func handleGetObject(s *server.Server, w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	bucketName := r.PathValue("bucket")
@@ -283,16 +298,7 @@ func handleGetObject(s *server.Server, w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Last-Modified", obj.LastModified().Format(http.TimeFormat))
 	w.Header().Set("ETag", objectETag(obj))
-	// Only objects written through single-request PutObject/CopyObject since
-	// #186 have a stored Content-Type. Older or externally-placed objects
-	// (e.g. files dropped directly onto an osfs root, see #188) and objects
-	// written via multipart upload (CreateMultipartUpload never captures
-	// Content-Type, see #191) have none, and this intentionally leaves the
-	// header unset for them rather than guessing from the key's extension --
-	// real S3 never does that at GetObject time.
-	if ct, ok := obj.Metadata().Get(contentTypeMetadataKey); ok {
-		w.Header().Set("Content-Type", ct)
-	}
+	w.Header().Set("Content-Type", objectContentType(strg, obj, key))
 
 	if rangeHeader := r.Header.Get("Range"); rangeHeader != "" && r.Method != http.MethodHead {
 		handleRangeRequest(w, r, obj, rangeHeader)
@@ -536,6 +542,15 @@ func handleCopyObject(s *server.Server, w http.ResponseWriter, r *http.Request, 
 		md[contentTypeMetadataKey] = resolveContentType(r)
 	} else {
 		md = srcObj.Metadata().Clone()
+		if md == nil {
+			md = make(s2.Metadata)
+		}
+		if _, ok := md.Get(contentTypeMetadataKey); !ok {
+			// The source may be answering with a guess from its key
+			// (#188). The copy carries an ETag, so it would never
+			// qualify for that guess; record the answer instead.
+			md[contentTypeMetadataKey] = objectContentType(srcStrg, srcObj, srcKey)
+		}
 	}
 
 	// Write to destination

--- a/server/handlers/s3api/objects.go
+++ b/server/handlers/s3api/objects.go
@@ -20,11 +20,7 @@ import (
 )
 
 const (
-	// etagMetadataKey and contentTypeMetadataKey alias server.EtagMetadataKey/
-	// server.ContentTypeMetadataKey (single source of truth for the reserved
-	// key strings -- see server.InternalMetadataKeys, which the GetObject
-	// x-amz-meta-* filter below and the Web Console's metadata panel both
-	// consult so a new internal key only needs adding in one place).
+	// Aliases for readability; the server package owns these values.
 	etagMetadataKey        = server.EtagMetadataKey
 	contentTypeMetadataKey = server.ContentTypeMetadataKey
 	defaultContentType     = server.DefaultContentType

--- a/server/handlers/s3api/objects_test.go
+++ b/server/handlers/s3api/objects_test.go
@@ -881,21 +881,111 @@ func (s *ObjectsTestSuite) TestContentType() {
 		s.Equal("application/json", headW.Header().Get("Content-Type"))
 	})
 
-	s.Run("object with no stored Content-Type (predates this feature) leaves the header unset", func() {
+	s.Run("object with no stored Content-Type falls back to the extension guess on osfs", func() {
 		s.createBucket("ctn")
 		// putObject bypasses handlePutObject entirely (direct storage write),
 		// so no s2-content-type metadata is ever recorded -- the same shape
 		// as a pre-existing or externally-placed osfs object (see #188).
-		s.putObject("ctn", "legacy.txt", "data")
+		s.putObject("ctn", "legacy.html", "<h1>hi</h1>")
 
-		getReq := httptest.NewRequest("GET", "/ctn/legacy.txt", nil)
-		getReq.SetPathValue("bucket", "ctn")
-		getReq.SetPathValue("key", "legacy.txt")
-		getW := httptest.NewRecorder()
-		handleGetObject(s.server, getW, getReq)
+		resp := s.roundTrip(s.server, http.MethodGet, "/ctn/legacy.html")
 
-		s.Equal(http.StatusOK, getW.Code)
-		s.Empty(getW.Header().Get("Content-Type"))
+		s.Equal(http.StatusOK, resp.StatusCode)
+		s.Contains(resp.Header.Get("Content-Type"), "text/html")
+	})
+
+	s.Run("object written through s2 without a Content-Type gets the default", func() {
+		// The multipart shape (#191): CompleteMultipartUpload records an
+		// ETag and no Content-Type. Metadata exists, so the object went
+		// through s2's write path and answers with S3's own default --
+		// guessing is only for files placed into the root from outside.
+		s.createBucket("ctnp")
+		s.putObject("ctnp", "part.txt", "data")
+		ctx := context.Background()
+		strg, err := s.server.Buckets.Get(ctx, "ctnp")
+		s.Require().NoError(err)
+		s.Require().NoError(strg.PutMetadata(ctx, "part.txt", s2.Metadata{etagMetadataKey: `"abc"`}))
+
+		for _, method := range []string{http.MethodGet, http.MethodHead} {
+			resp := s.roundTrip(s.server, method, "/ctnp/part.txt")
+
+			s.Equal(http.StatusOK, resp.StatusCode, method)
+			s.Equal(defaultContentType, resp.Header.Get("Content-Type"), method)
+		}
+	})
+
+	s.Run("extension guess also applies to HEAD", func() {
+		s.createBucket("ctnh")
+		s.putObject("ctnh", "pic.png", "fake-png")
+
+		resp := s.roundTrip(s.server, http.MethodHead, "/ctnh/pic.png")
+
+		s.Equal(http.StatusOK, resp.StatusCode)
+		s.Equal("image/png", resp.Header.Get("Content-Type"))
+	})
+
+	s.Run("unrecognized extension answers with the default", func() {
+		s.createBucket("ctnu")
+		s.putObject("ctnu", "blob.nopesuchtype", "plain words")
+
+		for _, method := range []string{http.MethodGet, http.MethodHead} {
+			resp := s.roundTrip(s.server, method, "/ctnu/blob.nopesuchtype")
+
+			s.Equal(http.StatusOK, resp.StatusCode, method)
+			s.Equal(defaultContentType, resp.Header.Get("Content-Type"), method)
+		}
+	})
+
+	s.Run("extensionless key answers with the default", func() {
+		// Setting the header explicitly is what keeps HEAD's answer equal
+		// to GET's here; net/http would otherwise sniff the GET body.
+		s.createBucket("ctne")
+		s.putObject("ctne", "LICENSE", "Copyright (c) 2026")
+
+		for _, method := range []string{http.MethodGet, http.MethodHead} {
+			resp := s.roundTrip(s.server, method, "/ctne/LICENSE")
+
+			s.Equal(http.StatusOK, resp.StatusCode, method)
+			s.Equal(defaultContentType, resp.Header.Get("Content-Type"), method)
+		}
+	})
+
+	s.Run("memfs guesses too, being a filesystem backend", func() {
+		cfg := server.DefaultConfig()
+		cfg.Type = s2.TypeMemFS
+		srv, err := server.NewServer(context.Background(), cfg)
+		s.Require().NoError(err)
+		ctx := context.Background()
+		s.Require().NoError(srv.Buckets.Create(ctx, "ctnm"))
+		strg, err := srv.Buckets.Get(ctx, "ctnm")
+		s.Require().NoError(err)
+		s.Require().NoError(strg.Put(ctx, s2.NewObjectBytes("legacy.png", []byte("fake-png"))))
+
+		resp := s.roundTrip(srv, http.MethodGet, "/ctnm/legacy.png")
+
+		s.Equal(http.StatusOK, resp.StatusCode)
+		s.Equal("image/png", resp.Header.Get("Content-Type"))
+	})
+
+	s.Run("CopyObject preserves the extension guess of a metadata-less source", func() {
+		// The copy carries an ETag, so it can never qualify for the
+		// guess itself; handleCopyObject records the source's answer.
+		s.createBucket("ctcs")
+		s.createBucket("ctcd")
+		s.putObject("ctcs", "page.html", "<h1>hi</h1>")
+
+		copyReq := httptest.NewRequest("PUT", "/ctcd/page.html", nil)
+		copyReq.SetPathValue("bucket", "ctcd")
+		copyReq.SetPathValue("key", "page.html")
+		copyReq.Header.Set("x-amz-copy-source", "/ctcs/page.html")
+		copyW := httptest.NewRecorder()
+		handlePutObject(s.server, copyW, copyReq)
+		s.Equal(http.StatusOK, copyW.Code)
+
+		resp := s.roundTrip(s.server, http.MethodGet, "/ctcd/page.html")
+
+		s.Equal(http.StatusOK, resp.StatusCode)
+		s.Contains(resp.Header.Get("Content-Type"), "text/html")
 	})
 
 	s.Run("CopyObject without directive preserves source Content-Type", func() {
@@ -1703,3 +1793,44 @@ func BenchmarkHTTPPutObject(b *testing.B)      { benchHTTPPutObject(b, s2.TypeOS
 func BenchmarkHTTPGetObject(b *testing.B)      { benchHTTPGetObject(b, s2.TypeOSFS) }
 func BenchmarkHTTPPutObjectMemFS(b *testing.B) { benchHTTPPutObject(b, s2.TypeMemFS) }
 func BenchmarkHTTPGetObjectMemFS(b *testing.B) { benchHTTPGetObject(b, s2.TypeMemFS) }
+
+// typedStorage reports an arbitrary s2.Type. The embedded interface is
+// nil: setContentType only ever calls Type(), and a cloud backend cannot
+// be stood up in a unit test.
+type typedStorage struct {
+	s2.Storage
+	typ s2.Type
+}
+
+func (t typedStorage) Type() s2.Type { return t.typ }
+
+func (s *ObjectsTestSuite) TestObjectContentTypeSkipsCloudBackends() {
+	// Cloud backends drop the bucket's own Content-Type on read (see
+	// objectContentType); guessing here would hide that gap rather than
+	// fix it, so they answer with S3's default instead of the extension.
+	// The filesystem backends are in the table to show the same call
+	// guesses.
+	testCases := []struct {
+		caseName  string
+		typ       s2.Type
+		wantGuess bool
+	}{
+		{caseName: "osfs guesses", typ: s2.TypeOSFS, wantGuess: true},
+		{caseName: "memfs guesses", typ: s2.TypeMemFS, wantGuess: true},
+		{caseName: "s3 defaults", typ: s2.TypeS3},
+		{caseName: "gcs defaults", typ: s2.TypeGCS},
+		{caseName: "azblob defaults", typ: s2.TypeAzblob},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			obj := s2.NewObjectBytes("pic.png", []byte("fake-png"))
+			got := objectContentType(typedStorage{typ: tc.typ}, obj, obj.Name())
+
+			if tc.wantGuess {
+				s.Equal("image/png", got)
+				return
+			}
+			s.Equal(defaultContentType, got)
+		})
+	}
+}

--- a/server/handlers/s3api/objects_test.go
+++ b/server/handlers/s3api/objects_test.go
@@ -988,6 +988,31 @@ func (s *ObjectsTestSuite) TestContentType() {
 		s.Contains(resp.Header.Get("Content-Type"), "text/html")
 	})
 
+	s.Run("CopyObject records only the guess, never the default", func() {
+		// Persisting binary/octet-stream here would outlive the reason
+		// for it: once a backend surfaces its own Content-Type (#198),
+		// the stamped default would win over it forever.
+		s.createBucket("ctcn")
+		s.createBucket("ctcnd")
+		s.putObject("ctcn", "blob.nopesuchtype", "data")
+
+		copyReq := httptest.NewRequest("PUT", "/ctcnd/blob.nopesuchtype", nil)
+		copyReq.SetPathValue("bucket", "ctcnd")
+		copyReq.SetPathValue("key", "blob.nopesuchtype")
+		copyReq.Header.Set("x-amz-copy-source", "/ctcn/blob.nopesuchtype")
+		copyW := httptest.NewRecorder()
+		handlePutObject(s.server, copyW, copyReq)
+		s.Equal(http.StatusOK, copyW.Code)
+
+		ctx := context.Background()
+		strg, err := s.server.Buckets.Get(ctx, "ctcnd")
+		s.Require().NoError(err)
+		obj, err := strg.Get(ctx, "blob.nopesuchtype")
+		s.Require().NoError(err)
+		_, ok := obj.Metadata().Get(contentTypeMetadataKey)
+		s.False(ok, "no Content-Type should have been stamped on the copy")
+	})
+
 	s.Run("CopyObject without directive preserves source Content-Type", func() {
 		s.createBucket("ctc")
 
@@ -1795,7 +1820,7 @@ func BenchmarkHTTPPutObjectMemFS(b *testing.B) { benchHTTPPutObject(b, s2.TypeMe
 func BenchmarkHTTPGetObjectMemFS(b *testing.B) { benchHTTPGetObject(b, s2.TypeMemFS) }
 
 // typedStorage reports an arbitrary s2.Type. The embedded interface is
-// nil: setContentType only ever calls Type(), and a cloud backend cannot
+// nil: objectContentType only ever calls Type(), and a cloud backend cannot
 // be stood up in a unit test.
 type typedStorage struct {
 	s2.Storage

--- a/server/handlers/s3api/s3api_test.go
+++ b/server/handlers/s3api/s3api_test.go
@@ -2,6 +2,9 @@ package s3api
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 
 	"github.com/mojatter/s2"
 	"github.com/mojatter/s2/server"
@@ -38,4 +41,24 @@ func (s *s3apiSuite) putObject(bucket, key, content string) {
 func (s *s3apiSuite) createBucket(name string) {
 	s.T().Helper()
 	s.Require().NoError(s.server.Buckets.Create(context.Background(), name))
+}
+
+// roundTrip drives target through a real server and returns the response,
+// body drained and closed. Unlike httptest.ResponseRecorder, this shows
+// what the client receives -- net/http's own Content-Type sniffing
+// included (#188).
+func (s *s3apiSuite) roundTrip(srv *server.Server, method, target string) *http.Response {
+	s.T().Helper()
+	ts := httptest.NewServer(srv.S3Handler())
+	defer ts.Close()
+
+	req, err := http.NewRequest(method, ts.URL+target, nil)
+	s.Require().NoError(err)
+	resp, err := ts.Client().Do(req)
+	s.Require().NoError(err)
+	defer func() { _ = resp.Body.Close() }()
+
+	_, err = io.Copy(io.Discard, resp.Body)
+	s.Require().NoError(err)
+	return resp
 }


### PR DESCRIPTION
## Summary
- Objects placed into a filesystem backend's root from outside s2 -- e.g. an existing directory of static assets mounted as `root` -- carry no metadata at all, so `GetObject`/`HeadObject` had nothing to answer with. They now resolve `Content-Type` from the key's extension.
- The guess fires only when an object has *no* metadata whatsoever. Everything s2 writes records at least an ETag (`PutObject`, `CompleteMultipartUpload`, and now the Web Console's upload), so it keeps answering with its stored `Content-Type`, or with `binary/octet-stream` when it stored none -- what real S3 answers. That is what separates "placed from outside" from "uploaded without a Content-Type", with no startup scan and no extra `.meta` files.
- `GetObject`/`HeadObject` now always send an explicit `Content-Type`. A typeless object previously got net/http's own body sniffing on `GET` and no header at all on `HEAD`; the two now agree.
- Scoped to the filesystem backends. `s3`/`gcs`/`azblob` discard the underlying bucket's own `Content-Type` on read -- only user metadata reaches `s2.Metadata` -- and guessing there would paper over that gap instead of fixing it.
- The Web Console's upload now records `s2-etag` and `s2-content-type` the way `PutObject` does, so a console upload is no longer indistinguishable from an externally-placed file. A generic `application/octet-stream` part header (what browsers send for any extension the OS does not know) falls back to the key's extension.
- `CopyObject` without `x-amz-metadata-directive: REPLACE` now records the source's effective `Content-Type` when the source has none stored. The copy carries an ETag, so it could never qualify for the guess itself, and its type would otherwise differ from the source it is supposed to preserve.
- The console's view endpoint now sends `Content-Security-Policy: sandbox`. The type it serves is the uploader's, and the preview modal's "Open in new tab" button navigates straight to it, so an object stored as `text/html` could otherwise run on the console's origin.
- Closes #188, closes #199.

## Non-goals
- Multipart uploads still capture no `Content-Type`; they answer with the S3 default like any other object s2 wrote without one -- tracked in #191.
- Cloud backends still drop the underlying bucket's native `Content-Type` on read -- tracked in #198.

Both of those get *less* useful to a browser here, not more. Until this PR a typeless object had no `Content-Type` header on `GET`, so net/http sniffed the body and often guessed well; now it answers `binary/octet-stream`. Concretely, an `aws s3 cp movie.mp4` above the CLI's multipart threshold used to play inline and now downloads, while the same file below the threshold still gets `video/mp4` from `PutObject`. The fix belongs in #191 and #198 -- real S3 stores a `Content-Type` for a multipart upload, and a cloud bucket already holds one -- rather than in extending the extension guess, which would paper over both gaps.

## Test plan
- [x] `go vet ./...` and `go test ./...` (root + every submodule)
- [x] Manual smoke test: served an existing directory as an `osfs` root with an anonymous public-read policy, then `curl`'d `GET` and `HEAD` -- `index.html` -> `text/html`, `style.css` -> `text/css`, `LICENSE` -> `binary/octet-stream`, with `GET` and `HEAD` agreeing on every one
- [x] Checked in Chrome: the preview modal's PDF renders inside the sandboxed `<iframe>`, and the "Download File" button (which targets the same `/view/` endpoint) still downloads -- the empty `sandbox` needs neither `allow-scripts` nor `allow-downloads`
- [x] CI passes (`golangci-lint` could not be run locally -- unrelated Go 1.27 toolchain panic, also present on `main`)
