### PR TITLE
fix(s3api): Reject CompleteMultipartUpload with an empty parts list

### DIFF
--- a/server/handlers/s3api/multipart.go
+++ b/server/handlers/s3api/multipart.go
@@ -203,6 +203,12 @@ func handleCompleteMultipartUpload(s *server.Server, w http.ResponseWriter, r *h
 		return
 	}
 
+	// An empty list would Put a zero-byte object, truncating the key.
+	if len(req.Parts) == 0 {
+		writeError(w, r, "InvalidRequest", "You must specify at least one part", http.StatusBadRequest)
+		return
+	}
+
 	// S3 rejects an unordered parts list rather than sorting it; sorting also
 	// hides a repeated part number, which assembles that part many times over.
 	for i, p := range req.Parts {

--- a/server/handlers/s3api/multipart_test.go
+++ b/server/handlers/s3api/multipart_test.go
@@ -107,6 +107,7 @@ func (s *MultipartTestSuite) TestCompleteMultipartUploadRejects() {
 		parts    string
 		wantCode string
 	}{
+		{caseName: "empty parts list", parts: "", wantCode: "InvalidRequest"},
 		{caseName: "duplicate part number", parts: part("1") + part("1"), wantCode: "InvalidPartOrder"},
 		{caseName: "descending order", parts: part("2") + part("1"), wantCode: "InvalidPartOrder"},
 		{caseName: "part number zero", parts: part("0"), wantCode: "InvalidArgument"},


### PR DESCRIPTION
## Summary
- `handleCompleteMultipartUpload` validated the order and range of the parts list but never that it had entries. An empty `<CompleteMultipartUpload/>` passed every check, assembled zero parts, and `Put` a zero-byte object at the key with a 200 -- truncating whatever was already there. S3 answers `InvalidRequest` / 400 ("You must specify at least one part").
- The check goes in before the parts loop, so it also closes the one shape in which a well-formed `uploadId` s2 never issued was accepted: with no parts listed, the existing `InvalidPart` check never ran.

## Behavior changes
- A Complete with an empty parts list is now a 400 `InvalidRequest` instead of a 200 that truncates the object. No client that completes a real upload is affected.

## Test plan
- [x] New `empty parts list` row in `TestCompleteMultipartUploadRejects`
- [x] `go test ./...` in the `server` module
- [x] Red against `main`: the new row returns 200 instead of 400
- [x] CI (`golangci-lint` cannot run locally -- Go 1.27 toolchain typecheck failure on `math/rand/v2`, also on `main`)

## Related
First PR of the #212 multipart series for v0.16.0; independent of the rest of it.

Closes #214.
