### PR TITLE
fix(s3api): Drive ListObjects paging with the backend's continuation token

### DIFF
--- a/server/handlers/s3api/objects.go
+++ b/server/handlers/s3api/objects.go
@@ -27,6 +27,10 @@ const (
 	// maxObjectKeys is S3's per-request key ceiling: ListObjects' default
 	// (and maximum) max-keys, and DeleteObjects' <Object> limit.
 	maxObjectKeys = 1000
+
+	// maxListFetches bounds the work one ListObjects request may do while
+	// refilling a page. Stopping early yields a short page with a token.
+	maxListFetches = 8
 )
 
 // requestContentType returns r's Content-Type, or "" if it sent none -- or
@@ -95,16 +99,6 @@ type listObjectsParams struct {
 	maxKeys           int
 }
 
-// startKey returns the key the listing resumes after: continuation-token wins
-// over start-after. Both are key names -- the token this handler hands out is
-// the last key of the page (see applyMaxKeys), not a backend token.
-func (p listObjectsParams) startKey() string {
-	if p.continuationToken != "" {
-		return p.continuationToken
-	}
-	return p.startAfter
-}
-
 func parseListObjectsParams(r *http.Request) (listObjectsParams, error) {
 	query := r.URL.Query()
 	p := listObjectsParams{
@@ -127,58 +121,108 @@ func parseListObjectsParams(r *http.Request) (listObjectsParams, error) {
 	return p, nil
 }
 
-// listObjects fetches objects (and common prefixes for delimited requests)
-// from storage according to params.
-func listObjects(ctx context.Context, strg s2.Storage, p listObjectsParams) ([]s2.Object, []string, error) {
-	// Fetch extra to detect truncation (+1) and account for hidden .keep files (+1)
-	fetchLimit := p.maxKeys + 2
+// renderPrefix is a common prefix as S3 shows it, delimiter included.
+func renderPrefix(prefix, delimiter string) string {
+	if delimiter == "" || strings.HasSuffix(prefix, delimiter) {
+		return prefix
+	}
+	return prefix + delimiter
+}
 
-	if p.delimiter == "" {
-		// Recursive: List already does string-prefix matching, so an
-		// arbitrary S3 prefix (e.g. "im" matching "images/a.png") works as-is.
-		res, err := strg.List(ctx, s2.ListOptions{
-			Prefix:     p.prefix,
-			StartAfter: p.startKey(),
-			Limit:      fetchLimit,
-			Recursive:  true,
-		})
-		if err != nil {
-			return nil, nil, err
-		}
-		return res.Objects, nil, nil
+// pastRange reports whether name sorts beyond every key the basename filter
+// can still match.
+func pastRange(name, rangeEnd string) bool {
+	return name > rangeEnd && !strings.HasPrefix(name, rangeEnd)
+}
+
+// listObjects collects one page, refilling it from the backend when hidden
+// entries thin a fetch out. The token returned is the backend's own
+// NextAfter: only the backend knows how to resume itself (#215).
+func listObjects(ctx context.Context, strg s2.Storage, p listObjectsParams) (objs []s2.Object, prefixes []string, nextToken string, err error) {
+	// S3 answers max-keys=0 with an empty, untruncated page, whatever the
+	// request resumes from -- echoing the token back would never terminate.
+	if p.maxKeys == 0 {
+		return nil, nil, "", nil
 	}
 
 	// Delimited: S3 prefixes are arbitrary strings, but storage.List has
 	// directory semantics. Split the prefix at the last "/" so we list the
 	// directory portion and filter the entries by the remaining basename.
 	listDir, baseFilter := splitS3Prefix(p.prefix)
-	res, err := strg.List(ctx, s2.ListOptions{
-		Prefix:     listDir,
-		StartAfter: p.startKey(),
-		Limit:      fetchLimit,
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-	objs := res.Objects
-	prefixes := res.CommonPrefixes
-	if baseFilter != "" {
-		objs = filterObjectsByBasename(objs, listDir, baseFilter)
-		prefixes = filterPrefixesByBasename(prefixes, listDir, baseFilter)
-	}
-	return objs, prefixes, nil
-}
 
-// applyMaxKeys clips objs to maxKeys, returning the cursor for the next page
-// when the input was truncated.
-func applyMaxKeys(objs []s2.Object, maxKeys int) (out []s2.Object, nextToken string, isTruncated bool) {
-	if maxKeys == 0 {
-		return nil, "", false
+	after := p.continuationToken
+	seen := make(map[string]struct{})
+	visible := 0
+	for fetches := 0; visible < p.maxKeys && fetches < maxListFetches; fetches++ {
+		opts := s2.ListOptions{
+			Prefix:     listDir,
+			After:      after,
+			StartAfter: p.startAfter,
+			Limit:      max(1, p.maxKeys-visible),
+			Recursive:  p.delimiter == "",
+		}
+		if opts.Recursive {
+			// List already does string-prefix matching, so an arbitrary S3
+			// prefix (e.g. "im" matching "images/a.png") works as-is.
+			opts.Prefix = p.prefix
+		}
+		res, err := strg.List(ctx, opts)
+		if err != nil {
+			return nil, nil, "", err
+		}
+		if res.NextAfter != "" && res.NextAfter == after {
+			return nil, nil, "", fmt.Errorf("storage returned a list token that does not advance: %q", after)
+		}
+
+		// Read the raw page's bounds before the basename filters, which
+		// compact their input in place.
+		lastObj, lastPrefix := "", ""
+		if n := len(res.Objects); n > 0 {
+			lastObj = res.Objects[n-1].Name()
+		}
+		if n := len(res.CommonPrefixes); n > 0 {
+			lastPrefix = res.CommonPrefixes[n-1]
+		}
+
+		pageObjs := filterMultipart(server.FilterKeep(res.Objects))
+		pagePrefixes := res.CommonPrefixes
+		if baseFilter != "" {
+			pageObjs = filterObjectsByBasename(pageObjs, listDir, baseFilter)
+			pagePrefixes = filterPrefixesByBasename(pagePrefixes, listDir, baseFilter)
+		}
+		// A backend may repeat a common prefix across fetches: the fs one
+		// returns every directory past the cursor on each call.
+		kept := pagePrefixes[:0]
+		for _, prefix := range pagePrefixes {
+			if _, dup := seen[prefix]; dup {
+				continue
+			}
+			seen[prefix] = struct{}{}
+			kept = append(kept, prefix)
+		}
+		pagePrefixes = kept
+
+		objs = append(objs, pageObjs...)
+		prefixes = append(prefixes, pagePrefixes...)
+		visible += len(pageObjs) + len(pagePrefixes)
+		after = res.NextAfter
+
+		// Nothing past the basename's range can match. Only an object-less
+		// page may be judged by its prefixes, which fs returns unbounded.
+		if baseFilter != "" {
+			rangeEnd := listDir + baseFilter
+			switch {
+			case lastObj != "" && pastRange(lastObj, rangeEnd):
+				after = ""
+			case lastObj == "" && lastPrefix != "" && pastRange(renderPrefix(lastPrefix, "/"), rangeEnd):
+				after = ""
+			}
+		}
+		if after == "" {
+			break
+		}
 	}
-	if len(objs) > maxKeys {
-		return objs[:maxKeys], objs[maxKeys-1].Name(), true
-	}
-	return objs, "", false
+	return objs, prefixes, after, nil
 }
 
 func buildListBucketResult(p listObjectsParams, objs []s2.Object, prefixes []string, nextToken string, isTruncated bool) ListBucketResult {
@@ -194,13 +238,7 @@ func buildListBucketResult(p listObjectsParams, objs []s2.Object, prefixes []str
 	}
 	commonPrefixes := make([]CommonPrefix, 0, len(prefixes))
 	for _, prefix := range prefixes {
-		prefixWithDelimiter := prefix
-		if p.delimiter != "" && prefix[len(prefix)-1] != p.delimiter[0] {
-			prefixWithDelimiter += p.delimiter
-		}
-		commonPrefixes = append(commonPrefixes, CommonPrefix{
-			Prefix: prefixWithDelimiter,
-		})
+		commonPrefixes = append(commonPrefixes, CommonPrefix{Prefix: renderPrefix(prefix, p.delimiter)})
 	}
 	return ListBucketResult{
 		Name:                  p.bucketName,
@@ -231,18 +269,14 @@ func handleListObjects(s *server.Server, w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	objs, prefixes, err := listObjects(ctx, strg, p)
+	objs, prefixes, nextToken, err := listObjects(ctx, strg, p)
 	if err != nil {
 		code, msg, status := s2ErrorToS3Error(err)
 		writeError(w, r, code, msg, status)
 		return
 	}
 
-	objs = server.FilterKeep(objs)
-	objs = filterMultipart(objs)
-	objs, nextToken, isTruncated := applyMaxKeys(objs, p.maxKeys)
-
-	writeXML(w, http.StatusOK, buildListBucketResult(p, objs, prefixes, nextToken, isTruncated))
+	writeXML(w, http.StatusOK, buildListBucketResult(p, objs, prefixes, nextToken, nextToken != ""))
 }
 
 // isFSBackend reports whether storage type typ is one of the filesystem

--- a/server/handlers/s3api/objects_test.go
+++ b/server/handlers/s3api/objects_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"strings"
 	"testing"
@@ -257,38 +258,389 @@ func (s *ObjectsTestSuite) TestListObjects() {
 
 // --- ListObjects pagination ---
 
-// startKeyStorage records the ListOptions the handler passes.
-type startKeyStorage struct {
+// recordingStorage records every ListOptions the handler passes.
+type recordingStorage struct {
 	s2.Storage
-	opts s2.ListOptions
+	calls []s2.ListOptions
 }
 
-func (t *startKeyStorage) List(_ context.Context, opts s2.ListOptions) (s2.ListResult, error) {
-	t.opts = opts
+func (r *recordingStorage) List(_ context.Context, opts s2.ListOptions) (s2.ListResult, error) {
+	r.calls = append(r.calls, opts)
 	return s2.ListResult{}, nil
 }
 
-// TestListObjectsResumesWithStartAfter pins that the caller's resume key goes
-// into StartAfter: After is reserved for a token a backend handed out.
-func (s *ObjectsTestSuite) TestListObjectsResumesWithStartAfter() {
+// The client's continuation token is a backend token and belongs in After;
+// start-after is a key the caller picked and stays in StartAfter (#215).
+func (s *ObjectsTestSuite) TestListObjectsForwardsTokens() {
 	testCases := []struct {
-		caseName string
-		params   listObjectsParams
-		want     string
+		caseName       string
+		params         listObjectsParams
+		wantCalls      int
+		wantAfter      string
+		wantStartAfter string
 	}{
-		{"continuation token", listObjectsParams{continuationToken: "a.txt", maxKeys: 10}, "a.txt"},
-		{"start after", listObjectsParams{startAfter: "b.txt", maxKeys: 10}, "b.txt"},
-		{"continuation token wins", listObjectsParams{continuationToken: "a.txt", startAfter: "b.txt", maxKeys: 10}, "a.txt"},
-		{"delimited", listObjectsParams{delimiter: "/", startAfter: "b.txt", maxKeys: 10}, "b.txt"},
+		{
+			caseName:  "continuation token goes to After",
+			params:    listObjectsParams{continuationToken: "tok", maxKeys: 10},
+			wantCalls: 1,
+			wantAfter: "tok",
+		},
+		{
+			caseName:       "start-after stays a key",
+			params:         listObjectsParams{startAfter: "b.txt", maxKeys: 10},
+			wantCalls:      1,
+			wantStartAfter: "b.txt",
+		},
+		{
+			// The backend decides: the contract says After wins.
+			caseName:       "both are forwarded",
+			params:         listObjectsParams{continuationToken: "tok", startAfter: "b.txt", maxKeys: 10},
+			wantCalls:      1,
+			wantAfter:      "tok",
+			wantStartAfter: "b.txt",
+		},
+		{
+			caseName:  "delimited forwards the same way",
+			params:    listObjectsParams{delimiter: "/", startAfter: "b.txt", maxKeys: 10},
+			wantCalls: 1, wantStartAfter: "b.txt",
+		},
+		{
+			caseName:  "max-keys=0 never reaches the backend",
+			params:    listObjectsParams{maxKeys: 0},
+			wantCalls: 0,
+		},
+		{
+			// Real S3 answers this with an empty, untruncated page; handing
+			// the token back would loop the client forever.
+			caseName:  "max-keys=0 does not echo the token back",
+			params:    listObjectsParams{continuationToken: "tok", maxKeys: 0},
+			wantCalls: 0,
+		},
 	}
 	for _, tc := range testCases {
 		s.Run(tc.caseName, func() {
-			strg := &startKeyStorage{}
+			strg := &recordingStorage{}
 
-			_, _, err := listObjects(context.Background(), strg, tc.params)
+			_, _, next, err := listObjects(context.Background(), strg, tc.params)
 			s.Require().NoError(err)
-			s.Empty(strg.opts.After)
-			s.Equal(tc.want, strg.opts.StartAfter)
+			s.Empty(next)
+			s.Require().Len(strg.calls, tc.wantCalls)
+			if tc.wantCalls == 0 {
+				return
+			}
+			s.Equal(tc.wantAfter, strg.calls[0].After)
+			s.Equal(tc.wantStartAfter, strg.calls[0].StartAfter)
+		})
+	}
+}
+
+// pagedStorage serves entries in S3 key order, objects and "dir/" prefixes
+// interleaved, and hands out a token that is deliberately not a key.
+type pagedStorage struct {
+	s2.Storage
+	entries        []string // sorted; a trailing "/" marks a common prefix
+	cap            int      // entries per page, before Limit
+	emptyFirstPage bool     // answer the first call with 0 entries and a token
+	stall          bool     // echo the caller's token back, never advancing
+	everyPageDirs  []string // prefixes repeated on every page, as fs does
+	calls          []s2.ListOptions
+}
+
+func (t *pagedStorage) List(_ context.Context, opts s2.ListOptions) (s2.ListResult, error) {
+	t.calls = append(t.calls, opts)
+	if t.stall {
+		return s2.ListResult{NextAfter: opts.After}, nil
+	}
+	if t.emptyFirstPage && opts.After == "" {
+		return s2.ListResult{NextAfter: "0"}, nil
+	}
+
+	start := 0
+	if opts.After != "" {
+		n, err := strconv.Atoi(opts.After)
+		if err != nil {
+			return s2.ListResult{}, fmt.Errorf("bad token %q", opts.After)
+		}
+		start = n
+	} else if opts.StartAfter != "" {
+		for start < len(t.entries) && t.entries[start] <= opts.StartAfter {
+			start++
+		}
+	}
+
+	end := min(start+min(t.cap, opts.Limit), len(t.entries))
+	var res s2.ListResult
+	for _, e := range t.entries[start:end] {
+		if strings.HasSuffix(e, "/") {
+			res.CommonPrefixes = append(res.CommonPrefixes, strings.TrimSuffix(e, "/"))
+		} else {
+			res.Objects = append(res.Objects, s2.NewObjectBytes(e, nil))
+		}
+	}
+	res.CommonPrefixes = append(res.CommonPrefixes, t.everyPageDirs...)
+	if end < len(t.entries) {
+		res.NextAfter = strconv.Itoa(end)
+	}
+	return res, nil
+}
+
+func objectNames(objs []s2.Object) []string {
+	names := make([]string, 0, len(objs))
+	for _, o := range objs {
+		names = append(names, o.Name())
+	}
+	return names
+}
+
+// walkPages follows the handler's own token until the listing ends.
+func (s *ObjectsTestSuite) walkPages(strg s2.Storage, p listObjectsParams) (keys, prefixes []string) {
+	s.T().Helper()
+
+	seen := map[string]bool{}
+	for pages := 0; ; pages++ {
+		s.Require().Less(pages, 20, "listing did not terminate")
+		objs, pfx, next, err := listObjects(context.Background(), strg, p)
+		s.Require().NoError(err)
+		for _, o := range objs {
+			keys = append(keys, o.Name())
+		}
+		for _, pf := range pfx {
+			// The fs backend re-sends directories past the cursor on every
+			// page; dedupe across pages so the set can be asserted.
+			if r := renderPrefix(pf, p.delimiter); !seen[r] {
+				seen[r] = true
+				prefixes = append(prefixes, r)
+			}
+		}
+		if next == "" {
+			return keys, prefixes
+		}
+		p.continuationToken = next
+	}
+}
+
+func (s *ObjectsTestSuite) TestListObjectsPagesWithBackendTokens() {
+	testCases := []struct {
+		caseName     string
+		strg         *pagedStorage
+		params       listObjectsParams
+		wantKeys     []string
+		wantPrefixes []string
+		wantCalls    int // 0 = do not assert
+	}{
+		{
+			// The backend hands back fewer entries than asked but says more
+			// follows; counting alone would call the listing complete.
+			caseName: "pages shorter than max-keys",
+			strg:     &pagedStorage{entries: []string{"a", "b", "c", "d", "e", "f", "g"}, cap: 2},
+			params:   listObjectsParams{maxKeys: 3},
+			wantKeys: []string{"a", "b", "c", "d", "e", "f", "g"},
+		},
+		{
+			caseName:     "page ends on a common prefix",
+			strg:         &pagedStorage{entries: []string{"a.txt", "d1/", "d2/", "z.txt"}, cap: 2},
+			params:       listObjectsParams{delimiter: "/", maxKeys: 2},
+			wantKeys:     []string{"a.txt", "z.txt"},
+			wantPrefixes: []string{"d1/", "d2/"},
+		},
+		{
+			// GCS can answer with no entries and a page token.
+			caseName: "empty page with a token",
+			strg:     &pagedStorage{entries: []string{"a", "b"}, cap: 2, emptyFirstPage: true},
+			params:   listObjectsParams{maxKeys: 3},
+			wantKeys: []string{"a", "b"},
+		},
+		{
+			// Everything past "im" is unreachable for this basename, so the
+			// listing must stop rather than page the rest of the bucket.
+			caseName:     "basename filter stops at the end of its range",
+			strg:         &pagedStorage{entries: []string{"im-a", "images/", "imz", "x1", "x2", "x3", "x4", "x5"}, cap: 4},
+			params:       listObjectsParams{prefix: "im", delimiter: "/", maxKeys: 10},
+			wantKeys:     []string{"im-a", "imz"},
+			wantPrefixes: []string{"images/"},
+			wantCalls:    1,
+		},
+		{
+			// A page of nothing but out-of-range prefixes must end it too,
+			// rather than paging the rest of the bucket one window at a time.
+			caseName: "prefixes alone end the range",
+			strg: &pagedStorage{
+				entries: []string{"z01/", "z02/", "z03/", "z04/", "z05/", "z06/", "z07/", "z08/", "z09/", "z10/", "z11/", "z12/"},
+				cap:     4,
+			},
+			params:    listObjectsParams{prefix: "im", delimiter: "/", maxKeys: 10},
+			wantCalls: 1,
+		},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			keys, prefixes := s.walkPages(tc.strg, tc.params)
+
+			s.Equal(tc.wantKeys, keys)
+			s.Equal(tc.wantPrefixes, prefixes)
+			if tc.wantCalls > 0 {
+				s.Len(tc.strg.calls, tc.wantCalls)
+			}
+			for _, c := range tc.strg.calls[1:] {
+				s.NotEmptyf(c.After, "a refill fetch must resume by the backend's token")
+			}
+		})
+	}
+
+	// The fs backend repeats its directories on every fetch, so one page
+	// must not report the same prefix twice.
+	s.Run("a prefix repeated across fetches is listed once", func() {
+		strg := &pagedStorage{entries: []string{"a", "b", "c", "d", "e"}, cap: 2, everyPageDirs: []string{"d1"}}
+
+		objs, prefixes, _, err := listObjects(context.Background(), strg, listObjectsParams{delimiter: "/", maxKeys: 4})
+		s.Require().NoError(err)
+		s.Require().Greater(len(strg.calls), 1, "the case needs more than one fetch to be meaningful")
+		s.Equal([]string{"a", "b", "c"}, objectNames(objs))
+		s.Equal([]string{"d1"}, prefixes)
+	})
+
+	s.Run("a window of only hidden entries ends the fetch loop", func() {
+		var entries []string
+		for i := range 20 {
+			entries = append(entries, fmt.Sprintf("%sx/%05d", multipartPrefix, i))
+		}
+		entries = append(entries, "a.txt")
+		strg := &pagedStorage{entries: entries, cap: 1}
+
+		objs, prefixes, next, err := listObjects(context.Background(), strg, listObjectsParams{maxKeys: 3})
+		s.Require().NoError(err)
+		s.Empty(objs)
+		s.Empty(prefixes)
+		s.NotEmpty(next, "a short page must carry the token that resumes it")
+		s.Len(strg.calls, maxListFetches)
+	})
+
+	s.Run("a token that does not advance is an error", func() {
+		strg := &pagedStorage{entries: []string{"a"}, cap: 1, stall: true}
+
+		_, _, _, err := listObjects(context.Background(), strg, listObjectsParams{continuationToken: "tok", maxKeys: 3})
+		s.Require().Error(err)
+		s.Contains(err.Error(), "does not advance")
+	})
+}
+
+// walkHandler pages a real listing through the HTTP handler, following the
+// token it hands out, and returns every key and prefix it saw.
+func (s *ObjectsTestSuite) walkHandler(bucket, query string) (keys, prefixes []string) {
+	s.T().Helper()
+
+	seenPrefix := map[string]bool{}
+	token := ""
+	for pages := 0; ; pages++ {
+		s.Require().Less(pages, 20, "listing did not terminate")
+		target := "/" + bucket + "?" + query
+		if token != "" {
+			target += "&continuation-token=" + url.QueryEscape(token)
+		}
+		req := httptest.NewRequest("GET", target, nil)
+		req.SetPathValue("bucket", bucket)
+		w := httptest.NewRecorder()
+		handleListObjects(s.server, w, req)
+		s.Require().Equal(http.StatusOK, w.Code, w.Body.String())
+
+		var page ListBucketResult
+		s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &page))
+		for _, c := range page.Contents {
+			keys = append(keys, c.Key)
+		}
+		for _, pf := range page.CommonPrefixes {
+			// The fs backend re-sends directories past the cursor on every
+			// page, so only the set of prefixes is meaningful here.
+			if !seenPrefix[pf.Prefix] {
+				seenPrefix[pf.Prefix] = true
+				prefixes = append(prefixes, pf.Prefix)
+			}
+		}
+		if !page.IsTruncated {
+			return keys, prefixes
+		}
+		s.Require().NotEmpty(page.NextContinuationToken, "a truncated page must carry a token")
+		token = page.NextContinuationToken
+	}
+}
+
+// The listing must reach every object on the real fs backend, whatever the
+// cursor lands on and however many hidden entries share the window (#215).
+func (s *ObjectsTestSuite) TestListObjectsWalksRealFS() {
+	hidden := []string{multipartPrefix + "u1/manifest", multipartPrefix + "u2/manifest"}
+	testCases := []struct {
+		caseName     string
+		objects      []string
+		query        string
+		wantKeys     []string
+		wantPrefixes []string
+	}{
+		{
+			// fs lists directory "report" before the files, but "report/"
+			// sorts after "report-N.pdf": a cursor built from the rendered
+			// prefix skipped every file in between.
+			caseName: "a directory next to similarly named keys",
+			objects: []string{
+				"report/x.pdf", "report (a).pdf",
+				"report-1.pdf", "report-2.pdf", "report-3.pdf", "report-4.pdf",
+				"report-5.pdf", "report-6.pdf", "report-7.pdf", "report-8.pdf", "report-9.pdf",
+			},
+			query: "prefix=report-&delimiter=/&max-keys=3",
+			wantKeys: []string{
+				"report-1.pdf", "report-2.pdf", "report-3.pdf", "report-4.pdf",
+				"report-5.pdf", "report-6.pdf", "report-7.pdf", "report-8.pdf", "report-9.pdf",
+			},
+		},
+		{
+			caseName: "hidden entries share the window",
+			objects:  append([]string{"a.txt", "b.txt", "c.txt", "d.txt", "e.txt"}, hidden...),
+			query:    "max-keys=3",
+			wantKeys: []string{"a.txt", "b.txt", "c.txt", "d.txt", "e.txt"},
+		},
+		{
+			caseName:     "hidden entries share the window, delimited",
+			objects:      append([]string{"a.txt", "b.txt", "c.txt", "d.txt", "e.txt"}, hidden...),
+			query:        "delimiter=/&max-keys=3",
+			wantKeys:     []string{"a.txt", "b.txt", "c.txt", "d.txt", "e.txt"},
+			wantPrefixes: []string{multipartPrefix},
+		},
+		{
+			// The basename filter drops the whole first window; the listing
+			// must keep going rather than report itself complete.
+			caseName:     "basename filter past a full window",
+			objects:      []string{"a1", "a2", "a3", "a4", "a5", "im.txt", "important.txt", "zzz/x"},
+			query:        "prefix=im&delimiter=/&max-keys=1",
+			wantKeys:     []string{"im.txt", "important.txt"},
+			wantPrefixes: nil,
+		},
+		{
+			// Real S3 still reports the folder a start-after key sits in.
+			caseName:     "start-after inside a directory",
+			objects:      []string{"dir/a.txt", "dir/b.txt", "e.txt"},
+			query:        "delimiter=/&start-after=dir/&max-keys=10",
+			wantKeys:     []string{"e.txt"},
+			wantPrefixes: []string{"dir/"},
+		},
+		{
+			// A page landing exactly on max-keys makes the fs backend claim
+			// more follows; the extra empty page must still terminate.
+			caseName: "page boundary on the last object",
+			objects:  []string{"a.txt", "b.txt"},
+			query:    "max-keys=2",
+			wantKeys: []string{"a.txt", "b.txt"},
+		},
+	}
+	for i, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			bucket := fmt.Sprintf("walk%d", i)
+			for _, key := range tc.objects {
+				s.putObject(bucket, key, "x")
+			}
+
+			keys, prefixes := s.walkHandler(bucket, tc.query)
+
+			s.Equal(tc.wantKeys, keys)
+			s.Equal(tc.wantPrefixes, prefixes)
 		})
 	}
 }
@@ -357,6 +709,8 @@ func (s *ObjectsTestSuite) TestListObjects_Pagination() {
 		var result ListBucketResult
 		s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &result))
 		s.Empty(result.Contents)
+		s.Empty(result.CommonPrefixes)
+		s.False(result.IsTruncated)
 	})
 
 	s.Run("max-keys above the limit is clamped", func() {


### PR DESCRIPTION
## Summary
- `ListObjectsV2` derived `IsTruncated` from how many entries survived hidden-key filtering of a `maxKeys + 2` fetch. Two hidden entries in the window (`__s2mp__/`, or a `.keep` per console-created folder) make the count fall short, and the listing ends with `IsTruncated=false` while objects remain (#215). The same check fails on every `s3`/`gcs` bucket over 1000 objects: the backend caps the page at 1000, and 1000 never exceeds `max-keys=1000`.
- The handler now forwards `continuation-token` as `ListOptions.After` and `start-after` as `StartAfter`, and returns the backend's `NextAfter` as `NextContinuationToken` verbatim. It no longer derives a cursor from keys. All four backends implement `After`; azblob's TODO about rescanning from the start on every page no longer applies to continuation pages (only the first page of a `start-after` request still scans from the start -- the comment will be updated when that module is next touched).
- A page is refilled with a bounded loop (`maxListFetches = 8`): fetch `maxKeys - visible`, drop hidden entries, dedupe prefixes a backend repeats across fetches, continue on the token. A token that does not advance is an error. Basename-filtered listings stop once a fetch's last entry sorts past the filter's range.
- `max-keys=0` returns early with no fetch and no token, matching real S3 (verified against a live bucket).

## Behavior changes
- `NextContinuationToken` is an opaque backend token, not a key. A client paginating across the upgrade gets a 500 from the cloud backends for its stale key token; fs accepts it. Worth a release-note line.
- The first page costs one extra backend `List` call when a hidden entry sits in its window (`.keep` at the bucket root does).
- Pages can be shorter than `max-keys`, even empty, with `IsTruncated=true` and a token.
- On fs, a page ending exactly on the last object is followed by one empty final page (`listFlat` sets `NextAfter` on reaching the limit). Pinned by a test; the fix belongs in fs.
- `max-keys=0` no longer returns common prefixes.
- Backend implementors: the handler now relies on `ListResult.NextAfter` alone to detect truncation, as the `ListOptions` contract already requires ("when empty, the listing is exhausted"). An out-of-tree `Storage` that fills `Limit` without setting `NextAfter` will report a complete listing early. `s2test.TestStorageListPaging` checks this; run it against your backend.
- Pre-existing and unchanged: fs re-sends directories past the cursor on every page and does not count them toward `Limit`, so delimited fs listings can repeat a prefix across pages and exceed `MaxKeys`.

## Test plan
- [x] `go vet ./...` and `go test ./...` in the root and every submodule
- [x] Red against `main`: two hidden entries lose `c`…`e`; a `report/` cursor skips `report-1..9.pdf`; `prefix=im` past a full window returns nothing
- [x] Each mechanism verified load-bearing by removing it alone: refill loop, `After` forwarding, non-advancing-token guard, prefix-side range stop, in-page prefix dedupe, `max-keys=0` early return
- [x] CI passes (`golangci-lint` cannot run locally -- Go 1.27 toolchain panic, also on `main`)

## Related
#202, #212 (source of the multipart hidden entries), #211 (widened the trigger to an abandoned initiate). This fix stands on its own: `.keep` per folder and the cloud page cap break the old check with no multipart state at all.

Closes #215.
