### PR TITLE
fix(s3api): Align DeleteObjects, ListObjects and multipart with S3's request limits

### DIFF
--- a/server/handlers/s3api/multipart.go
+++ b/server/handlers/s3api/multipart.go
@@ -5,13 +5,10 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"encoding/hex"
-	"encoding/xml"
-	"errors"
 	"fmt"
 	"hash"
 	"io"
 	"net/http"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -85,7 +82,7 @@ func handleUploadPart(s *server.Server, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	partNumber, err := strconv.Atoi(partNumberStr)
-	if err != nil || partNumber < 1 || partNumber > 10000 {
+	if err != nil || partNumber < 1 || partNumber > maxUploadParts {
 		writeError(w, r, "InvalidArgument", "Part number must be between 1 and 10000", http.StatusBadRequest)
 		return
 	}
@@ -133,14 +130,7 @@ func handleCompleteMultipartUpload(s *server.Server, w http.ResponseWriter, r *h
 	}
 
 	var req CompleteMultipartUploadRequest
-	r.Body = http.MaxBytesReader(w, r.Body, maxXMLRequestBody)
-	if err := xml.NewDecoder(r.Body).Decode(&req); err != nil {
-		var maxErr *http.MaxBytesError
-		if errors.As(err, &maxErr) {
-			writeError(w, r, "EntityTooLarge", fmt.Sprintf("Your proposed upload exceeds the maximum allowed size (%d bytes)", maxXMLRequestBody), http.StatusRequestEntityTooLarge)
-			return
-		}
-		writeError(w, r, "MalformedXML", "The XML you provided was not well-formed", http.StatusBadRequest)
+	if !decodeXMLBody(w, r, &req) {
 		return
 	}
 
@@ -151,9 +141,18 @@ func handleCompleteMultipartUpload(s *server.Server, w http.ResponseWriter, r *h
 		return
 	}
 
-	sort.Slice(req.Parts, func(i, j int) bool {
-		return req.Parts[i].PartNumber < req.Parts[j].PartNumber
-	})
+	// S3 rejects an unordered parts list rather than sorting it; sorting also
+	// hides a repeated part number, which assembles that part many times over.
+	for i, p := range req.Parts {
+		if p.PartNumber < 1 || p.PartNumber > maxUploadParts {
+			writeError(w, r, "InvalidArgument", "Part number must be between 1 and 10000", http.StatusBadRequest)
+			return
+		}
+		if i > 0 && p.PartNumber <= req.Parts[i-1].PartNumber {
+			writeError(w, r, "InvalidPartOrder", "The list of parts was not in ascending order. Parts list must be specified in order by part number.", http.StatusBadRequest)
+			return
+		}
+	}
 
 	// Stat each part once up front: verify existence and compute the total
 	// length required by NewObjectReader. We intentionally do NOT read part

--- a/server/handlers/s3api/multipart_test.go
+++ b/server/handlers/s3api/multipart_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -70,6 +71,77 @@ func (s *MultipartTestSuite) TestCreateMultipartUpload() {
 			s.Equal(tc.wantErrCode, errResp.Code)
 		})
 	}
+}
+
+func (s *MultipartTestSuite) TestCompleteMultipartUploadRejects() {
+	// Upload a real part so these cases fail on validation, not on a missing part.
+	s.createBucket("cmp")
+	createReq := httptest.NewRequest("POST", "/cmp/o.txt?uploads", nil)
+	createReq.SetPathValue("bucket", "cmp")
+	createReq.SetPathValue("key", "o.txt")
+	createW := httptest.NewRecorder()
+	handleCreateMultipartUpload(s.server, createW, createReq)
+	s.Require().Equal(http.StatusOK, createW.Code)
+
+	var created InitiateMultipartUploadResult
+	s.Require().NoError(xml.Unmarshal(createW.Body.Bytes(), &created))
+
+	partReq := httptest.NewRequest("PUT", "/cmp/o.txt?partNumber=1&uploadId="+created.UploadID, strings.NewReader("hello"))
+	partReq.SetPathValue("bucket", "cmp")
+	partReq.SetPathValue("key", "o.txt")
+	partReq.ContentLength = 5
+	partW := httptest.NewRecorder()
+	handleUploadPart(s.server, partW, partReq)
+	s.Require().Equal(http.StatusOK, partW.Code)
+
+	part := func(n string) string {
+		return "<Part><PartNumber>" + n + "</PartNumber><ETag>x</ETag></Part>"
+	}
+	testCases := []struct {
+		caseName string
+		parts    string
+		wantCode string
+	}{
+		{caseName: "duplicate part number", parts: part("1") + part("1"), wantCode: "InvalidPartOrder"},
+		{caseName: "descending order", parts: part("2") + part("1"), wantCode: "InvalidPartOrder"},
+		{caseName: "part number zero", parts: part("0"), wantCode: "InvalidArgument"},
+		{caseName: "part number above the ceiling", parts: part("10001"), wantCode: "InvalidArgument"},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			body := "<CompleteMultipartUpload>" + tc.parts + "</CompleteMultipartUpload>"
+			req := httptest.NewRequest("POST", "/cmp/o.txt?uploadId="+created.UploadID, strings.NewReader(body))
+			req.SetPathValue("bucket", "cmp")
+			req.SetPathValue("key", "o.txt")
+			w := httptest.NewRecorder()
+			handleCompleteMultipartUpload(s.server, w, req)
+
+			s.Equal(http.StatusBadRequest, w.Code)
+			var errResp ErrorResponse
+			s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &errResp))
+			s.Equal(tc.wantCode, errResp.Code)
+		})
+	}
+
+	s.Run("body over the cap", func() {
+		var b strings.Builder
+		b.WriteString("<CompleteMultipartUpload>")
+		for b.Len() < 12<<20 { // ~12 MiB, over maxXMLRequestBody (8 MiB)
+			b.WriteString(part("1"))
+		}
+		b.WriteString("</CompleteMultipartUpload>")
+
+		req := httptest.NewRequest("POST", "/cmp/o.txt?uploadId="+created.UploadID, strings.NewReader(b.String()))
+		req.SetPathValue("bucket", "cmp")
+		req.SetPathValue("key", "o.txt")
+		w := httptest.NewRecorder()
+		handleCompleteMultipartUpload(s.server, w, req)
+
+		s.Equal(http.StatusBadRequest, w.Code)
+		var errResp ErrorResponse
+		s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &errResp))
+		s.Equal("MaxMessageLengthExceeded", errResp.Code)
+	})
 }
 
 func TestPartsReader(t *testing.T) {

--- a/server/handlers/s3api/objects.go
+++ b/server/handlers/s3api/objects.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"crypto/md5" // #nosec G501 -- MD5 is required for S3-compatible ETag
 	"encoding/hex"
-	"encoding/xml"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -629,14 +627,7 @@ func handleDeleteObjects(s *server.Server, w http.ResponseWriter, r *http.Reques
 	bucketName := r.PathValue("bucket")
 
 	var req DeleteObjectsRequest
-	r.Body = http.MaxBytesReader(w, r.Body, maxXMLRequestBody)
-	if err := xml.NewDecoder(r.Body).Decode(&req); err != nil {
-		var maxErr *http.MaxBytesError
-		if errors.As(err, &maxErr) {
-			writeError(w, r, "EntityTooLarge", fmt.Sprintf("Your proposed upload exceeds the maximum allowed size (%d bytes)", maxXMLRequestBody), http.StatusRequestEntityTooLarge)
-			return
-		}
-		writeError(w, r, "MalformedXML", "The XML you provided was not well-formed", http.StatusBadRequest)
+	if !decodeXMLBody(w, r, &req) {
 		return
 	}
 	if len(req.Objects) > maxObjectKeys {

--- a/server/handlers/s3api/objects.go
+++ b/server/handlers/s3api/objects.go
@@ -25,7 +25,10 @@ const (
 	etagMetadataKey        = server.EtagMetadataKey
 	contentTypeMetadataKey = server.ContentTypeMetadataKey
 	defaultContentType     = server.DefaultContentType
-	defaultMaxKeys         = 1000
+
+	// maxObjectKeys is S3's per-request key ceiling: ListObjects' default
+	// (and maximum) max-keys, and DeleteObjects' <Object> limit.
+	maxObjectKeys = 1000
 )
 
 // resolveContentType returns r's Content-Type header, or defaultContentType
@@ -100,7 +103,7 @@ func (p listObjectsParams) startKey() string {
 	return p.startAfter
 }
 
-func parseListObjectsParams(r *http.Request) listObjectsParams {
+func parseListObjectsParams(r *http.Request) (listObjectsParams, error) {
 	query := r.URL.Query()
 	p := listObjectsParams{
 		bucketName:        r.PathValue("bucket"),
@@ -108,14 +111,18 @@ func parseListObjectsParams(r *http.Request) listObjectsParams {
 		delimiter:         query.Get("delimiter"),
 		continuationToken: query.Get("continuation-token"),
 		startAfter:        query.Get("start-after"),
-		maxKeys:           defaultMaxKeys,
+		maxKeys:           maxObjectKeys,
 	}
 	if v := query.Get("max-keys"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
-			p.maxKeys = n
+		// bitSize 32: Atoi would accept up to int64 on a 64-bit build.
+		n, err := strconv.ParseInt(v, 10, 32)
+		if err != nil || n < 0 {
+			return p, fmt.Errorf("max-keys must be an integer between 0 and 2147483647, got %q", v)
 		}
+		// S3 caps max-keys rather than rejecting an over-large one.
+		p.maxKeys = min(int(n), maxObjectKeys)
 	}
-	return p
+	return p, nil
 }
 
 // listObjects fetches objects (and common prefixes for delimited requests)
@@ -209,7 +216,11 @@ func buildListBucketResult(p listObjectsParams, objs []s2.Object, prefixes []str
 
 func handleListObjects(s *server.Server, w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	p := parseListObjectsParams(r)
+	p, err := parseListObjectsParams(r)
+	if err != nil {
+		writeError(w, r, "InvalidArgument", err.Error(), http.StatusBadRequest)
+		return
+	}
 
 	strg, err := s.Buckets.Get(ctx, p.bucketName)
 	if err != nil {
@@ -626,6 +637,10 @@ func handleDeleteObjects(s *server.Server, w http.ResponseWriter, r *http.Reques
 			return
 		}
 		writeError(w, r, "MalformedXML", "The XML you provided was not well-formed", http.StatusBadRequest)
+		return
+	}
+	if len(req.Objects) > maxObjectKeys {
+		writeError(w, r, "MalformedXML", fmt.Sprintf("The XML you provided was not well-formed: a request may contain at most %d keys", maxObjectKeys), http.StatusBadRequest)
 		return
 	}
 

--- a/server/handlers/s3api/objects_test.go
+++ b/server/handlers/s3api/objects_test.go
@@ -44,7 +44,7 @@ func (s *ObjectsTestSuite) TestListObjects() {
 		s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &result))
 		s.Equal("b", result.Name)
 		s.Equal("/", result.Delimiter)
-		s.Equal(defaultMaxKeys, result.MaxKeys)
+		s.Equal(maxObjectKeys, result.MaxKeys)
 		s.False(result.IsTruncated)
 		s.Len(result.Contents, 1)
 		s.Equal("file.txt", result.Contents[0].Key)
@@ -359,15 +359,42 @@ func (s *ObjectsTestSuite) TestListObjects_Pagination() {
 		s.Empty(result.Contents)
 	})
 
-	s.Run("invalid max-keys uses default", func() {
-		req := httptest.NewRequest("GET", "/pg?max-keys=abc", nil)
+	s.Run("max-keys above the limit is clamped", func() {
+		req := httptest.NewRequest("GET", "/pg?max-keys=100000", nil)
 		req.SetPathValue("bucket", "pg")
 		w := httptest.NewRecorder()
 		handleListObjects(s.server, w, req)
 
+		s.Equal(http.StatusOK, w.Code)
 		var result ListBucketResult
 		s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &result))
-		s.Equal(defaultMaxKeys, result.MaxKeys)
+		s.Equal(maxObjectKeys, result.MaxKeys)
+	})
+
+	s.Run("invalid max-keys is rejected", func() {
+		testCases := []struct {
+			caseName string
+			maxKeys  string
+		}{
+			{caseName: "non-numeric", maxKeys: "abc"},
+			{caseName: "negative", maxKeys: "-1"},
+			{caseName: "float", maxKeys: "1.5"},
+			{caseName: "above int32", maxKeys: "2147483648"},
+			{caseName: "above int64", maxKeys: "99999999999999999999"},
+		}
+		for _, tc := range testCases {
+			s.Run(tc.caseName, func() {
+				req := httptest.NewRequest("GET", "/pg?max-keys="+tc.maxKeys, nil)
+				req.SetPathValue("bucket", "pg")
+				w := httptest.NewRecorder()
+				handleListObjects(s.server, w, req)
+
+				s.Equal(http.StatusBadRequest, w.Code)
+				var errResp ErrorResponse
+				s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &errResp))
+				s.Equal("InvalidArgument", errResp.Code)
+			})
+		}
 	})
 
 	s.Run("delimiter with start-after", func() {
@@ -1339,6 +1366,52 @@ func (s *ObjectsTestSuite) TestDeleteObjects() {
 		s.Len(result.Deleted, 1)
 		s.Equal("ghost.txt", result.Deleted[0].Key)
 		s.Empty(result.Errors)
+	})
+
+	s.Run("at the 1000-key limit", func() {
+		s.createBucket("dl")
+
+		var sb strings.Builder
+		sb.WriteString("<Delete>")
+		for i := range 1000 {
+			fmt.Fprintf(&sb, "<Object><Key>k%d.txt</Key></Object>", i)
+		}
+		sb.WriteString("</Delete>")
+
+		req := httptest.NewRequest("POST", "/dl?delete", strings.NewReader(sb.String()))
+		req.SetPathValue("bucket", "dl")
+		w := httptest.NewRecorder()
+		handleDeleteObjects(s.server, w, req)
+
+		s.Equal(http.StatusOK, w.Code)
+	})
+
+	s.Run("more than 1000 keys is rejected", func() {
+		s.createBucket("dx")
+		s.putObject("dx", "k0.txt", "data")
+
+		var sb strings.Builder
+		sb.WriteString("<Delete>")
+		for i := range 1001 {
+			fmt.Fprintf(&sb, "<Object><Key>k%d.txt</Key></Object>", i)
+		}
+		sb.WriteString("</Delete>")
+
+		req := httptest.NewRequest("POST", "/dx?delete", strings.NewReader(sb.String()))
+		req.SetPathValue("bucket", "dx")
+		w := httptest.NewRecorder()
+		handleDeleteObjects(s.server, w, req)
+
+		s.Equal(http.StatusBadRequest, w.Code)
+		s.Contains(w.Body.String(), "MalformedXML")
+
+		// Rejected before any key is deleted.
+		getReq := httptest.NewRequest("GET", "/dx/k0.txt", nil)
+		getReq.SetPathValue("bucket", "dx")
+		getReq.SetPathValue("key", "k0.txt")
+		getW := httptest.NewRecorder()
+		handleGetObject(s.server, getW, getReq)
+		s.Equal(http.StatusOK, getW.Code)
 	})
 
 	s.Run("nonexistent bucket", func() {

--- a/server/handlers/s3api/objects_test.go
+++ b/server/handlers/s3api/objects_test.go
@@ -1486,12 +1486,10 @@ func (s *ObjectsTestSuite) TestDeleteObjects() {
 		s.Len(result.Deleted, 1)
 	})
 
-	s.Run("oversized body is rejected with EntityTooLarge", func() {
-		// A DeleteObjects body is parsed with a streaming xml.Decoder, which
-		// would otherwise grow req.Objects until the process runs out of
-		// memory. MaxBytesReader must reject a body over the cap, and the
-		// handler must surface that as 413 EntityTooLarge (not MalformedXML),
-		// matching S3's behavior for this failure mode.
+	s.Run("oversized body is rejected", func() {
+		// An uncapped xml.Decoder would grow req.Objects until the process runs
+		// out of memory. S3's code for an over-large body is
+		// MaxMessageLengthExceeded, not MalformedXML.
 		s.createBucket("bomb")
 
 		var b strings.Builder
@@ -1507,10 +1505,10 @@ func (s *ObjectsTestSuite) TestDeleteObjects() {
 		w := httptest.NewRecorder()
 		handleDeleteObjects(s.server, w, req)
 
-		s.Equal(http.StatusRequestEntityTooLarge, w.Code)
+		s.Equal(http.StatusBadRequest, w.Code)
 		var errResp ErrorResponse
 		s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &errResp))
-		s.Equal("EntityTooLarge", errResp.Code)
+		s.Equal("MaxMessageLengthExceeded", errResp.Code)
 	})
 
 	s.Run("small body under the cap still works", func() {

--- a/server/handlers/s3api/utils.go
+++ b/server/handlers/s3api/utils.go
@@ -2,6 +2,7 @@ package s3api
 
 import (
 	"bufio"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
@@ -25,7 +26,25 @@ const (
 	// few MiB is generous, while an uncapped xml.Decoder would let a client grow
 	// the decoded slice until the process runs out of memory.
 	maxXMLRequestBody = 8 << 20 // 8 MiB
+
+	maxUploadParts = 10000 // S3's per-upload part ceiling
 )
+
+// decodeXMLBody decodes a capped XML request body, writing the S3 error
+// response itself on failure. It reports whether v was decoded.
+func decodeXMLBody(w http.ResponseWriter, r *http.Request, v any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxXMLRequestBody)
+	if err := xml.NewDecoder(r.Body).Decode(v); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeError(w, r, "MaxMessageLengthExceeded", fmt.Sprintf("Your request was too big (maximum %d bytes)", maxXMLRequestBody), http.StatusBadRequest)
+			return false
+		}
+		writeError(w, r, "MalformedXML", "The XML you provided was not well-formed", http.StatusBadRequest)
+		return false
+	}
+	return true
+}
 
 func writeXML(w http.ResponseWriter, status int, v interface{}) {
 	server.WriteXML(w, status, v)


### PR DESCRIPTION
## Summary
- `DeleteObjects` decoded the request body and looped over every `<Object>` entry without checking the count. #190 capped the body at 8 MiB, but a body within that cap still holds ~290,000 small entries, each driving a backend `Delete` and an entry in the response. The handler now rejects more than 1000 keys with `MalformedXML`, before the bucket lookup and before any key is deleted.
- `max-keys` is now clamped to 1000 rather than honoured as given, so `max-keys=100000` returns one page plus a continuation token instead of a single huge response. A value that is not an integer in `[0, 2147483647]` is `InvalidArgument`/400, where it previously fell back to the default -- `strconv.ParseInt(v, 10, 32)` rather than `Atoi`, which accepts up to int64 on a 64-bit build and made the outcome depend on `GOARCH`.
- `defaultMaxKeys` becomes `maxObjectKeys`, shared by both limits above. It caps the `max-keys` parameter and DeleteObjects' `<Object>` count -- not the number of entries a listing returns, which `CommonPrefixes` can still exceed.
- An oversized XML body now answers `MaxMessageLengthExceeded`/400 ("Your request was too big"), not `EntityTooLarge`/413. S3 documents `EntityTooLarge` as 400 and has no 413 in its error list at all, and that code is defined in terms of object size, not request size. My review comment on #190 asked for 413; it was wrong. MinIO and Ceph RGW both map `EntityTooLarge` to 400 as well. `PutObject` keeps `EntityTooLarge`/400 -- there the limit really is the object's size.
- `CompleteMultipartUpload` sorted the parts list instead of validating it. Sorting silently accepts a repeated part number, which assembles that part once per entry: one 1 KiB part repeated 500 times produced a 512,000-byte object, and at the body cap (~215,000 entries) with 5 GiB parts that is petabyte-scale writes from a single request. The list is now required to be strictly ascending (`InvalidPartOrder`) with each part number in `[1, 10000]` (`InvalidArgument`).
- The identical cap-and-decode block in both XML handlers moves to `decodeXMLBody`, which is also where the `CompleteMultipartUpload` half of #190 gets its first test.

## Breaking change
A client that sent an unordered parts list to `CompleteMultipartUpload` now gets `InvalidPartOrder`/400 where it used to succeed. This matches S3, which rejects rather than sorts, and the AWS SDKs send parts in order.

## Test plan
- [x] `go vet ./...` and `go test ./...` (root + every submodule)
- [x] Every new test verified red first, in a throwaway `git worktree` at `HEAD`: restoring the silent sort fails all four part-list cases, and restoring `EntityTooLarge`/413 fails both oversized-body cases
- [x] The intermediate commit builds and tests clean on its own
- [x] CI passes (`golangci-lint` cannot be run locally -- unrelated Go 1.27 toolchain panic, also present on `main`)

Closes #195.
