### PR TITLE
fix(s2): Split ListOptions.After into a token and a start-after key

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,10 +345,11 @@ type Storage interface {
 // One List method covers flat and recursive listings, with explicit
 // pagination via continuation token.
 type ListOptions struct {
-	Prefix    string
-	After     string // continuation token; empty = first page
-	Limit     int    // 0 = backend default
-	Recursive bool
+	Prefix     string
+	After      string // opaque continuation token; empty = first page
+	StartAfter string // caller-chosen key to resume after; ignored when After is set
+	Limit      int    // 0 = backend default
+	Recursive  bool
 }
 
 type ListResult struct {

--- a/azblob/integ_test.go
+++ b/azblob/integ_test.go
@@ -61,6 +61,10 @@ func (s *AzblobIntegrationSuite) TestGetPut() {
 	s.Require().NoError(s2test.TestStorageGetPut(context.Background(), s.strg))
 }
 
+func (s *AzblobIntegrationSuite) TestList() {
+	s.Require().NoError(s2test.TestStorageListPaging(context.Background(), s.strg))
+}
+
 func (s *AzblobIntegrationSuite) TestGetNotExist() {
 	s.Require().NoError(s2test.TestStorageGetNotExist(context.Background(), s.strg))
 }

--- a/azblob/storage.go
+++ b/azblob/storage.go
@@ -120,6 +120,10 @@ func (s *azblobStorage) Sub(_ context.Context, prefix string) (s2.Storage, error
 
 const defaultListLimit = 1000
 
+// List implements s2.Storage. ListOptions.After is Azure's own list marker.
+// Azure has no start-after parameter, so ListOptions.StartAfter is emulated
+// by paging from the start and discarding names up to it, one request per
+// page skipped; prefer After for pagination.
 func (s *azblobStorage) List(ctx context.Context, opts s2.ListOptions) (s2.ListResult, error) {
 	limit := opts.Limit
 	if limit <= 0 {
@@ -127,45 +131,62 @@ func (s *azblobStorage) List(ctx context.Context, opts s2.ListOptions) (s2.ListR
 	}
 
 	prefix := s.fullPrefix(opts.Prefix)
-
-	var res listBlobsResult
-	var err error
-	if opts.Recursive {
-		res, err = s.client.listBlobs(ctx, s.container, prefix, int32(limit), opts.After)
-	} else {
-		res, err = s.client.listBlobsHierarchy(ctx, s.container, prefix, "/", int32(limit), opts.After)
-	}
-	if err != nil {
-		return s2.ListResult{}, fmt.Errorf("azblob: list blobs: %w", err)
+	marker := opts.After
+	// TODO: the s3api handler resumes with a key, not a marker, so paging a
+	// bucket rescans from the start on every request.
+	startAfter := ""
+	if opts.After == "" && opts.StartAfter != "" {
+		startAfter = s.key(opts.StartAfter)
 	}
 
 	out := s2.ListResult{
-		Objects:        make([]s2.Object, 0, len(res.items)),
-		CommonPrefixes: make([]string, 0, len(res.prefixes)),
+		Objects:        make([]s2.Object, 0),
+		CommonPrefixes: make([]string, 0),
 	}
+	for {
+		var res listBlobsResult
+		var err error
+		if opts.Recursive {
+			res, err = s.client.listBlobs(ctx, s.container, prefix, int32(limit), marker)
+		} else {
+			res, err = s.client.listBlobsHierarchy(ctx, s.container, prefix, "/", int32(limit), marker)
+		}
+		if err != nil {
+			return s2.ListResult{}, fmt.Errorf("azblob: list blobs: %w", err)
+		}
+		marker = res.nextMarker
 
-	for _, item := range res.items {
-		name := item.name
-		if s.prefix != "" {
-			name = name[len(s.prefix)+1:]
+		for _, item := range res.items {
+			// Names are sorted, so this only discards a leading run: what
+			// survives is a page tail the marker still points just past.
+			if item.name <= startAfter {
+				continue
+			}
+			out.Objects = append(out.Objects, &object{
+				client:    s.client,
+				container: s.container,
+				prefix:    s.prefix,
+				name:      s2.RelName(s.prefix, item.name),
+				length:    s2.MustUint64(item.contentLength),
+				modified:  item.lastModified,
+				metadata:  s2.Metadata(fromPtrMetadata(item.metadata)),
+			})
 		}
 
-		out.Objects = append(out.Objects, &object{
-			client:    s.client,
-			container: s.container,
-			prefix:    s.prefix,
-			name:      name,
-			length:    s2.MustUint64(item.contentLength),
-			modified:  item.lastModified,
-			metadata:  s2.Metadata(fromPtrMetadata(item.metadata)),
-		})
+		for _, p := range res.prefixes {
+			// A prefix holding keys past startAfter still belongs here.
+			if startAfter >= p && !strings.HasPrefix(startAfter, p) {
+				continue
+			}
+			out.CommonPrefixes = append(out.CommonPrefixes, s2.RelName(s.prefix, p))
+		}
+
+		if len(out.Objects) > 0 || len(out.CommonPrefixes) > 0 || marker == "" {
+			break
+		}
 	}
 
-	out.CommonPrefixes = append(out.CommonPrefixes, res.prefixes...)
-
-	if res.nextMarker != "" {
-		out.NextAfter = res.nextMarker
-	}
+	out.NextAfter = marker
 	return out, nil
 }
 

--- a/azblob/storage_test.go
+++ b/azblob/storage_test.go
@@ -160,17 +160,31 @@ func (m *mockAzblobClient) copyBlob(_ context.Context, container, src, dst strin
 	return nil
 }
 
+// mockMarkerPrefix marks the mock's markers. Azure's are opaque, so the mock
+// rejects anything it did not hand out itself.
+const mockMarkerPrefix = "mock-marker:"
+
 func (m *mockAzblobClient) listBlobs(_ context.Context, ctr, prefix string, maxResults int32, marker string) (listBlobsResult, error) {
-	return m.doList(ctr, prefix, "", maxResults, marker), nil
+	return m.doList(ctr, prefix, "", maxResults, marker)
 }
 
 func (m *mockAzblobClient) listBlobsHierarchy(_ context.Context, ctr, prefix, delimiter string, maxResults int32, marker string) (listBlobsResult, error) {
-	return m.doList(ctr, prefix, delimiter, maxResults, marker), nil
+	return m.doList(ctr, prefix, delimiter, maxResults, marker)
 }
 
-func (m *mockAzblobClient) doList(ctr, prefix, delimiter string, maxResults int32, marker string) listBlobsResult {
+func (m *mockAzblobClient) doList(ctr, prefix, delimiter string, maxResults int32, marker string) (listBlobsResult, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+
+	// The marker names the page's first key, inclusive.
+	from := ""
+	if marker != "" {
+		key, ok := strings.CutPrefix(marker, mockMarkerPrefix)
+		if !ok {
+			return listBlobsResult{}, fmt.Errorf("invalid marker %q", marker)
+		}
+		from = key
+	}
 
 	var keys []string
 	for k := range m.blobs {
@@ -189,7 +203,7 @@ func (m *mockAzblobClient) doList(ctr, prefix, delimiter string, maxResults int3
 		if !strings.HasPrefix(b.key, prefix) {
 			continue
 		}
-		if marker != "" && b.key <= marker {
+		if from != "" && b.key < from {
 			continue
 		}
 
@@ -207,7 +221,7 @@ func (m *mockAzblobClient) doList(ctr, prefix, delimiter string, maxResults int3
 		}
 
 		if int32(len(result.items)) >= maxResults {
-			result.nextMarker = b.key
+			result.nextMarker = mockMarkerPrefix + b.key
 			break
 		}
 
@@ -218,7 +232,7 @@ func (m *mockAzblobClient) doList(ctr, prefix, delimiter string, maxResults int3
 			metadata:      b.metadata,
 		})
 	}
-	return result
+	return result, nil
 }
 
 func (m *mockAzblobClient) signedURL(container, blobName string, _ string, _ time.Time) (string, error) {
@@ -338,6 +352,86 @@ func (s *StorageTestSuite) TestS2TestList() {
 
 	err = s2test.TestStorageList(ctx, strg, "cc", "cc/c1.txt", "cc/c2.txt")
 	s.Require().NoError(err)
+}
+
+// TestListStartAfter covers the emulated start-after: the backend pages from
+// the start and drops the names before the key.
+func (s *StorageTestSuite) TestListStartAfter() {
+	testCases := []struct {
+		caseName     string
+		prefix       string
+		after        string
+		startAfter   string
+		limit        int
+		flat         bool
+		want         []string
+		wantPrefixes []string
+	}{
+		{
+			caseName:   "skips names up to the key",
+			startAfter: "a.txt",
+			want:       []string{"b.txt", "cc/c1.txt", "cc/c2.txt"},
+		},
+		{
+			caseName:   "pages past a fully skipped page",
+			startAfter: "b.txt",
+			limit:      1,
+			want:       []string{"cc/c1.txt"},
+		},
+		{
+			caseName:   "resolves the key against the storage prefix",
+			prefix:     "cc",
+			startAfter: "c1.txt",
+			want:       []string{"c2.txt"},
+		},
+		{
+			caseName:   "after wins over start after",
+			after:      mockMarkerPrefix + "b.txt",
+			startAfter: "cc/c2.txt",
+			want:       []string{"b.txt", "cc/c1.txt", "cc/c2.txt"},
+		},
+		{
+			caseName:     "keeps the prefix holding the key",
+			startAfter:   "cc/c1.txt",
+			flat:         true,
+			want:         []string{},
+			wantPrefixes: []string{"cc/"},
+		},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			_, strg := s.testMockStorage()
+			strg.(*azblobStorage).prefix = tc.prefix
+
+			res, err := strg.List(context.Background(), s2.ListOptions{
+				After:      tc.after,
+				StartAfter: tc.startAfter,
+				Limit:      tc.limit,
+				Recursive:  !tc.flat,
+			})
+			s.Require().NoError(err)
+			got := make([]string, 0, len(res.Objects))
+			for _, obj := range res.Objects {
+				got = append(got, obj.Name())
+			}
+			s.Equal(tc.want, got)
+			if tc.wantPrefixes != nil {
+				s.Equal(tc.wantPrefixes, res.CommonPrefixes)
+			}
+		})
+	}
+}
+
+// TestListPrefixesAreRelative pins that CommonPrefixes drop the storage
+// prefix, as object names do.
+func (s *StorageTestSuite) TestListPrefixesAreRelative() {
+	m, strg := s.testMockStorage()
+	m.put("mycontainer", "cc/dd/x.txt", []byte("x"), nil)
+	strg.(*azblobStorage).prefix = "cc"
+
+	res, err := strg.List(context.Background(), s2.ListOptions{})
+	s.Require().NoError(err)
+	s.Equal([]string{"dd/"}, res.CommonPrefixes)
 }
 
 func (s *StorageTestSuite) TestS2TestGetPut() {

--- a/fs/storage.go
+++ b/fs/storage.go
@@ -97,10 +97,23 @@ func (s *storage) List(ctx context.Context, opts s2.ListOptions) (s2.ListResult,
 	if limit <= 0 {
 		limit = defaultListLimit
 	}
-	if opts.Recursive {
-		return s.listRecursive(opts.Prefix, opts.After, limit)
+	// Both cursors are plain key names here, so they collapse into one
+	// comparison; After wins.
+	after := opts.After
+	if after == "" {
+		after = opts.StartAfter
 	}
-	return s.listFlat(opts.Prefix, opts.After, limit)
+	if opts.Recursive {
+		return s.listRecursive(opts.Prefix, after, limit)
+	}
+	return s.listFlat(opts.Prefix, after, limit)
+}
+
+// pastSubtree reports whether after sorts beyond every key under dir. A
+// directory holding keys past after is still a common prefix.
+func pastSubtree(dir, after string) bool {
+	sub := dir + "/"
+	return after >= sub && !strings.HasPrefix(after, sub)
 }
 
 func (s *storage) listFlat(prefix, after string, limit int) (s2.ListResult, error) {
@@ -127,9 +140,6 @@ func (s *storage) listFlat(prefix, after string, limit int) (s2.ListResult, erro
 		if dir != "." {
 			name = path.Join(dir, entry.Name())
 		}
-		if after != "" && name <= after {
-			continue
-		}
 		if isMetaDir(entry.Name()) || isTempFile(entry.Name()) {
 			continue
 		}
@@ -138,7 +148,13 @@ func (s *storage) listFlat(prefix, after string, limit int) (s2.ListResult, erro
 			return s2.ListResult{}, fmt.Errorf("failed to get info: %w", err)
 		}
 		if info.IsDir() {
+			if pastSubtree(name, after) {
+				continue
+			}
 			res.CommonPrefixes = append(res.CommonPrefixes, name)
+			continue
+		}
+		if after != "" && name <= after {
 			continue
 		}
 		res.Objects = append(res.Objects, newObjectFileInfo(s.fsys, name, info))

--- a/fs/storage_test.go
+++ b/fs/storage_test.go
@@ -334,6 +334,79 @@ func (s *StorageTestSuite) TestListAfter() {
 	}
 }
 
+func (s *StorageTestSuite) TestListStartAfter() {
+	testCases := []struct {
+		caseName     string
+		prefix       string
+		after        string
+		startAfter   string
+		recursive    bool
+		want         []string
+		wantPrefixes []string
+	}{
+		{
+			caseName:   "start after key",
+			startAfter: "a.txt",
+			want:       []string{"b.txt"},
+		},
+		{
+			caseName:   "start after a key that does not exist",
+			startAfter: "a0.txt",
+			want:       []string{"b.txt"},
+		},
+		{
+			caseName:   "after wins over start after",
+			after:      "a.txt",
+			startAfter: "b.txt",
+			want:       []string{"b.txt"},
+		},
+		{
+			caseName:   "recursive",
+			startAfter: "b.txt",
+			recursive:  true,
+			want:       []string{"cc/c1.txt", "cc/c2.txt"},
+		},
+		{
+			caseName:   "with prefix",
+			prefix:     "cc",
+			startAfter: "cc/c1.txt",
+			want:       []string{"cc/c2.txt"},
+		},
+		{
+			caseName:     "keeps the prefix holding the key",
+			startAfter:   "cc/c1.txt",
+			want:         []string{},
+			wantPrefixes: []string{"cc"},
+		},
+		{
+			caseName:     "drops a prefix sorting before the key",
+			startAfter:   "d",
+			want:         []string{},
+			wantPrefixes: []string{},
+		},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			strg := &storage{fsys: s.testMemFS()}
+			res, err := strg.List(context.Background(), s2.ListOptions{
+				Prefix:     tc.prefix,
+				After:      tc.after,
+				StartAfter: tc.startAfter,
+				Recursive:  tc.recursive,
+			})
+			s.Require().NoError(err)
+			got := make([]string, 0, len(res.Objects))
+			for _, obj := range res.Objects {
+				got = append(got, obj.Name())
+			}
+			s.Equal(tc.want, got)
+			if tc.wantPrefixes != nil {
+				s.Equal(tc.wantPrefixes, res.CommonPrefixes)
+			}
+		})
+	}
+}
+
 func (s *StorageTestSuite) TestListRecursiveAfter() {
 	testCases := []struct {
 		caseName string

--- a/gcs/client.go
+++ b/gcs/client.go
@@ -30,6 +30,15 @@ type gcsObject interface {
 
 type gcsObjectIterator interface {
 	next() (*storage.ObjectAttrs, error)
+	// setPageToken resumes the iteration at the given page token.
+	setPageToken(token string)
+	// setMaxSize caps how many items one page holds.
+	setMaxSize(n int)
+	// remaining reports how many items of the current page are still buffered.
+	remaining() int
+	// nextPageToken is the token for the page after the current one, empty
+	// once the listing is exhausted.
+	nextPageToken() string
 }
 
 // --- sdk implementations wrapping the GCS SDK ---
@@ -104,4 +113,20 @@ type sdkObjectIterator struct {
 
 func (i *sdkObjectIterator) next() (*storage.ObjectAttrs, error) {
 	return i.it.Next()
+}
+
+func (i *sdkObjectIterator) setPageToken(token string) {
+	i.it.PageInfo().Token = token
+}
+
+func (i *sdkObjectIterator) setMaxSize(n int) {
+	i.it.PageInfo().MaxSize = n
+}
+
+func (i *sdkObjectIterator) remaining() int {
+	return i.it.PageInfo().Remaining()
+}
+
+func (i *sdkObjectIterator) nextPageToken() string {
+	return i.it.PageInfo().Token
 }

--- a/gcs/integ_test.go
+++ b/gcs/integ_test.go
@@ -56,6 +56,10 @@ func (s *GCSIntegrationSuite) TestGetPut() {
 	s.Require().NoError(s2test.TestStorageGetPut(context.Background(), s.strg))
 }
 
+func (s *GCSIntegrationSuite) TestList() {
+	s.Require().NoError(s2test.TestStorageListPaging(context.Background(), s.strg))
+}
+
 func (s *GCSIntegrationSuite) TestGetNotExist() {
 	s.Require().NoError(s2test.TestStorageGetNotExist(context.Background(), s.strg))
 }

--- a/gcs/storage.go
+++ b/gcs/storage.go
@@ -85,11 +85,15 @@ func (s *gcsStorage) List(ctx context.Context, opts s2.ListOptions) (s2.ListResu
 	if !opts.Recursive {
 		q.Delimiter = "/"
 	}
-	if opts.After != "" {
-		q.StartOffset = opts.After
+	if opts.After == "" && opts.StartAfter != "" {
+		q.StartOffset = s.key(opts.StartAfter)
 	}
 
 	it := s.client.bucket(s.bucket).objects(ctx, q)
+	// One s2 page is one SDK page, so the token the SDK hands back resumes
+	// where this call stops.
+	it.setMaxSize(limit)
+	it.setPageToken(opts.After)
 
 	out := s2.ListResult{
 		Objects:        make([]s2.Object, 0),
@@ -104,36 +108,28 @@ func (s *gcsStorage) List(ctx context.Context, opts s2.ListOptions) (s2.ListResu
 			return s2.ListResult{}, fmt.Errorf("gcs: list objects: %w", err)
 		}
 
-		// Common prefix (directory marker in non-recursive listing).
+		// A common prefix is a directory marker in a non-recursive listing.
+		// StartOffset is inclusive, so objects skip the match itself.
 		if attrs.Prefix != "" {
-			out.CommonPrefixes = append(out.CommonPrefixes, attrs.Prefix)
-			continue
+			out.CommonPrefixes = append(out.CommonPrefixes, s2.RelName(s.prefix, attrs.Prefix))
+		} else if name := s2.RelName(s.prefix, attrs.Name); q.StartOffset == "" || name != opts.StartAfter {
+			out.Objects = append(out.Objects, &object{
+				client:       s.client,
+				bucket:       s.bucket,
+				prefix:       s.prefix,
+				name:         name,
+				length:       s2.MustUint64(attrs.Size),
+				lastModified: attrs.Updated,
+				metadata:     s2.Metadata(attrs.Metadata),
+			})
 		}
 
-		name := attrs.Name
-		if s.prefix != "" {
-			name = name[len(s.prefix)+1:]
-		}
-
-		// StartOffset is inclusive; skip the exact match for "after" semantics.
-		if opts.After != "" && name == opts.After {
-			continue
-		}
-
-		if len(out.Objects) >= limit {
-			out.NextAfter = name
+		// Once the buffered page is drained, the token the SDK holds resumes
+		// at the next one.
+		if it.remaining() == 0 {
+			out.NextAfter = it.nextPageToken()
 			break
 		}
-
-		out.Objects = append(out.Objects, &object{
-			client:       s.client,
-			bucket:       s.bucket,
-			prefix:       s.prefix,
-			name:         name,
-			length:       s2.MustUint64(attrs.Size),
-			lastModified: attrs.Updated,
-			metadata:     s2.Metadata(attrs.Metadata),
-		})
 	}
 	return out, nil
 }

--- a/gcs/storage_test.go
+++ b/gcs/storage_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"path"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -24,11 +25,11 @@ import (
 // --- mock implementations ---
 
 type mockObject struct {
-	bucket       string
-	key          string
-	body         []byte
-	updated      time.Time
-	metadata     map[string]string
+	bucket   string
+	key      string
+	body     []byte
+	updated  time.Time
+	metadata map[string]string
 }
 
 type mockGCSClient struct {
@@ -259,20 +260,66 @@ func (w *mockWriter) Close() error {
 	return nil
 }
 
+// mockPageTokenPrefix marks the mock's page tokens. Real ones are opaque, so
+// the mock rejects anything it did not hand out itself.
+const mockPageTokenPrefix = "mock-page:"
+
 type mockIterator struct {
 	entries []struct {
 		attrs *storage.ObjectAttrs
 	}
-	idx int
+	idx     int // next entry to return
+	pageEnd int // exclusive end of the page currently buffered
+	maxSize int
+	err     error
 }
 
 func (i *mockIterator) next() (*storage.ObjectAttrs, error) {
+	if i.err != nil {
+		return nil, i.err
+	}
 	if i.idx >= len(i.entries) {
 		return nil, iterator.Done
+	}
+	if i.idx >= i.pageEnd {
+		// The buffered page is drained; fetch the next one.
+		size := i.maxSize
+		if size <= 0 {
+			size = len(i.entries)
+		}
+		i.pageEnd = min(i.idx+size, len(i.entries))
 	}
 	a := i.entries[i.idx].attrs
 	i.idx++
 	return a, nil
+}
+
+func (i *mockIterator) setPageToken(token string) {
+	if token == "" {
+		return
+	}
+	n, err := strconv.Atoi(strings.TrimPrefix(token, mockPageTokenPrefix))
+	if !strings.HasPrefix(token, mockPageTokenPrefix) || err != nil {
+		i.err = fmt.Errorf("invalid page token %q", token)
+		return
+	}
+	i.idx = n
+	i.pageEnd = n
+}
+
+func (i *mockIterator) setMaxSize(n int) {
+	i.maxSize = n
+}
+
+func (i *mockIterator) remaining() int {
+	return i.pageEnd - i.idx
+}
+
+func (i *mockIterator) nextPageToken() string {
+	if i.pageEnd >= len(i.entries) {
+		return ""
+	}
+	return mockPageTokenPrefix + strconv.Itoa(i.pageEnd)
 }
 
 // --- test suite ---
@@ -331,6 +378,91 @@ func (s *StorageTestSuite) TestS2TestList() {
 
 	err = s2test.TestStorageList(ctx, strg, "cc", "cc/c1.txt", "cc/c2.txt")
 	s.Require().NoError(err)
+}
+
+// TestListCursors separates the two resume paths: After is the SDK's page
+// token, StartAfter a caller-chosen key mapped onto StartOffset.
+func (s *StorageTestSuite) TestListCursors() {
+	testCases := []struct {
+		caseName   string
+		prefix     string
+		startAfter string
+		limit      int
+		want       []string
+		wantNext   bool
+	}{
+		{
+			caseName:   "start after skips the key itself",
+			startAfter: "a.txt",
+			want:       []string{"b.txt", "cc/c1.txt", "cc/c2.txt"},
+		},
+		{
+			caseName:   "resolves the key against the storage prefix",
+			prefix:     "cc",
+			startAfter: "c1.txt",
+			want:       []string{"c2.txt"},
+		},
+		{
+			caseName: "limit yields a page token",
+			limit:    2,
+			want:     []string{"a.txt", "b.txt"},
+			wantNext: true,
+		},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			_, strg := s.testMockStorage()
+			strg.(*gcsStorage).prefix = tc.prefix
+			ctx := context.Background()
+
+			res, err := strg.List(ctx, s2.ListOptions{
+				StartAfter: tc.startAfter,
+				Limit:      tc.limit,
+				Recursive:  true,
+			})
+			s.Require().NoError(err)
+			s.Equal(tc.want, objectNames(res.Objects))
+			if !tc.wantNext {
+				s.Empty(res.NextAfter)
+				return
+			}
+
+			// The token must round-trip as After.
+			s.Require().NotEmpty(res.NextAfter)
+			res2, err := strg.List(ctx, s2.ListOptions{After: res.NextAfter, Recursive: true})
+			s.Require().NoError(err)
+			s.Equal([]string{"cc/c1.txt", "cc/c2.txt"}, objectNames(res2.Objects))
+		})
+	}
+}
+
+// TestListAfterNotAKey passes a key name where a token belongs; the real SDK
+// would fail the request too.
+func (s *StorageTestSuite) TestListAfterNotAKey() {
+	_, strg := s.testMockStorage()
+
+	_, err := strg.List(context.Background(), s2.ListOptions{After: "a.txt", Recursive: true})
+	s.Require().Error(err)
+}
+
+func objectNames(objs []s2.Object) []string {
+	names := make([]string, 0, len(objs))
+	for _, obj := range objs {
+		names = append(names, obj.Name())
+	}
+	return names
+}
+
+// TestListPrefixesAreRelative pins that CommonPrefixes drop the storage
+// prefix, as object names do.
+func (s *StorageTestSuite) TestListPrefixesAreRelative() {
+	m, strg := s.testMockStorage()
+	m.put("mybucket", "cc/dd/x.txt", []byte("x"), nil)
+	strg.(*gcsStorage).prefix = "cc"
+
+	res, err := strg.List(context.Background(), s2.ListOptions{})
+	s.Require().NoError(err)
+	s.Equal([]string{"dd/"}, res.CommonPrefixes)
 }
 
 func (s *StorageTestSuite) TestS2TestGetPut() {

--- a/s2test/s2test.go
+++ b/s2test/s2test.go
@@ -13,8 +13,8 @@ import (
 
 // TestStorageList is a test helper for validating s2.Storage list operations.
 // It exercises the flat-listing path of Storage.List (Recursive: false) for a
-// particular prefix against the expected direct object names, including a
-// pagination round-trip via the After continuation token.
+// particular prefix against the expected direct object names, including both
+// resume paths: the After continuation token and the StartAfter key.
 // The expected array should only contain names of objects immediately beneath the prefix.
 // expectedPrefixes is an optional list of expected common prefixes (subdirectories).
 func TestStorageList(ctx context.Context, strg s2.Storage, prefix string, expected ...string) error {
@@ -71,18 +71,35 @@ func TestStorageListWithPrefixes(ctx context.Context, strg s2.Storage, prefix st
 		res1, err := strg.List(ctx, s2.ListOptions{Prefix: prefix, Limit: limit})
 		if err != nil {
 			errorf("List(prefix=%q, limit=%d) failed: %v", prefix, limit, err)
-		} else if len(res1.Objects) != limit {
-			errorf("List(prefix=%q, limit=%d) returned %d objects", prefix, limit, len(res1.Objects))
+		} else if n := len(res1.Objects); n == 0 || n > limit {
+			// Limit caps entries, so CommonPrefixes may take part of the page.
+			errorf("List(prefix=%q, limit=%d) returned %d objects", prefix, limit, n)
 		} else {
+			// NextAfter fed back as After.
+			if res1.NextAfter == "" {
+				errorf("List(prefix=%q, limit=%d) returned no NextAfter", prefix, limit)
+			} else {
+				res2, err := strg.List(ctx, s2.ListOptions{Prefix: prefix, After: res1.NextAfter})
+				if err != nil {
+					errorf("List(prefix=%q, after=<token>) failed: %v", prefix, err)
+				} else {
+					var combined []s2.Object
+					combined = append(combined, res1.Objects...)
+					combined = append(combined, res2.Objects...)
+					checkMatch(fmt.Sprintf("List Pagination (prefix %q, limit %d, after token)", prefix, limit), combined, expected)
+				}
+			}
+
+			// The caller-chosen resume key.
 			last := res1.Objects[len(res1.Objects)-1].Name()
-			res2, err := strg.List(ctx, s2.ListOptions{Prefix: prefix, After: last})
+			res2, err := strg.List(ctx, s2.ListOptions{Prefix: prefix, StartAfter: last})
 			if err != nil {
-				errorf("List(prefix=%q, after=%q) failed: %v", prefix, last, err)
+				errorf("List(prefix=%q, start-after=%q) failed: %v", prefix, last, err)
 			} else {
 				var combined []s2.Object
 				combined = append(combined, res1.Objects...)
 				combined = append(combined, res2.Objects...)
-				checkMatch(fmt.Sprintf("List Pagination (prefix %q, limit %d, after %q)", prefix, limit, last), combined, expected)
+				checkMatch(fmt.Sprintf("List StartAfter (prefix %q, limit %d, start-after %q)", prefix, limit, last), combined, expected)
 			}
 		}
 	}
@@ -95,8 +112,8 @@ func TestStorageListWithPrefixes(ctx context.Context, strg s2.Storage, prefix st
 
 // TestStorageListRecursive is a test helper for validating s2.Storage recursive list operations.
 // It exercises the recursive path of Storage.List (Recursive: true) — including
-// a prefix-filter case and a pagination round-trip via the After continuation
-// token — against the expected object names.
+// a prefix-filter case and both resume paths, the After continuation token
+// and the StartAfter key — against the expected object names.
 // The provided expected array must be the comprehensive list of object names in the storage.
 func TestStorageListRecursive(ctx context.Context, strg s2.Storage, expected ...string) error {
 	sort.Strings(expected)
@@ -149,7 +166,7 @@ func TestStorageListRecursive(ctx context.Context, strg s2.Storage, expected ...
 		}
 	}
 
-	// 3. Test pagination via After
+	// 3. Test both resume paths
 	if len(expected) > 1 {
 		limit := len(expected) / 2
 		res1, err := strg.List(ctx, s2.ListOptions{Limit: limit, Recursive: true})
@@ -158,15 +175,31 @@ func TestStorageListRecursive(ctx context.Context, strg s2.Storage, expected ...
 		} else if len(res1.Objects) != limit {
 			errorf("List(limit=%d, recursive) returned %d objects", limit, len(res1.Objects))
 		} else {
+			// NextAfter fed back as After.
+			if res1.NextAfter == "" {
+				errorf("List(limit=%d, recursive) returned no NextAfter", limit)
+			} else {
+				res2, err := strg.List(ctx, s2.ListOptions{After: res1.NextAfter, Recursive: true})
+				if err != nil {
+					errorf("List(after=<token>, recursive) failed: %v", err)
+				} else {
+					var combined []s2.Object
+					combined = append(combined, res1.Objects...)
+					combined = append(combined, res2.Objects...)
+					checkMatch(fmt.Sprintf("Pagination combined (limit %d, after token)", limit), combined, expected)
+				}
+			}
+
+			// The caller-chosen resume key.
 			last := res1.Objects[len(res1.Objects)-1].Name()
-			res2, err := strg.List(ctx, s2.ListOptions{After: last, Recursive: true})
+			res2, err := strg.List(ctx, s2.ListOptions{StartAfter: last, Recursive: true})
 			if err != nil {
-				errorf("List(after=%q, recursive) failed: %v", last, err)
+				errorf("List(start-after=%q, recursive) failed: %v", last, err)
 			} else {
 				var combined []s2.Object
 				combined = append(combined, res1.Objects...)
 				combined = append(combined, res2.Objects...)
-				checkMatch(fmt.Sprintf("Pagination combined (limit %d, after %q)", limit, last), combined, expected)
+				checkMatch(fmt.Sprintf("StartAfter combined (limit %d, start-after %q)", limit, last), combined, expected)
 			}
 		}
 	}
@@ -175,6 +208,37 @@ func TestStorageListRecursive(ctx context.Context, strg s2.Storage, expected ...
 		return fmt.Errorf("TestStorageListRecursive found %d errors:\n\t%s", len(errs), strings.Join(errs, "\n\t"))
 	}
 	return nil
+}
+
+// TestStorageListPaging writes its own fixture, then lists it flat and
+// recursively (on a Sub storage), covering both resume paths.
+func TestStorageListPaging(ctx context.Context, strg s2.Storage) error {
+	const dir = "s2test-list"
+	names := []string{
+		dir + "/a.txt",
+		dir + "/b.txt",
+		dir + "/c.txt",
+		dir + "/d.txt",
+		dir + "/sub/e.txt",
+	}
+	for _, name := range names {
+		if err := strg.Put(ctx, s2.NewObjectBytes(name, []byte("x"))); err != nil {
+			return fmt.Errorf("Put(%q) failed: %w", name, err)
+		}
+	}
+
+	if err := TestStorageListWithPrefixes(ctx, strg, dir, []string{dir + "/sub/"},
+		dir+"/a.txt", dir+"/b.txt", dir+"/c.txt", dir+"/d.txt"); err != nil {
+		return err
+	}
+
+	// A Sub storage isolates the recursive listing from other objects.
+	sub, err := strg.Sub(ctx, dir)
+	if err != nil {
+		return fmt.Errorf("Sub(%q) failed: %w", dir, err)
+	}
+
+	return TestStorageListRecursive(ctx, sub, "a.txt", "b.txt", "c.txt", "d.txt", "sub/e.txt")
 }
 
 // TestStorageGetPut validates that Put writes an object and Get reads it back correctly.

--- a/s3/integ_test.go
+++ b/s3/integ_test.go
@@ -74,6 +74,10 @@ func (s *S3IntegrationSuite) TestGetPut() {
 	s.Require().NoError(s2test.TestStorageGetPut(context.Background(), s.strg))
 }
 
+func (s *S3IntegrationSuite) TestList() {
+	s.Require().NoError(s2test.TestStorageListPaging(context.Background(), s.strg))
+}
+
 func (s *S3IntegrationSuite) TestGetNotExist() {
 	s.Require().NoError(s2test.TestStorageGetNotExist(context.Background(), s.strg))
 }

--- a/s3/storage.go
+++ b/s3/storage.go
@@ -173,15 +173,18 @@ func (s *storage) List(ctx context.Context, opts s2.ListOptions) (s2.ListResult,
 		Bucket:  aws.String(s.bucket),
 		MaxKeys: aws.Int32(int32(limit)),
 	}
-	inputPrefix := path.Join(s.prefix, opts.Prefix)
+	inputPrefix := s.listPrefix(opts.Prefix)
 	if delimiter != "" && inputPrefix != "" && !strings.HasSuffix(inputPrefix, delimiter) {
 		inputPrefix += delimiter
 	}
 	if inputPrefix != "" {
 		input.Prefix = aws.String(inputPrefix)
 	}
-	if opts.After != "" {
-		input.StartAfter = aws.String(opts.After)
+	switch {
+	case opts.After != "":
+		input.ContinuationToken = aws.String(opts.After)
+	case opts.StartAfter != "":
+		input.StartAfter = aws.String(s2.Key(s.prefix, opts.StartAfter))
 	}
 	if delimiter != "" {
 		input.Delimiter = aws.String(delimiter)
@@ -197,13 +200,10 @@ func (s *storage) List(ctx context.Context, opts s2.ListOptions) (s2.ListResult,
 		Objects:        make([]s2.Object, 0, len(res.Contents)),
 	}
 	for _, p := range res.CommonPrefixes {
-		out.CommonPrefixes = append(out.CommonPrefixes, aws.ToString(p.Prefix))
+		out.CommonPrefixes = append(out.CommonPrefixes, s2.RelName(s.prefix, aws.ToString(p.Prefix)))
 	}
 	for _, c := range res.Contents {
-		key := aws.ToString(c.Key)
-		if s.prefix != "" {
-			key = key[len(s.prefix)+1:]
-		}
+		key := s2.RelName(s.prefix, aws.ToString(c.Key))
 		out.Objects = append(out.Objects, &object{
 			client:       s.client,
 			bucket:       s.bucket,
@@ -217,6 +217,19 @@ func (s *storage) List(ctx context.Context, opts s2.ListOptions) (s2.ListResult,
 		out.NextAfter = aws.ToString(res.NextContinuationToken)
 	}
 	return out, nil
+}
+
+// listPrefix joins the storage prefix with the caller's, restoring the
+// separator path.Join drops: "data" must not match "data2/".
+func (s *storage) listPrefix(prefix string) string {
+	full := path.Join(s.prefix, prefix)
+	if full == "" {
+		return ""
+	}
+	if strings.HasSuffix(prefix, "/") || (prefix == "" && s.prefix != "") {
+		full += "/"
+	}
+	return full
 }
 
 func (s *storage) Get(ctx context.Context, name string) (s2.Object, error) {

--- a/s3/storage_test.go
+++ b/s3/storage_test.go
@@ -31,8 +31,9 @@ type mockObject struct {
 }
 
 type mockS3Client struct {
-	mu      sync.RWMutex
-	objects map[string]*mockObject
+	mu            sync.RWMutex
+	objects       map[string]*mockObject
+	lastListInput *s3.ListObjectsV2Input
 }
 
 func newMockS3Client() *mockS3Client {
@@ -71,13 +72,29 @@ func (m *mockS3Client) get(bucket, key string) (*mockObject, bool) {
 
 // clientAPI and presignClientAPI implementation
 
+// mockContinuationPrefix marks the mock's continuation tokens. Real ones are
+// opaque, so the mock rejects anything it did not hand out itself.
+const mockContinuationPrefix = "mock-token:"
+
 func (m *mockS3Client) ListObjectsV2(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	m.mu.Lock()
+	m.lastListInput = params
+	m.mu.Unlock()
+
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	bucket := aws.ToString(params.Bucket)
 	prefix := aws.ToString(params.Prefix)
 	after := aws.ToString(params.StartAfter)
+	if tok := aws.ToString(params.ContinuationToken); tok != "" {
+		key, ok := strings.CutPrefix(tok, mockContinuationPrefix)
+		if !ok {
+			return nil, fmt.Errorf("invalid continuation token %q", tok)
+		}
+		// A continuation token overrides start-after, as in the real service.
+		after = key
+	}
 	delimiter := aws.ToString(params.Delimiter)
 	limit := int(aws.ToInt32(params.MaxKeys))
 	if limit == 0 {
@@ -85,6 +102,8 @@ func (m *mockS3Client) ListObjectsV2(ctx context.Context, params *s3.ListObjects
 	}
 
 	var contents []s3types.Object
+	var commonPrefixes []s3types.CommonPrefix
+	prefixSet := make(map[string]bool)
 	var keys []string
 	for k := range m.objects {
 		keys = append(keys, k)
@@ -98,14 +117,19 @@ func (m *mockS3Client) ListObjectsV2(ctx context.Context, params *s3.ListObjects
 		if !strings.HasPrefix(obj.key, prefix) {
 			continue
 		}
-		remainder := obj.key[len(prefix):]
-		if delimiter != "" {
-			if strings.Contains(remainder, delimiter) {
-				continue // skip objects deep in subdirectories
-			}
-		}
 		if after != "" && obj.key <= after {
 			continue
+		}
+		remainder := obj.key[len(prefix):]
+		if delimiter != "" {
+			if idx := strings.Index(remainder, delimiter); idx >= 0 {
+				cp := prefix + remainder[:idx+len(delimiter)]
+				if !prefixSet[cp] {
+					prefixSet[cp] = true
+					commonPrefixes = append(commonPrefixes, s3types.CommonPrefix{Prefix: aws.String(cp)})
+				}
+				continue
+			}
 		}
 		contents = append(contents, s3types.Object{
 			Key:          aws.String(obj.key),
@@ -123,13 +147,20 @@ func (m *mockS3Client) ListObjectsV2(ctx context.Context, params *s3.ListObjects
 		}
 	}
 
-	if len(contents) > limit {
+	truncated := len(contents) > limit
+	if truncated {
 		contents = contents[:limit]
 	}
 
-	return &s3.ListObjectsV2Output{
-		Contents: contents,
-	}, nil
+	out := &s3.ListObjectsV2Output{
+		Contents:       contents,
+		CommonPrefixes: commonPrefixes,
+		IsTruncated:    aws.Bool(truncated),
+	}
+	if truncated {
+		out.NextContinuationToken = aws.String(mockContinuationPrefix + aws.ToString(contents[len(contents)-1].Key))
+	}
+	return out, nil
 }
 
 func (m *mockS3Client) HeadObject(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
@@ -262,6 +293,91 @@ func (s *StorageTestSuite) TestS2TestList() {
 
 	err = s2test.TestStorageList(ctx, strg, "cc", "cc/c1.txt", "cc/c2.txt")
 	s.Require().NoError(err)
+}
+
+// TestListCursorMapping pins which ListObjectsV2 parameter each cursor field
+// reaches: AWS reads StartAfter as a key name, so a token must never land
+// there.
+func (s *StorageTestSuite) TestListCursorMapping() {
+	testCases := []struct {
+		caseName       string
+		prefix         string
+		opts           s2.ListOptions
+		wantToken      string
+		wantStartAfter string
+	}{
+		{
+			caseName:  "after becomes a continuation token",
+			opts:      s2.ListOptions{After: mockContinuationPrefix + "a.txt"},
+			wantToken: mockContinuationPrefix + "a.txt",
+		},
+		{
+			caseName:       "start after becomes start-after",
+			opts:           s2.ListOptions{StartAfter: "a.txt"},
+			wantStartAfter: "a.txt",
+		},
+		{
+			caseName:  "after wins over start after",
+			opts:      s2.ListOptions{After: mockContinuationPrefix + "a.txt", StartAfter: "b.txt"},
+			wantToken: mockContinuationPrefix + "a.txt",
+		},
+		{
+			caseName:       "start after keeps a trailing delimiter",
+			opts:           s2.ListOptions{StartAfter: "dir/"},
+			wantStartAfter: "dir/",
+		},
+		{
+			caseName:       "start after is resolved against the storage prefix",
+			prefix:         "cc",
+			opts:           s2.ListOptions{StartAfter: "c1.txt"},
+			wantStartAfter: "cc/c1.txt",
+		},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			m, strg := s.testMockClient()
+			strg.(*storage).prefix = tc.prefix
+
+			_, err := strg.List(context.Background(), tc.opts)
+			s.Require().NoError(err)
+			s.Equal(tc.wantToken, aws.ToString(m.lastListInput.ContinuationToken))
+			s.Equal(tc.wantStartAfter, aws.ToString(m.lastListInput.StartAfter))
+		})
+	}
+}
+
+// TestListSubPrefixBoundary pins that a Sub storage lists only its own
+// subtree: "data" must not pull in "data2/" keys.
+func (s *StorageTestSuite) TestListSubPrefixBoundary() {
+	m, strg := s.testMockClient()
+	m.put("mybucket", "data", []byte("root key"), nil)
+	m.put("mybucket", "data/a.txt", []byte("a"), nil)
+	m.put("mybucket", "data2/secret.txt", []byte("s"), nil)
+	strg.(*storage).prefix = "data"
+
+	res, err := strg.List(context.Background(), s2.ListOptions{Recursive: true})
+	s.Require().NoError(err)
+	s.Equal([]string{"a.txt"}, objectNames(res.Objects))
+}
+
+func objectNames(objs []s2.Object) []string {
+	names := make([]string, 0, len(objs))
+	for _, obj := range objs {
+		names = append(names, obj.Name())
+	}
+	return names
+}
+
+// TestListPrefixesAreRelative pins that CommonPrefixes drop the storage
+// prefix, as object names do.
+func (s *StorageTestSuite) TestListPrefixesAreRelative() {
+	m, strg := s.testMockClient()
+	m.put("mybucket", "cc/dd/x.txt", []byte("x"), nil)
+	strg.(*storage).prefix = "cc"
+
+	res, err := strg.List(context.Background(), s2.ListOptions{})
+	s.Require().NoError(err)
+	s.Equal([]string{"dd/"}, res.CommonPrefixes)
 }
 
 func (s *StorageTestSuite) TestS2TestGetPut() {

--- a/server/handlers/s3api/objects.go
+++ b/server/handlers/s3api/objects.go
@@ -90,8 +90,10 @@ type listObjectsParams struct {
 	maxKeys           int
 }
 
-// after returns the continuation point: continuation-token wins over start-after.
-func (p listObjectsParams) after() string {
+// startKey returns the key the listing resumes after: continuation-token wins
+// over start-after. Both are key names -- the token this handler hands out is
+// the last key of the page (see applyMaxKeys), not a backend token.
+func (p listObjectsParams) startKey() string {
 	if p.continuationToken != "" {
 		return p.continuationToken
 	}
@@ -126,10 +128,10 @@ func listObjects(ctx context.Context, strg s2.Storage, p listObjectsParams) ([]s
 		// Recursive: List already does string-prefix matching, so an
 		// arbitrary S3 prefix (e.g. "im" matching "images/a.png") works as-is.
 		res, err := strg.List(ctx, s2.ListOptions{
-			Prefix:    p.prefix,
-			After:     p.after(),
-			Limit:     fetchLimit,
-			Recursive: true,
+			Prefix:     p.prefix,
+			StartAfter: p.startKey(),
+			Limit:      fetchLimit,
+			Recursive:  true,
 		})
 		if err != nil {
 			return nil, nil, err
@@ -142,9 +144,9 @@ func listObjects(ctx context.Context, strg s2.Storage, p listObjectsParams) ([]s
 	// directory portion and filter the entries by the remaining basename.
 	listDir, baseFilter := splitS3Prefix(p.prefix)
 	res, err := strg.List(ctx, s2.ListOptions{
-		Prefix: listDir,
-		After:  p.after(),
-		Limit:  fetchLimit,
+		Prefix:     listDir,
+		StartAfter: p.startKey(),
+		Limit:      fetchLimit,
 	})
 	if err != nil {
 		return nil, nil, err

--- a/server/handlers/s3api/objects_test.go
+++ b/server/handlers/s3api/objects_test.go
@@ -257,6 +257,42 @@ func (s *ObjectsTestSuite) TestListObjects() {
 
 // --- ListObjects pagination ---
 
+// startKeyStorage records the ListOptions the handler passes.
+type startKeyStorage struct {
+	s2.Storage
+	opts s2.ListOptions
+}
+
+func (t *startKeyStorage) List(_ context.Context, opts s2.ListOptions) (s2.ListResult, error) {
+	t.opts = opts
+	return s2.ListResult{}, nil
+}
+
+// TestListObjectsResumesWithStartAfter pins that the caller's resume key goes
+// into StartAfter: After is reserved for a token a backend handed out.
+func (s *ObjectsTestSuite) TestListObjectsResumesWithStartAfter() {
+	testCases := []struct {
+		caseName string
+		params   listObjectsParams
+		want     string
+	}{
+		{"continuation token", listObjectsParams{continuationToken: "a.txt", maxKeys: 10}, "a.txt"},
+		{"start after", listObjectsParams{startAfter: "b.txt", maxKeys: 10}, "b.txt"},
+		{"continuation token wins", listObjectsParams{continuationToken: "a.txt", startAfter: "b.txt", maxKeys: 10}, "a.txt"},
+		{"delimited", listObjectsParams{delimiter: "/", startAfter: "b.txt", maxKeys: 10}, "b.txt"},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			strg := &startKeyStorage{}
+
+			_, _, err := listObjects(context.Background(), strg, tc.params)
+			s.Require().NoError(err)
+			s.Empty(strg.opts.After)
+			s.Equal(tc.want, strg.opts.StartAfter)
+		})
+	}
+}
+
 func (s *ObjectsTestSuite) TestListObjects_Pagination() {
 	s.putObject("pg", "a.txt", "1")
 	s.putObject("pg", "b.txt", "2")

--- a/storage.go
+++ b/storage.go
@@ -21,9 +21,15 @@ type ListOptions struct {
 	Prefix string
 	// After is an opaque continuation token returned by a previous call as
 	// ListResult.NextAfter; pass it to fetch the next page. Empty for the
-	// first page.
+	// first page. Its encoding is backend-specific: never construct one or
+	// carry one across storages. After wins over StartAfter.
 	After string
-	// Limit caps the number of returned Objects. Zero means no limit.
+	// StartAfter is a key name picked by the caller, existing or not; the
+	// listing resumes at the first entry sorting after it. Ignored when
+	// After is set.
+	StartAfter string
+	// Limit caps the number of returned entries. Backends may count
+	// CommonPrefixes toward it, as S3's max-keys does. Zero means no limit.
 	Limit int
 	// Recursive, when true, walks subdirectories and returns no
 	// CommonPrefixes; when false, the listing stops at the first "/" past

--- a/utils.go
+++ b/utils.go
@@ -3,6 +3,8 @@ package s2
 import (
 	"fmt"
 	"math"
+	"path"
+	"strings"
 )
 
 // MustInt64 converts a uint64 to int64, panicking if the value exceeds math.MaxInt64.
@@ -19,4 +21,25 @@ func MustUint64(v int64) uint64 {
 		panic(fmt.Sprintf("numconv: int64 value %d is negative", v))
 	}
 	return uint64(v)
+}
+
+// Key joins a storage prefix and an object name.
+func Key(prefix, name string) string {
+	if prefix == "" {
+		return name
+	}
+	return path.Join(prefix, name)
+}
+
+// RelName is the inverse of Key: it strips the storage prefix, leaving a name
+// that does not carry it untouched.
+func RelName(prefix, name string) string {
+	if prefix == "" {
+		return name
+	}
+	dir := path.Clean(prefix) + "/"
+	if !strings.HasPrefix(name, dir) {
+		return name
+	}
+	return name[len(dir):]
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -86,3 +86,48 @@ func TestMustUint64Panic(t *testing.T) {
 		})
 	}
 }
+
+func TestKey(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		prefix   string
+		name     string
+		want     string
+	}{
+		{"no prefix", "", "a.txt", "a.txt"},
+		{"no prefix keeps the trailing slash", "", "dir/", "dir/"},
+		{"with prefix", "data", "a.txt", "data/a.txt"},
+		{"prefix with a trailing slash", "data/", "a.txt", "data/a.txt"},
+		{"nested prefix", "data/sub", "a.txt", "data/sub/a.txt"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			if got := Key(tc.prefix, tc.name); got != tc.want {
+				t.Errorf("Key(%q, %q) = %q, want %q", tc.prefix, tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRelName(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		prefix   string
+		name     string
+		want     string
+	}{
+		{"no prefix", "", "a.txt", "a.txt"},
+		{"strips the prefix", "data", "data/a.txt", "a.txt"},
+		{"prefix with a trailing slash", "data/", "data/a.txt", "a.txt"},
+		{"unnormalized prefix", "data//sub", "data/sub/a.txt", "a.txt"},
+		{"name without the prefix is untouched", "data", "data2/a.txt", "data2/a.txt"},
+		{"name equal to the prefix is untouched", "data", "data", "data"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			if got := RelName(tc.prefix, tc.name); got != tc.want {
+				t.Errorf("RelName(%q, %q) = %q, want %q", tc.prefix, tc.name, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `ListOptions.After` was documented as an opaque continuation token but also used for S3's `start-after`, and each backend implemented whichever meaning suited it. The two are now separate fields: `After` is only ever a value a previous `List` returned as `NextAfter`, `StartAfter` is a key name the caller picks, and `After` wins when both are set -- matching S3's precedence of `ContinuationToken` over `StartAfter`.
- Backend mapping: `s3` sends `ContinuationToken`/`StartAfter`; `gcs` uses the SDK's page token (one s2 page is one SDK page) and `StartOffset`; `azblob` keeps the marker and emulates `StartAfter` by paging from the start, which costs one request per page skipped; `fs` compares keys for both.
- The s3api handler no longer funnels `start-after` through `After`. Its own continuation token is a key (`applyMaxKeys` returns the page's last key), so it goes into `StartAfter`.
- `StartAfter` no longer drops the common prefix that *contains* it: `start-after=dir/c1.txt` with `delimiter=/` still returns `dir/`, since keys under it can sort after the cursor.
- `CommonPrefixes` are now relative to the storage prefix, as object names already were. A `Sub` storage leaked its own prefix into every prefix it returned.
- The `s3` backend's list prefix keeps the trailing separator `path.Join` drops, so a bucket named `data` no longer pulls in `data2/` keys on a recursive listing.
- `s2.Key`/`s2.RelName` replace the copies of the same prefix arithmetic in three backends.
- `s2test.TestStorageListPaging` writes its own fixture and covers both resume paths; the three integration suites now call it, which is the first list coverage they have had.

## Breaking change
`s2.Storage` implementations outside this repository still compile but silently ignore `StartAfter`, so an S3 client following continuation tokens loops over page 1. The new `s2test` coverage catches it.

## Non-goals
- Paging an azblob-backed bucket rescans from the start on every request, because the handler resumes with a key rather than a marker. Marked with a TODO rather than redesigned here.
- `max-keys` still ignores `CommonPrefixes`, as before this PR.

## Test plan
- [x] `go vet ./...` and `go test ./...` (root + every submodule)
- [x] Each fix verified red first: reverted in a scratch copy, confirmed the new test fails, restored
- [x] `-tags integtest` against real S3 and GCS
- [x] `-tags integtest` for the `s3` suite against a local `s2-server` (its own S3 API over `osfs`), including a red run with the old `After` -> `StartAfter` mapping
- [x] CI passes (`golangci-lint` cannot be run locally -- unrelated Go 1.27 toolchain panic, also present on `main`)

Closes #203.
