### PR TITLE
fix(s3api): Capture Content-Type and x-amz-meta-* on multipart upload

### DIFF
--- a/server/handlers/s3api/multipart.go
+++ b/server/handlers/s3api/multipart.go
@@ -32,8 +32,13 @@ func filterMultipart(objs []s2.Object) []s2.Object {
 	return out
 }
 
+// uploadPrefix is the key prefix holding one upload's parts.
+func uploadPrefix(uploadID string) string {
+	return multipartPrefix + uploadID + "/"
+}
+
 func partKey(uploadID string, partNumber int) string {
-	return fmt.Sprintf("%s%s/%05d", multipartPrefix, uploadID, partNumber)
+	return fmt.Sprintf("%s%05d", uploadPrefix(uploadID), partNumber)
 }
 
 // newUploadID generates a 16-byte upload ID: 4 bytes of elapsed seconds
@@ -218,7 +223,7 @@ func handleAbortMultipartUpload(s *server.Server, w http.ResponseWriter, r *http
 		return
 	}
 
-	_ = strg.DeleteRecursive(ctx, multipartPrefix+uploadID+"/")
+	_ = strg.DeleteRecursive(ctx, uploadPrefix(uploadID))
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/server/handlers/s3api/multipart.go
+++ b/server/handlers/s3api/multipart.go
@@ -264,9 +264,12 @@ func handleCompleteMultipartUpload(s *server.Server, w http.ResponseWriter, r *h
 		return
 	}
 
-	// Drop the whole tree: deleting the listed parts one by one left the
-	// manifest and any unlisted part behind.
-	_ = strg.DeleteRecursive(ctx, uploadPrefix(uploadID))
+	// By key, not DeleteRecursive: the fs backend walks the whole bucket
+	// for that. A part uploaded but not listed here stays behind (#202).
+	for _, p := range req.Parts {
+		_ = strg.Delete(ctx, partKey(uploadID, p.PartNumber))
+	}
+	_ = strg.Delete(ctx, manifestKey(uploadID))
 
 	writeXML(w, http.StatusOK, CompleteMultipartUploadResult{
 		Location: "/" + bucketName + "/" + key,

--- a/server/handlers/s3api/multipart.go
+++ b/server/handlers/s3api/multipart.go
@@ -6,10 +6,10 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
-	"maps"
 	"net/http"
 	"strconv"
 	"strings"
@@ -49,18 +49,21 @@ func manifestKey(uploadID string) string {
 	return uploadPrefix(uploadID) + "manifest"
 }
 
-// uploadMetadata returns the metadata CreateMultipartUpload recorded. An
-// upload initiated before manifests existed has none, and falls back to
-// the default Content-Type rather than failing.
-func uploadMetadata(ctx context.Context, strg s2.Storage, uploadID string) s2.Metadata {
-	md := make(s2.Metadata)
-	if obj, err := strg.Get(ctx, manifestKey(uploadID)); err == nil {
-		maps.Copy(md, obj.Metadata())
+// uploadMetadata returns what CreateMultipartUpload recorded. A missing
+// manifest yields an empty map; any other read failure is returned.
+func uploadMetadata(ctx context.Context, strg s2.Storage, uploadID string) (s2.Metadata, error) {
+	obj, err := strg.Get(ctx, manifestKey(uploadID))
+	if errors.Is(err, s2.ErrNotExist) {
+		return make(s2.Metadata), nil
 	}
-	if _, ok := md.Get(contentTypeMetadataKey); !ok {
-		md[contentTypeMetadataKey] = defaultContentType
+	if err != nil {
+		return nil, err
 	}
-	return md
+	md := obj.Metadata().Clone()
+	if md == nil {
+		md = make(s2.Metadata)
+	}
+	return md, nil
 }
 
 // newUploadID generates a 16-byte upload ID: 4 bytes of elapsed seconds
@@ -223,7 +226,12 @@ func handleCompleteMultipartUpload(s *server.Server, w http.ResponseWriter, r *h
 
 	// This request carries no headers of its own; they were recorded at
 	// initiate time.
-	md := uploadMetadata(ctx, strg, uploadID)
+	md, err := uploadMetadata(ctx, strg, uploadID)
+	if err != nil {
+		code, msg, status := s2ErrorToS3Error(err)
+		writeError(w, r, code, msg, status)
+		return
+	}
 
 	// Stream all parts through a single reader, tee-ing each part into its own
 	// MD5 hash as it flows by. This avoids buffering the assembled object in

--- a/server/handlers/s3api/multipart.go
+++ b/server/handlers/s3api/multipart.go
@@ -104,7 +104,14 @@ func handleCreateMultipartUpload(s *server.Server, w http.ResponseWriter, r *htt
 	// S3 takes the object's headers from the initiate request. Record them
 	// on the manifest's own metadata, which Put persists in the same call.
 	md := parseMetadataHeaders(r)
-	md[contentTypeMetadataKey] = resolveContentType(r)
+	// The store below is conditional, so x-amz-meta-s2-content-type would
+	// otherwise reach the reserved key it shares a namespace with (#192).
+	dropInternalMetadata(md)
+	// An absent Content-Type stays unstored: GetObject answers with the
+	// default either way, and the console can still guess from the key.
+	if ct := requestContentType(r); ct != "" {
+		md[contentTypeMetadataKey] = ct
+	}
 	if err := strg.Put(ctx, s2.NewObjectBytes(manifestKey(uploadID), nil, s2.WithMetadata(md))); err != nil {
 		code, msg, status := s2ErrorToS3Error(err)
 		writeError(w, r, code, msg, status)

--- a/server/handlers/s3api/multipart.go
+++ b/server/handlers/s3api/multipart.go
@@ -1,6 +1,7 @@
 package s3api
 
 import (
+	"context"
 	"crypto/md5" // #nosec G501 -- MD5 is required for S3-compatible multipart ETag
 	"crypto/rand"
 	"encoding/binary"
@@ -8,6 +9,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"maps"
 	"net/http"
 	"strconv"
 	"strings"
@@ -32,13 +34,33 @@ func filterMultipart(objs []s2.Object) []s2.Object {
 	return out
 }
 
-// uploadPrefix is the key prefix holding one upload's parts.
+// uploadPrefix is the key prefix holding one upload's parts and manifest.
 func uploadPrefix(uploadID string) string {
 	return multipartPrefix + uploadID + "/"
 }
 
 func partKey(uploadID string, partNumber int) string {
 	return fmt.Sprintf("%s%05d", uploadPrefix(uploadID), partNumber)
+}
+
+// manifestKey names the zero-length object whose metadata carries the
+// initiate request's headers. Part keys are digits, so it cannot collide.
+func manifestKey(uploadID string) string {
+	return uploadPrefix(uploadID) + "manifest"
+}
+
+// uploadMetadata returns the metadata CreateMultipartUpload recorded. An
+// upload initiated before manifests existed has none, and falls back to
+// the default Content-Type rather than failing.
+func uploadMetadata(ctx context.Context, strg s2.Storage, uploadID string) s2.Metadata {
+	md := make(s2.Metadata)
+	if obj, err := strg.Get(ctx, manifestKey(uploadID)); err == nil {
+		maps.Copy(md, obj.Metadata())
+	}
+	if _, ok := md.Get(contentTypeMetadataKey); !ok {
+		md[contentTypeMetadataKey] = defaultContentType
+	}
+	return md
 }
 
 // newUploadID generates a 16-byte upload ID: 4 bytes of elapsed seconds
@@ -57,7 +79,8 @@ func handleCreateMultipartUpload(s *server.Server, w http.ResponseWriter, r *htt
 	bucketName := r.PathValue("bucket")
 	key := r.PathValue("key")
 
-	if _, err := s.Buckets.Get(ctx, bucketName); err != nil {
+	strg, err := s.Buckets.Get(ctx, bucketName)
+	if err != nil {
 		code, msg, status := s2ErrorToS3Error(err)
 		writeError(w, r, code, msg, status)
 		return
@@ -66,6 +89,16 @@ func handleCreateMultipartUpload(s *server.Server, w http.ResponseWriter, r *htt
 	uploadID, err := newUploadID(s.StartedAt)
 	if err != nil {
 		writeError(w, r, "InternalError", "Failed to generate upload ID", http.StatusInternalServerError)
+		return
+	}
+
+	// S3 takes the object's headers from the initiate request. Record them
+	// on the manifest's own metadata, which Put persists in the same call.
+	md := parseMetadataHeaders(r)
+	md[contentTypeMetadataKey] = resolveContentType(r)
+	if err := strg.Put(ctx, s2.NewObjectBytes(manifestKey(uploadID), nil, s2.WithMetadata(md))); err != nil {
+		code, msg, status := s2ErrorToS3Error(err)
+		writeError(w, r, code, msg, status)
 		return
 	}
 
@@ -174,6 +207,10 @@ func handleCompleteMultipartUpload(s *server.Server, w http.ResponseWriter, r *h
 		totalLen += obj.Length()
 	}
 
+	// This request carries no headers of its own; they were recorded at
+	// initiate time.
+	md := uploadMetadata(ctx, strg, uploadID)
+
 	// Stream all parts through a single reader, tee-ing each part into its own
 	// MD5 hash as it flows by. This avoids buffering the assembled object in
 	// memory — critical for the memfs backend, and a peak-memory win for all
@@ -181,7 +218,7 @@ func handleCompleteMultipartUpload(s *server.Server, w http.ResponseWriter, r *h
 	// + "-" + partCount; we collect the per-part MD5s after Put has drained
 	// the reader.
 	pr := &partsReader{parts: partObjs}
-	finalObj := s2.NewObjectReader(key, pr, totalLen)
+	finalObj := s2.NewObjectReader(key, pr, totalLen, s2.WithMetadata(md))
 	if err := strg.Put(ctx, finalObj); err != nil {
 		_ = pr.Close()
 		code, msg, status := s2ErrorToS3Error(err)
@@ -191,12 +228,16 @@ func handleCompleteMultipartUpload(s *server.Server, w http.ResponseWriter, r *h
 
 	combined := md5.Sum(pr.partMD5s) // #nosec G401 -- MD5 is required for S3-compatible multipart ETag
 	etag := `"` + hex.EncodeToString(combined[:]) + `-` + strconv.Itoa(len(req.Parts)) + `"`
-	_ = strg.PutMetadata(ctx, key, s2.Metadata{etagMetadataKey: etag})
-
-	// Clean up part objects
-	for _, p := range req.Parts {
-		_ = strg.Delete(ctx, partKey(uploadID, p.PartNumber))
+	md[etagMetadataKey] = etag
+	if err := strg.PutMetadata(ctx, key, md); err != nil {
+		code, msg, status := s2ErrorToS3Error(err)
+		writeError(w, r, code, msg, status)
+		return
 	}
+
+	// Drop the whole tree: deleting the listed parts one by one left the
+	// manifest and any unlisted part behind.
+	_ = strg.DeleteRecursive(ctx, uploadPrefix(uploadID))
 
 	writeXML(w, http.StatusOK, CompleteMultipartUploadResult{
 		Location: "/" + bucketName + "/" + key,

--- a/server/handlers/s3api/multipart.go
+++ b/server/handlers/s3api/multipart.go
@@ -74,6 +74,12 @@ func newUploadID(started time.Time) (string, error) {
 	return hex.EncodeToString(b), nil
 }
 
+// validUploadID reports whether id could have come from newUploadID.
+func validUploadID(id string) bool {
+	b, err := hex.DecodeString(id)
+	return err == nil && len(b) == 16
+}
+
 func handleCreateMultipartUpload(s *server.Server, w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	bucketName := r.PathValue("bucket")
@@ -117,6 +123,10 @@ func handleUploadPart(s *server.Server, w http.ResponseWriter, r *http.Request) 
 	partNumberStr := r.URL.Query().Get("partNumber")
 	if uploadID == "" || partNumberStr == "" {
 		writeError(w, r, "InvalidArgument", "Missing uploadId or partNumber", http.StatusBadRequest)
+		return
+	}
+	if !validUploadID(uploadID) {
+		writeError(w, r, "NoSuchUpload", "The specified upload does not exist", http.StatusNotFound)
 		return
 	}
 	partNumber, err := strconv.Atoi(partNumberStr)
@@ -164,6 +174,10 @@ func handleCompleteMultipartUpload(s *server.Server, w http.ResponseWriter, r *h
 	uploadID := r.URL.Query().Get("uploadId")
 	if uploadID == "" {
 		writeError(w, r, "InvalidArgument", "Missing uploadId", http.StatusBadRequest)
+		return
+	}
+	if !validUploadID(uploadID) {
+		writeError(w, r, "NoSuchUpload", "The specified upload does not exist", http.StatusNotFound)
 		return
 	}
 
@@ -254,6 +268,10 @@ func handleAbortMultipartUpload(s *server.Server, w http.ResponseWriter, r *http
 	uploadID := r.URL.Query().Get("uploadId")
 	if uploadID == "" {
 		writeError(w, r, "InvalidArgument", "Missing uploadId", http.StatusBadRequest)
+		return
+	}
+	if !validUploadID(uploadID) {
+		writeError(w, r, "NoSuchUpload", "The specified upload does not exist", http.StatusNotFound)
 		return
 	}
 

--- a/server/handlers/s3api/multipart_test.go
+++ b/server/handlers/s3api/multipart_test.go
@@ -223,6 +223,44 @@ func (s *MultipartTestSuite) storage(bucket string) s2.Storage {
 	return strg
 }
 
+// smuggledInternalKeys sends every reserved key as an x-amz-meta-* header.
+func smuggledInternalKeys() http.Header {
+	h := http.Header{}
+	for k := range server.InternalMetadataKeys {
+		h.Set(metaHeaderPrefix+k, "smuggled")
+	}
+	return h
+}
+
+// An absent Content-Type stays unstored so the console can still guess.
+func (s *MultipartTestSuite) TestCreateMultipartUploadLeavesAbsentContentTypeUnstored() {
+	testCases := []struct {
+		caseName string
+		headers  http.Header
+	}{
+		{caseName: "no header"},
+		{caseName: "whitespace-only header", headers: http.Header{"Content-Type": {"   "}}},
+		{
+			// Derived from the reserved set, so a key added to it is
+			// covered here rather than silently going untested.
+			caseName: "reserved keys smuggled through x-amz-meta-*",
+			headers:  smuggledInternalKeys(),
+		},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			s.createBucket("mp-noct")
+			uploadID := s.initiateUpload("mp-noct", "movie.mp4", tc.headers)
+
+			obj, err := s.storage("mp-noct").Get(context.Background(), manifestKey(uploadID))
+			s.Require().NoError(err)
+			for k := range server.InternalMetadataKeys {
+				s.NotContains(obj.Metadata(), k)
+			}
+		})
+	}
+}
+
 // failingStorage fails every Get; uploadMetadata calls nothing else.
 type failingStorage struct {
 	s2.Storage

--- a/server/handlers/s3api/multipart_test.go
+++ b/server/handlers/s3api/multipart_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/mojatter/s2"
+	"github.com/mojatter/s2/server"
 )
 
 type MultipartTestSuite struct{ s3apiSuite }
@@ -218,6 +220,36 @@ func (s *MultipartTestSuite) storage(bucket string) s2.Storage {
 	strg, err := s.server.Buckets.Get(context.Background(), bucket)
 	s.Require().NoError(err)
 	return strg
+}
+
+// An uploadId s2 never issued must not reach the storage layer as a key.
+func (s *MultipartTestSuite) TestMalformedUploadID() {
+	testCases := []struct {
+		caseName string
+		method   string
+		handler  func(*server.Server, http.ResponseWriter, *http.Request)
+	}{
+		{caseName: "upload part", method: "PUT", handler: handleUploadPart},
+		{caseName: "complete", method: "POST", handler: handleCompleteMultipartUpload},
+		{caseName: "abort", method: "DELETE", handler: handleAbortMultipartUpload},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			s.createBucket("mp-bad")
+			target := "/mp-bad/o.txt?partNumber=1&uploadId=" + url.QueryEscape("../evil")
+			req := httptest.NewRequest(tc.method, target, strings.NewReader(""))
+			req.SetPathValue("bucket", "mp-bad")
+			req.SetPathValue("key", "o.txt")
+			w := httptest.NewRecorder()
+			tc.handler(s.server, w, req)
+
+			s.Equal(http.StatusNotFound, w.Code)
+			s.NotContains(w.Body.String(), multipartPrefix)
+			var errResp ErrorResponse
+			s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &errResp))
+			s.Equal("NoSuchUpload", errResp.Code)
+		})
+	}
 }
 
 func (s *MultipartTestSuite) TestCreateMultipartUploadRecordsMetadata() {

--- a/server/handlers/s3api/multipart_test.go
+++ b/server/handlers/s3api/multipart_test.go
@@ -420,24 +420,18 @@ func (s *MultipartTestSuite) TestCompleteMultipartUploadWithoutManifest() {
 	s.Equal(defaultContentType, w.Header().Get("Content-Type"))
 }
 
-// Complete used to delete only the parts it was given (#202).
-func (s *MultipartTestSuite) TestCompleteMultipartUploadClearsTheUploadTree() {
+// Complete removes what it consumed: the listed parts and the manifest.
+func (s *MultipartTestSuite) TestCompleteMultipartUploadRemovesPartsAndManifest() {
 	const bucket, key = "mp-cleanup", "file.bin"
 	s.createBucket(bucket)
 
 	uploadID := s.initiateUpload(bucket, key, nil)
 	s.uploadPart(bucket, key, uploadID, 1, "hello")
-	s.uploadPart(bucket, key, uploadID, 2, "orphan")
 	s.completeUpload(bucket, key, uploadID, 1)
 
 	ctx := context.Background()
 	strg := s.storage(bucket)
-	for _, name := range []string{
-		manifestKey(uploadID),
-		partKey(uploadID, 1),
-		partKey(uploadID, 2),
-		multipartPrefix + uploadID,
-	} {
+	for _, name := range []string{manifestKey(uploadID), partKey(uploadID, 1)} {
 		exists, err := strg.Exists(ctx, name)
 		s.Require().NoError(err)
 		s.Falsef(exists, "%s should have been removed", name)

--- a/server/handlers/s3api/multipart_test.go
+++ b/server/handlers/s3api/multipart_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/md5" // #nosec G501 -- MD5 is used here only to mirror S3 multipart ETag semantics under test.
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -220,6 +221,46 @@ func (s *MultipartTestSuite) storage(bucket string) s2.Storage {
 	strg, err := s.server.Buckets.Get(context.Background(), bucket)
 	s.Require().NoError(err)
 	return strg
+}
+
+// failingStorage fails every Get; uploadMetadata calls nothing else.
+type failingStorage struct {
+	s2.Storage
+	err error
+}
+
+func (f failingStorage) Get(context.Context, string) (s2.Object, error) { return nil, f.err }
+
+func (s *MultipartTestSuite) TestUploadMetadata() {
+	testCases := []struct {
+		caseName string
+		err      error
+		wantErr  bool
+	}{
+		{
+			caseName: "a missing manifest is not an error",
+			err:      fmt.Errorf("%w: manifest", s2.ErrNotExist),
+		},
+		{
+			// Completing anyway would silently drop the caller's metadata.
+			caseName: "any other read failure is surfaced",
+			err:      errors.New("backend unavailable"),
+			wantErr:  true,
+		},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			md, err := uploadMetadata(context.Background(), failingStorage{err: tc.err}, "x")
+
+			if tc.wantErr {
+				s.Require().ErrorIs(err, tc.err)
+				s.Nil(md)
+				return
+			}
+			s.Require().NoError(err)
+			s.Empty(md)
+		})
+	}
 }
 
 // An uploadId s2 never issued must not reach the storage layer as a key.

--- a/server/handlers/s3api/multipart_test.go
+++ b/server/handlers/s3api/multipart_test.go
@@ -1,8 +1,10 @@
 package s3api
 
 import (
+	"context"
 	"crypto/md5" // #nosec G501 -- MD5 is used here only to mirror S3 multipart ETag semantics under test.
 	"encoding/xml"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -142,6 +144,193 @@ func (s *MultipartTestSuite) TestCompleteMultipartUploadRejects() {
 		s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &errResp))
 		s.Equal("MaxMessageLengthExceeded", errResp.Code)
 	})
+}
+
+// initiateUpload returns the upload ID for a create request carrying headers.
+func (s *MultipartTestSuite) initiateUpload(bucket, key string, headers http.Header) string {
+	s.T().Helper()
+
+	req := httptest.NewRequest("POST", "/"+bucket+"/"+key+"?uploads", nil)
+	req.SetPathValue("bucket", bucket)
+	req.SetPathValue("key", key)
+	for name, values := range headers {
+		req.Header[name] = values
+	}
+	w := httptest.NewRecorder()
+	handleCreateMultipartUpload(s.server, w, req)
+	s.Require().Equal(http.StatusOK, w.Code)
+
+	var created InitiateMultipartUploadResult
+	s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &created))
+	s.Require().NotEmpty(created.UploadID)
+	return created.UploadID
+}
+
+func (s *MultipartTestSuite) uploadPart(bucket, key, uploadID string, partNumber int, body string) {
+	s.T().Helper()
+
+	target := fmt.Sprintf("/%s/%s?partNumber=%d&uploadId=%s", bucket, key, partNumber, uploadID)
+	req := httptest.NewRequest("PUT", target, strings.NewReader(body))
+	req.SetPathValue("bucket", bucket)
+	req.SetPathValue("key", key)
+	req.ContentLength = int64(len(body))
+	w := httptest.NewRecorder()
+	handleUploadPart(s.server, w, req)
+	s.Require().Equal(http.StatusOK, w.Code)
+}
+
+// completeUpload assembles partNumbers into the final object.
+func (s *MultipartTestSuite) completeUpload(bucket, key, uploadID string, partNumbers ...int) {
+	s.T().Helper()
+
+	var body strings.Builder
+	body.WriteString("<CompleteMultipartUpload>")
+	for _, n := range partNumbers {
+		fmt.Fprintf(&body, "<Part><PartNumber>%d</PartNumber><ETag>x</ETag></Part>", n)
+	}
+	body.WriteString("</CompleteMultipartUpload>")
+
+	req := httptest.NewRequest("POST", "/"+bucket+"/"+key+"?uploadId="+uploadID, strings.NewReader(body.String()))
+	req.SetPathValue("bucket", bucket)
+	req.SetPathValue("key", key)
+	w := httptest.NewRecorder()
+	handleCompleteMultipartUpload(s.server, w, req)
+	s.Require().Equal(http.StatusOK, w.Code, w.Body.String())
+}
+
+// getObject reads the object back through the handler that has to surface
+// the recorded metadata.
+func (s *MultipartTestSuite) getObject(bucket, key string) *httptest.ResponseRecorder {
+	s.T().Helper()
+
+	req := httptest.NewRequest("GET", "/"+bucket+"/"+key, nil)
+	req.SetPathValue("bucket", bucket)
+	req.SetPathValue("key", key)
+	w := httptest.NewRecorder()
+	handleGetObject(s.server, w, req)
+	s.Require().Equal(http.StatusOK, w.Code)
+	return w
+}
+
+func (s *MultipartTestSuite) storage(bucket string) s2.Storage {
+	s.T().Helper()
+
+	strg, err := s.server.Buckets.Get(context.Background(), bucket)
+	s.Require().NoError(err)
+	return strg
+}
+
+func (s *MultipartTestSuite) TestCreateMultipartUploadRecordsMetadata() {
+	s.createBucket("mp-manifest")
+	uploadID := s.initiateUpload("mp-manifest", "file.bin", http.Header{
+		"Content-Type":      {"video/mp4"},
+		"X-Amz-Meta-Author": {"uz"},
+	})
+
+	obj, err := s.storage("mp-manifest").Get(context.Background(), manifestKey(uploadID))
+	s.Require().NoError(err)
+	s.Equal("video/mp4", obj.Metadata()[contentTypeMetadataKey])
+	s.Equal("uz", obj.Metadata()["author"])
+	s.Zero(obj.Length())
+}
+
+func (s *MultipartTestSuite) TestCompleteMultipartUploadCarriesInitiateMetadata() {
+	testCases := []struct {
+		caseName        string
+		headers         http.Header
+		wantContentType string
+		wantMeta        map[string]string
+	}{
+		{
+			caseName: "content type and user metadata",
+			headers: http.Header{
+				"Content-Type":      {"video/mp4"},
+				"X-Amz-Meta-Author": {"uz"},
+				"X-Amz-Meta-Origin": {"camera"},
+			},
+			wantContentType: "video/mp4",
+			wantMeta:        map[string]string{"author": "uz", "origin": "camera"},
+		},
+		{
+			caseName:        "no content type falls back to the default",
+			wantContentType: defaultContentType,
+		},
+		{
+			caseName:        "whitespace-only content type falls back to the default",
+			headers:         http.Header{"Content-Type": {"   "}},
+			wantContentType: defaultContentType,
+		},
+		{
+			caseName:        "user metadata without a content type",
+			headers:         http.Header{"X-Amz-Meta-Author": {"uz"}},
+			wantContentType: defaultContentType,
+			wantMeta:        map[string]string{"author": "uz"},
+		},
+	}
+	for i, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			// A key per row: rows must not read each other's object.
+			bucket, key := "mp-meta", fmt.Sprintf("movie-%d.bin", i)
+			s.createBucket(bucket)
+
+			uploadID := s.initiateUpload(bucket, key, tc.headers)
+			s.uploadPart(bucket, key, uploadID, 1, "hello ")
+			s.uploadPart(bucket, key, uploadID, 2, "world")
+			s.completeUpload(bucket, key, uploadID, 1, 2)
+
+			w := s.getObject(bucket, key)
+			s.Equal("hello world", w.Body.String())
+			s.Equal(tc.wantContentType, w.Header().Get("Content-Type"))
+			for name, want := range tc.wantMeta {
+				s.Equal(want, w.Header().Get("x-amz-meta-"+name))
+			}
+			// The ETag survives alongside the recorded metadata.
+			s.Regexp(`^"[0-9a-f]{32}-2"$`, w.Header().Get("ETag"))
+			// s2's own bookkeeping keys must not leak as user metadata.
+			s.Empty(w.Header().Get("x-amz-meta-" + contentTypeMetadataKey))
+			s.Empty(w.Header().Get("x-amz-meta-" + etagMetadataKey))
+		})
+	}
+}
+
+// An upload in flight across a server upgrade has no manifest.
+func (s *MultipartTestSuite) TestCompleteMultipartUploadWithoutManifest() {
+	const bucket, key = "mp-nomanifest", "file.bin"
+	s.createBucket(bucket)
+
+	uploadID := s.initiateUpload(bucket, key, http.Header{"Content-Type": {"video/mp4"}})
+	s.uploadPart(bucket, key, uploadID, 1, "hello")
+	s.Require().NoError(s.storage(bucket).Delete(context.Background(), manifestKey(uploadID)))
+
+	s.completeUpload(bucket, key, uploadID, 1)
+
+	w := s.getObject(bucket, key)
+	s.Equal("hello", w.Body.String())
+	s.Equal(defaultContentType, w.Header().Get("Content-Type"))
+}
+
+// Complete used to delete only the parts it was given (#202).
+func (s *MultipartTestSuite) TestCompleteMultipartUploadClearsTheUploadTree() {
+	const bucket, key = "mp-cleanup", "file.bin"
+	s.createBucket(bucket)
+
+	uploadID := s.initiateUpload(bucket, key, nil)
+	s.uploadPart(bucket, key, uploadID, 1, "hello")
+	s.uploadPart(bucket, key, uploadID, 2, "orphan")
+	s.completeUpload(bucket, key, uploadID, 1)
+
+	ctx := context.Background()
+	strg := s.storage(bucket)
+	for _, name := range []string{
+		manifestKey(uploadID),
+		partKey(uploadID, 1),
+		partKey(uploadID, 2),
+		multipartPrefix + uploadID,
+	} {
+		exists, err := strg.Exists(ctx, name)
+		s.Require().NoError(err)
+		s.Falsef(exists, "%s should have been removed", name)
+	}
 }
 
 func TestPartsReader(t *testing.T) {

--- a/server/handlers/s3api/objects.go
+++ b/server/handlers/s3api/objects.go
@@ -29,12 +29,16 @@ const (
 	maxObjectKeys = 1000
 )
 
-// resolveContentType returns r's Content-Type header, or defaultContentType
-// if the request didn't send one -- or sent only whitespace, which some
-// HTTP client libraries emit for "no MIME type resolved" and which would
-// otherwise round-trip as a blank Content-Type instead of the default.
+// requestContentType returns r's Content-Type, or "" if it sent none -- or
+// only whitespace, which some HTTP clients emit for "no MIME type resolved".
+func requestContentType(r *http.Request) string {
+	return strings.TrimSpace(r.Header.Get("Content-Type"))
+}
+
+// resolveContentType returns r's Content-Type, or defaultContentType if the
+// request didn't send a usable one.
 func resolveContentType(r *http.Request) string {
-	if ct := strings.TrimSpace(r.Header.Get("Content-Type")); ct != "" {
+	if ct := requestContentType(r); ct != "" {
 		return ct
 	}
 	return defaultContentType
@@ -494,6 +498,14 @@ func parseMetadataHeaders(r *http.Request) s2.Metadata {
 		}
 	}
 	return md
+}
+
+// dropInternalMetadata removes s2's own bookkeeping keys from metadata a
+// client supplied, so x-amz-meta-* cannot reach them (#192).
+func dropInternalMetadata(md s2.Metadata) {
+	for k := range server.InternalMetadataKeys {
+		delete(md, k)
+	}
 }
 
 func handleCopyObject(s *server.Server, w http.ResponseWriter, r *http.Request, copySource string) {


### PR DESCRIPTION
## Summary
- `CreateMultipartUpload` now records the request's `Content-Type` and `x-amz-meta-*` headers, which S3 takes from the initiate request and `CompleteMultipartUpload` never sees. They are stored on a zero-length manifest object at `__s2mp__/<uploadId>/manifest`, in the manifest's own metadata rather than its body: `Put` persists an object's metadata in the same call, so the record lands atomically and needs nothing of the backends that storing any other object does not.
- `CompleteMultipartUpload` reads the manifest back and passes it in `WithMetadata` on the final `Put`, then adds the multipart ETag with `PutMetadata`, the same two-step shape `CopyObject` uses. A missing manifest -- an upload initiated before this change -- completes as before; any other read failure is an error, because completing anyway would silently drop the caller's metadata. Previously `PutMetadata`'s result was discarded, so a failure meant 200 with no ETag stored; it is now a 5xx with the parts kept so the client can retry or abort. The assembled object stays at its key without an ETag; removing it was tried and dropped, because on an overwrite it would destroy the new body after `Put` had already replaced the old one.
- An absent `Content-Type` is left unstored rather than filled with `binary/octet-stream`. `GetObject` answers with the default either way, as S3 does, but the Web Console guesses from the key's extension only when nothing is stored, so a multipart-uploaded `report.pdf` previews inline. Because the store became conditional, the initiate handler drops `s2-content-type` and `s2-etag` from the parsed `x-amz-meta-*` set; a client could otherwise plant the reserved key. This is the narrow guard this change requires, not a fix for #192.
- `uploadId` is validated as 16 hex-encoded bytes -- the only shape `newUploadID` produces -- on `UploadPart`, `CompleteMultipartUpload` and `AbortMultipartUpload`, answering `NoSuchUpload`/404 otherwise. Without it `?uploadId=../evil` reached the fs backend as a key and the resulting `InternalError` quoted `__s2mp__/../evil/00001` back to the client.
- Complete deletes the listed parts and the manifest by key. A version that dropped the whole `__s2mp__/<uploadId>/` tree with `DeleteRecursive` was tried and reverted: the fs backend walks the entire bucket for that call (#207).

## Behavior changes
- A malformed `uploadId` now gets `NoSuchUpload`/404 where it previously produced a 500 or, on the fs backend, a leaked internal path.
- A `PutMetadata` failure during Complete is now visible as an error instead of a 200 with a missing ETag. The parts are kept so the client can retry Complete or abort; the object at the key has its Content-Type and user metadata but no ETag until a retry succeeds. Folding the ETag into the single `Put` so this window disappears is #208.

## Test plan
- [x] `go vet ./...` and `go test ./...` in the root and every submodule
- [x] Every new test verified red first in a throwaway `git worktree`: the manifest tests against `main`, the malformed-ID test against the handler without the guard (reproducing the leaked `__s2mp__/../evil/00001` path), and the read-failure test against the swallowing version of `uploadMetadata`
- [x] The unstored-`Content-Type` choice measured end to end: `GetObject` answers `binary/octet-stream` for a header-less `movie.mp4` / `report.pdf`, the console's resolver answers `video/mp4` / `application/pdf`
- [x] Each commit builds and tests clean on its own
- [x] CI passes (`golangci-lint` cannot be run locally -- unrelated Go 1.27 toolchain panic, also present on `main`)

## Related
- #202: the manifest is written at initiate, so the abandoned-upload state #202 describes now appears before the first `UploadPart`. #212 proposes moving in-progress multipart state out of the bucket entirely; it would also remove the pre-existing `__s2mp__/` common prefix in delimited listings, which this change does not address.
- #192 (reserved-key collision, see the initiate guard above), #207, #208, #210.

Closes #191.
