### PR TITLE
Minio-go client header fix for Sigv4

### DIFF
--- a/server/middleware/sigv4.go
+++ b/server/middleware/sigv4.go
@@ -250,7 +250,7 @@ func stripQueryParam(rawQuery, name string) string {
 
 func parseAuthHeader(s string) map[string]string {
 	result := make(map[string]string)
-	for _, part := range strings.Split(s, ", ") {
+	for _, part := range strings.Split(s, ",") {
 		part = strings.TrimSpace(part)
 		idx := strings.IndexByte(part, '=')
 		if idx > 0 {

--- a/server/middleware/sigv4_test.go
+++ b/server/middleware/sigv4_test.go
@@ -736,6 +736,18 @@ func TestParseAuthHeader(t *testing.T) {
 			wantKey:  "Signature",
 			wantVal:  "abc123",
 		},
+		{
+			caseName: "no space after comma",
+			input:    "Credential=AKID/20130524/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-date,Signature=abc123",
+			wantKey:  "SignedHeaders",
+			wantVal:  "host;x-amz-date",
+		},
+		{
+			caseName: "mixed spacing after comma",
+			input:    "Credential=AKID/20130524/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-date, Signature=abc123",
+			wantKey:  "Signature",
+			wantVal:  "abc123",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.caseName, func(t *testing.T) {


### PR DESCRIPTION
It seems that some S3 clients disagree on the header delimiter: 
 - botocore emits ", "
 - minio-go emits "," (no space)

This seems to cause an issues with the existing `strings.Split` and break calls from Minio-GO client library. The AWS SigV4 spec seems allows either (and AWS S3 servers seem to work with both)

Because `strings.TrimSpace` was already being called next, the extra prefix whitespace should be removed and maintain existing compatibility.