### PR TITLE
chore: Bump intra-repo deps to v0.15.0

### DIFF
--- a/azblob/go.mod
+++ b/azblob/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.23.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.1
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0
-	github.com/mojatter/s2 v0.14.0
+	github.com/mojatter/s2 v0.15.0
 	github.com/stretchr/testify v1.12.1
 )
 

--- a/gcs/go.mod
+++ b/gcs/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	cloud.google.com/go/storage v1.66.0
-	github.com/mojatter/s2 v0.14.0
+	github.com/mojatter/s2 v0.15.0
 	github.com/stretchr/testify v1.12.1
 	google.golang.org/api v0.295.0
 )

--- a/s2env/go.mod
+++ b/s2env/go.mod
@@ -3,10 +3,10 @@ module github.com/mojatter/s2/s2env
 go 1.25.8
 
 require (
-	github.com/mojatter/s2 v0.14.0
-	github.com/mojatter/s2/azblob v0.14.0
-	github.com/mojatter/s2/gcs v0.14.0
-	github.com/mojatter/s2/s3 v0.14.0
+	github.com/mojatter/s2 v0.15.0
+	github.com/mojatter/s2/azblob v0.15.0
+	github.com/mojatter/s2/gcs v0.15.0
+	github.com/mojatter/s2/s3 v0.15.0
 	github.com/stretchr/testify v1.12.1
 )
 

--- a/s3/go.mod
+++ b/s3/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.33.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.109.1
 	github.com/aws/smithy-go v1.28.1
-	github.com/mojatter/s2 v0.14.0
+	github.com/mojatter/s2 v0.15.0
 	github.com/stretchr/testify v1.12.1
 )
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.20.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.109.1
 	github.com/chromedp/chromedp v0.16.0
-	github.com/mojatter/s2 v0.14.0
+	github.com/mojatter/s2 v0.15.0
 	github.com/stretchr/testify v1.12.1
 )
 


### PR DESCRIPTION
## Summary
Bumps the intra-repo `require` lines in the five replace-modules (`s3`, `gcs`, `azblob`, `server`, `s2env`) from v0.14.0 to v0.15.0, ahead of tagging the release. `cmd/s2-server` is deliberately left on v0.14.0: it has no `replace` directive, so it can only require v0.15.0 after those tags are published (a separate follow-up PR).

## Test plan
- [x] `go vet ./...` and `go test ./...` in the root and every submodule, under `GOTOOLCHAIN=go1.26.0` (matching `go.work`)
- [x] `GOWORK=off go build` for `cmd/s2-server` (still resolving the published v0.14.0) and `server`
- [x] `GOWORK=off go test -tags integtest -c` for `s3`
- [x] `goreleaser release --snapshot --clean --skip=publish --skip=docker` — the only local check that exercises GoReleaser's workspace-mode Go version gate
- [x] No `go.sum` changes (replace resolves locally)
