### PR TITLE
feat(s3api): Move multipart uploads onto the multipart store

### DIFF
--- a/fs/storage.go
+++ b/fs/storage.go
@@ -324,6 +324,13 @@ func (s *storage) DeleteRecursive(ctx context.Context, prefix string) error {
 	dirName := strings.TrimSuffix(prefix, "/")
 	var dirs []string
 	err := fs.WalkDir(s.fsys, ".", func(name string, d fs.DirEntry, err error) error {
+		// A nil entry means the root could not be stat'd; a missing one is a no-op.
+		if d == nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
+			return err
+		}
 		if prefix != "" && !strings.HasPrefix(name, prefix) && name != dirName {
 			return nil
 		}

--- a/fs/storage_test.go
+++ b/fs/storage_test.go
@@ -697,6 +697,44 @@ func (s *StorageTestSuite) TestDeleteRecursive() {
 	}
 }
 
+// A missing root is a no-op, as Delete is on a missing name.
+func (s *StorageTestSuite) TestDeleteRecursiveMissingRoot() {
+	testCases := []struct {
+		caseName string
+		strg     s2.Storage
+	}{
+		{caseName: "osfs", strg: NewStorageDir(s.T().TempDir())},
+		{caseName: "memfs", strg: NewStorageMem(s2.Config{})},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			ctx := context.Background()
+			sub, err := tc.strg.Sub(ctx, "missing")
+			s.Require().NoError(err)
+			s.NoError(sub.DeleteRecursive(ctx, ""))
+		})
+	}
+}
+
+// errStatMemFS is a writable memfs whose root cannot be stat'd.
+type errStatMemFS struct {
+	*memfs.MemFS
+}
+
+func (e *errStatMemFS) Stat(name string) (fs.FileInfo, error) {
+	if name == "." {
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrPermission}
+	}
+	return e.MemFS.Stat(name)
+}
+
+// An unreadable root is reported, not dereferenced.
+func (s *StorageTestSuite) TestDeleteRecursiveUnreadableRoot() {
+	strg := &storage{fsys: &errStatMemFS{memfs.New()}}
+
+	s.ErrorIs(strg.DeleteRecursive(context.Background(), ""), fs.ErrPermission)
+}
+
 func (s *StorageTestSuite) TestSub() {
 	strg := &storage{fsys: s.testMemFS(), typ: s2.TypeMemFS}
 

--- a/server/handlers/s3api/multipart.go
+++ b/server/handlers/s3api/multipart.go
@@ -1,14 +1,12 @@
 package s3api
 
 import (
-	"context"
 	"crypto/md5" // #nosec G501 -- MD5 is required for S3-compatible multipart ETag
 	"crypto/rand"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"hash"
 	"io"
 	"net/http"
 	"strconv"
@@ -20,8 +18,7 @@ import (
 	"github.com/mojatter/s2/server/middleware"
 )
 
-// multipartPrefix is the reserved key prefix used to store in-progress part data.
-// Keys with this prefix are hidden from ListObjects results.
+// multipartPrefix is the pre-v0.16 in-bucket layout, still hidden from listings.
 const multipartPrefix = "__s2mp__/"
 
 func filterMultipart(objs []s2.Object) []s2.Object {
@@ -32,38 +29,6 @@ func filterMultipart(objs []s2.Object) []s2.Object {
 		}
 	}
 	return out
-}
-
-// uploadPrefix is the key prefix holding one upload's parts and manifest.
-func uploadPrefix(uploadID string) string {
-	return multipartPrefix + uploadID + "/"
-}
-
-func partKey(uploadID string, partNumber int) string {
-	return fmt.Sprintf("%s%05d", uploadPrefix(uploadID), partNumber)
-}
-
-// manifestKey names the zero-length object whose metadata carries the
-// initiate request's headers. Part keys are digits, so it cannot collide.
-func manifestKey(uploadID string) string {
-	return uploadPrefix(uploadID) + "manifest"
-}
-
-// uploadMetadata returns what CreateMultipartUpload recorded. A missing
-// manifest yields an empty map; any other read failure is returned.
-func uploadMetadata(ctx context.Context, strg s2.Storage, uploadID string) (s2.Metadata, error) {
-	obj, err := strg.Get(ctx, manifestKey(uploadID))
-	if errors.Is(err, s2.ErrNotExist) {
-		return make(s2.Metadata), nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	md := obj.Metadata().Clone()
-	if md == nil {
-		md = make(s2.Metadata)
-	}
-	return md, nil
 }
 
 // newUploadID generates a 16-byte upload ID: 4 bytes of elapsed seconds
@@ -88,8 +53,7 @@ func handleCreateMultipartUpload(s *server.Server, w http.ResponseWriter, r *htt
 	bucketName := r.PathValue("bucket")
 	key := r.PathValue("key")
 
-	strg, err := s.Buckets.Get(ctx, bucketName)
-	if err != nil {
+	if _, err := s.Buckets.Get(ctx, bucketName); err != nil {
 		code, msg, status := s2ErrorToS3Error(err)
 		writeError(w, r, code, msg, status)
 		return
@@ -101,8 +65,7 @@ func handleCreateMultipartUpload(s *server.Server, w http.ResponseWriter, r *htt
 		return
 	}
 
-	// S3 takes the object's headers from the initiate request. Record them
-	// on the manifest's own metadata, which Put persists in the same call.
+	// S3 takes the object's headers from the initiate request.
 	md := parseMetadataHeaders(r)
 	// The store below is conditional, so x-amz-meta-s2-content-type would
 	// otherwise reach the reserved key it shares a namespace with (#192).
@@ -112,12 +75,11 @@ func handleCreateMultipartUpload(s *server.Server, w http.ResponseWriter, r *htt
 	if ct := requestContentType(r); ct != "" {
 		md[contentTypeMetadataKey] = ct
 	}
-	if err := strg.Put(ctx, s2.NewObjectBytes(manifestKey(uploadID), nil, s2.WithMetadata(md))); err != nil {
+	if err := s.Multipart.Create(ctx, uploadID, bucketName, key, md); err != nil {
 		code, msg, status := s2ErrorToS3Error(err)
 		writeError(w, r, code, msg, status)
 		return
 	}
-
 	writeXML(w, http.StatusOK, InitiateMultipartUploadResult{
 		Bucket:   bucketName,
 		Key:      key,
@@ -128,6 +90,7 @@ func handleCreateMultipartUpload(s *server.Server, w http.ResponseWriter, r *htt
 func handleUploadPart(s *server.Server, w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	bucketName := r.PathValue("bucket")
+	key := r.PathValue("key")
 
 	uploadID := r.URL.Query().Get("uploadId")
 	partNumberStr := r.URL.Query().Get("partNumber")
@@ -145,8 +108,12 @@ func handleUploadPart(s *server.Server, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	strg, err := s.Buckets.Get(ctx, bucketName)
-	if err != nil {
+	if _, err := s.Buckets.Get(ctx, bucketName); err != nil {
+		code, msg, status := s2ErrorToS3Error(err)
+		writeError(w, r, code, msg, status)
+		return
+	}
+	if _, err := s.Multipart.Metadata(ctx, uploadID, bucketName, key); err != nil {
 		code, msg, status := s2ErrorToS3Error(err)
 		writeError(w, r, code, msg, status)
 		return
@@ -161,16 +128,13 @@ func handleUploadPart(s *server.Server, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	partObj := s2.NewObjectBytes(partKey(uploadID, partNumber), data)
-	if err := strg.Put(ctx, partObj); err != nil {
+	h := md5.Sum(data) // #nosec G401 -- MD5 is required for S3-compatible ETag
+	etag := `"` + hex.EncodeToString(h[:]) + `"`
+	if err := s.Multipart.PutPart(ctx, uploadID, partNumber, data, etag); err != nil {
 		code, msg, status := s2ErrorToS3Error(err)
 		writeError(w, r, code, msg, status)
 		return
 	}
-
-	h := md5.Sum(data) // #nosec G401 -- MD5 is required for S3-compatible ETag
-	etag := `"` + hex.EncodeToString(h[:]) + `"`
-	_ = strg.PutMetadata(ctx, partKey(uploadID, partNumber), s2.Metadata{etagMetadataKey: etag})
 
 	w.Header().Set("ETag", etag)
 	w.WriteHeader(http.StatusOK)
@@ -222,60 +186,55 @@ func handleCompleteMultipartUpload(s *server.Server, w http.ResponseWriter, r *h
 		}
 	}
 
-	// Stat each part once up front: verify existence and compute the total
-	// length required by NewObjectReader. We intentionally do NOT read part
-	// bodies here — they are streamed lazily by partsReader below.
-	partObjs := make([]s2.Object, len(req.Parts))
-	var totalLen uint64
-	for i, p := range req.Parts {
-		obj, err := strg.Get(ctx, partKey(uploadID, p.PartNumber))
-		if err != nil {
-			writeError(w, r, "InvalidPart", fmt.Sprintf("Part %d not found", p.PartNumber), http.StatusBadRequest)
-			return
-		}
-		partObjs[i] = obj
-		totalLen += obj.Length()
-	}
-
-	// This request carries no headers of its own; they were recorded at
-	// initiate time.
-	md, err := uploadMetadata(ctx, strg, uploadID)
+	// Complete carries no headers; they were recorded at initiate time.
+	md, err := s.Multipart.Metadata(ctx, uploadID, bucketName, key)
 	if err != nil {
 		code, msg, status := s2ErrorToS3Error(err)
 		writeError(w, r, code, msg, status)
 		return
 	}
 
-	// Stream all parts through a single reader, tee-ing each part into its own
-	// MD5 hash as it flows by. This avoids buffering the assembled object in
-	// memory — critical for the memfs backend, and a peak-memory win for all
-	// backends. The multipart ETag is MD5(concat of each part's raw MD5 bytes)
-	// + "-" + partCount; we collect the per-part MD5s after Put has drained
-	// the reader.
+	// Stat parts up front for length and digest; bodies stream below.
+	partObjs := make([]s2.Object, len(req.Parts))
+	digests := make([]byte, 0, len(req.Parts)*md5.Size)
+	var totalLen uint64
+	for i, p := range req.Parts {
+		obj, err := s.Multipart.Part(ctx, uploadID, p.PartNumber)
+		if errors.Is(err, s2.ErrNotExist) {
+			writeError(w, r, "InvalidPart", fmt.Sprintf("Part %d not found", p.PartNumber), http.StatusBadRequest)
+			return
+		}
+		if err != nil {
+			code, msg, status := s2ErrorToS3Error(err)
+			writeError(w, r, code, msg, status)
+			return
+		}
+		digest, err := hex.DecodeString(strings.Trim(obj.Metadata()[etagMetadataKey], `"`))
+		if err != nil || len(digest) != md5.Size {
+			writeError(w, r, "InvalidPart", fmt.Sprintf("Part %d has no ETag", p.PartNumber), http.StatusBadRequest)
+			return
+		}
+		if !strings.EqualFold(strings.Trim(strings.TrimSpace(p.ETag), `"`), hex.EncodeToString(digest)) {
+			writeError(w, r, "InvalidPart", fmt.Sprintf("Part %d: the specified ETag did not match the uploaded part's ETag", p.PartNumber), http.StatusBadRequest)
+			return
+		}
+		digests = append(digests, digest...)
+		partObjs[i] = obj
+		totalLen += obj.Length()
+	}
+
+	combined := md5.Sum(digests) // #nosec G401 -- MD5 is required for S3-compatible multipart ETag
+	etag := `"` + hex.EncodeToString(combined[:]) + `-` + strconv.Itoa(len(req.Parts)) + `"`
+	md[etagMetadataKey] = etag
+
 	pr := &partsReader{parts: partObjs}
-	finalObj := s2.NewObjectReader(key, pr, totalLen, s2.WithMetadata(md))
-	if err := strg.Put(ctx, finalObj); err != nil {
+	if err := strg.Put(ctx, s2.NewObjectReader(key, pr, totalLen, s2.WithMetadata(md))); err != nil {
 		_ = pr.Close()
 		code, msg, status := s2ErrorToS3Error(err)
 		writeError(w, r, code, msg, status)
 		return
 	}
-
-	combined := md5.Sum(pr.partMD5s) // #nosec G401 -- MD5 is required for S3-compatible multipart ETag
-	etag := `"` + hex.EncodeToString(combined[:]) + `-` + strconv.Itoa(len(req.Parts)) + `"`
-	md[etagMetadataKey] = etag
-	if err := strg.PutMetadata(ctx, key, md); err != nil {
-		code, msg, status := s2ErrorToS3Error(err)
-		writeError(w, r, code, msg, status)
-		return
-	}
-
-	// By key, not DeleteRecursive: the fs backend walks the whole bucket
-	// for that. A part uploaded but not listed here stays behind (#202).
-	for _, p := range req.Parts {
-		_ = strg.Delete(ctx, partKey(uploadID, p.PartNumber))
-	}
-	_ = strg.Delete(ctx, manifestKey(uploadID))
+	_ = s.Multipart.Remove(ctx, uploadID)
 
 	writeXML(w, http.StatusOK, CompleteMultipartUploadResult{
 		Location: "/" + bucketName + "/" + key,
@@ -288,6 +247,7 @@ func handleCompleteMultipartUpload(s *server.Server, w http.ResponseWriter, r *h
 func handleAbortMultipartUpload(s *server.Server, w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	bucketName := r.PathValue("bucket")
+	key := r.PathValue("key")
 
 	uploadID := r.URL.Query().Get("uploadId")
 	if uploadID == "" {
@@ -299,28 +259,24 @@ func handleAbortMultipartUpload(s *server.Server, w http.ResponseWriter, r *http
 		return
 	}
 
-	strg, err := s.Buckets.Get(ctx, bucketName)
-	if err != nil {
+	if _, err := s.Buckets.Get(ctx, bucketName); err != nil {
 		code, msg, status := s2ErrorToS3Error(err)
 		writeError(w, r, code, msg, status)
 		return
 	}
-
-	_ = strg.DeleteRecursive(ctx, uploadPrefix(uploadID))
+	if err := s.Multipart.Abort(ctx, uploadID, bucketName, key); err != nil {
+		code, msg, status := s2ErrorToS3Error(err)
+		writeError(w, r, code, msg, status)
+		return
+	}
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// partsReader is an io.ReadCloser that concatenates the bodies of a slice of
-// s2.Object parts, opening each one lazily. As each part's body flows through
-// Read, it is also hashed into a per-part MD5; after the reader is fully
-// drained, partMD5s holds the concatenation of those digests in part order —
-// exactly what the S3 multipart ETag formula requires.
+// partsReader concatenates the bodies of parts, opening each one lazily.
 type partsReader struct {
-	parts    []s2.Object
-	idx      int
-	current  io.ReadCloser
-	currentH hash.Hash
-	partMD5s []byte
+	parts   []s2.Object
+	idx     int
+	current io.ReadCloser
 }
 
 func (p *partsReader) Read(buf []byte) (int, error) {
@@ -334,17 +290,11 @@ func (p *partsReader) Read(buf []byte) (int, error) {
 				return 0, err
 			}
 			p.current = rc
-			p.currentH = md5.New() // #nosec G401 -- MD5 is required for S3-compatible multipart ETag
 		}
 		n, err := p.current.Read(buf)
-		if n > 0 {
-			_, _ = p.currentH.Write(buf[:n])
-		}
 		if err == io.EOF {
-			p.partMD5s = append(p.partMD5s, p.currentH.Sum(nil)...)
 			_ = p.current.Close()
 			p.current = nil
-			p.currentH = nil
 			p.idx++
 			if n > 0 {
 				return n, nil

--- a/server/handlers/s3api/multipart_test.go
+++ b/server/handlers/s3api/multipart_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/md5" // #nosec G501 -- MD5 is used here only to mirror S3 multipart ETag semantics under test.
 	"encoding/xml"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -170,7 +169,8 @@ func (s *MultipartTestSuite) initiateUpload(bucket, key string, headers http.Hea
 	return created.UploadID
 }
 
-func (s *MultipartTestSuite) uploadPart(bucket, key, uploadID string, partNumber int, body string) {
+// uploadPart returns the entry Complete needs for the part.
+func (s *MultipartTestSuite) uploadPart(bucket, key, uploadID string, partNumber int, body string) CompletePart {
 	s.T().Helper()
 
 	target := fmt.Sprintf("/%s/%s?partNumber=%d&uploadId=%s", bucket, key, partNumber, uploadID)
@@ -180,26 +180,48 @@ func (s *MultipartTestSuite) uploadPart(bucket, key, uploadID string, partNumber
 	req.ContentLength = int64(len(body))
 	w := httptest.NewRecorder()
 	handleUploadPart(s.server, w, req)
-	s.Require().Equal(http.StatusOK, w.Code)
+	s.Require().Equal(http.StatusOK, w.Code, w.Body.String())
+	return CompletePart{PartNumber: partNumber, ETag: w.Header().Get("ETag")}
 }
 
-// completeUpload assembles partNumbers into the final object.
-func (s *MultipartTestSuite) completeUpload(bucket, key, uploadID string, partNumbers ...int) {
-	s.T().Helper()
-
+func completeBody(parts ...CompletePart) string {
 	var body strings.Builder
 	body.WriteString("<CompleteMultipartUpload>")
-	for _, n := range partNumbers {
-		fmt.Fprintf(&body, "<Part><PartNumber>%d</PartNumber><ETag>x</ETag></Part>", n)
+	for _, p := range parts {
+		fmt.Fprintf(&body, "<Part><PartNumber>%d</PartNumber><ETag>%s</ETag></Part>", p.PartNumber, p.ETag)
 	}
 	body.WriteString("</CompleteMultipartUpload>")
+	return body.String()
+}
 
-	req := httptest.NewRequest("POST", "/"+bucket+"/"+key+"?uploadId="+uploadID, strings.NewReader(body.String()))
+func (s *MultipartTestSuite) complete(bucket, key, uploadID string, parts ...CompletePart) *httptest.ResponseRecorder {
+	s.T().Helper()
+
+	req := httptest.NewRequest("POST", "/"+bucket+"/"+key+"?uploadId="+uploadID, strings.NewReader(completeBody(parts...)))
 	req.SetPathValue("bucket", bucket)
 	req.SetPathValue("key", key)
 	w := httptest.NewRecorder()
 	handleCompleteMultipartUpload(s.server, w, req)
+	return w
+}
+
+// completeUpload assembles parts into the final object.
+func (s *MultipartTestSuite) completeUpload(bucket, key, uploadID string, parts ...CompletePart) {
+	s.T().Helper()
+
+	w := s.complete(bucket, key, uploadID, parts...)
 	s.Require().Equal(http.StatusOK, w.Code, w.Body.String())
+}
+
+func (s *MultipartTestSuite) abortUpload(bucket, key, uploadID string) {
+	s.T().Helper()
+
+	req := httptest.NewRequest("DELETE", "/"+bucket+"/"+key+"?uploadId="+uploadID, nil)
+	req.SetPathValue("bucket", bucket)
+	req.SetPathValue("key", key)
+	w := httptest.NewRecorder()
+	handleAbortMultipartUpload(s.server, w, req)
+	s.Require().Equal(http.StatusNoContent, w.Code, w.Body.String())
 }
 
 // getObject reads the object back through the handler that has to surface
@@ -222,6 +244,17 @@ func (s *MultipartTestSuite) storage(bucket string) s2.Storage {
 	strg, err := s.server.Buckets.Get(context.Background(), bucket)
 	s.Require().NoError(err)
 	return strg
+}
+
+// multipartETag is S3's ETag for parts: the MD5 of their MD5s, then "-N".
+func multipartETag(parts ...string) string {
+	var digests []byte
+	for _, p := range parts {
+		h := md5.Sum([]byte(p)) // #nosec G401
+		digests = append(digests, h[:]...)
+	}
+	sum := md5.Sum(digests) // #nosec G401
+	return fmt.Sprintf(`"%x-%d"`, sum, len(parts))
 }
 
 // smuggledInternalKeys sends every reserved key as an x-amz-meta-* header.
@@ -253,51 +286,11 @@ func (s *MultipartTestSuite) TestCreateMultipartUploadLeavesAbsentContentTypeUns
 			s.createBucket("mp-noct")
 			uploadID := s.initiateUpload("mp-noct", "movie.mp4", tc.headers)
 
-			obj, err := s.storage("mp-noct").Get(context.Background(), manifestKey(uploadID))
+			md, err := s.server.Multipart.Metadata(context.Background(), uploadID, "mp-noct", "movie.mp4")
 			s.Require().NoError(err)
 			for k := range server.InternalMetadataKeys {
-				s.NotContains(obj.Metadata(), k)
+				s.NotContains(md, k)
 			}
-		})
-	}
-}
-
-// failingStorage fails every Get; uploadMetadata calls nothing else.
-type failingStorage struct {
-	s2.Storage
-	err error
-}
-
-func (f failingStorage) Get(context.Context, string) (s2.Object, error) { return nil, f.err }
-
-func (s *MultipartTestSuite) TestUploadMetadata() {
-	testCases := []struct {
-		caseName string
-		err      error
-		wantErr  bool
-	}{
-		{
-			caseName: "a missing manifest is not an error",
-			err:      fmt.Errorf("%w: manifest", s2.ErrNotExist),
-		},
-		{
-			// Completing anyway would silently drop the caller's metadata.
-			caseName: "any other read failure is surfaced",
-			err:      errors.New("backend unavailable"),
-			wantErr:  true,
-		},
-	}
-	for _, tc := range testCases {
-		s.Run(tc.caseName, func() {
-			md, err := uploadMetadata(context.Background(), failingStorage{err: tc.err}, "x")
-
-			if tc.wantErr {
-				s.Require().ErrorIs(err, tc.err)
-				s.Nil(md)
-				return
-			}
-			s.Require().NoError(err)
-			s.Empty(md)
 		})
 	}
 }
@@ -339,11 +332,10 @@ func (s *MultipartTestSuite) TestCreateMultipartUploadRecordsMetadata() {
 		"X-Amz-Meta-Author": {"uz"},
 	})
 
-	obj, err := s.storage("mp-manifest").Get(context.Background(), manifestKey(uploadID))
+	md, err := s.server.Multipart.Metadata(context.Background(), uploadID, "mp-manifest", "file.bin")
 	s.Require().NoError(err)
-	s.Equal("video/mp4", obj.Metadata()[contentTypeMetadataKey])
-	s.Equal("uz", obj.Metadata()["author"])
-	s.Zero(obj.Length())
+	s.Equal("video/mp4", md[contentTypeMetadataKey])
+	s.Equal("uz", md["author"])
 }
 
 func (s *MultipartTestSuite) TestCompleteMultipartUploadCarriesInitiateMetadata() {
@@ -386,9 +378,9 @@ func (s *MultipartTestSuite) TestCompleteMultipartUploadCarriesInitiateMetadata(
 			s.createBucket(bucket)
 
 			uploadID := s.initiateUpload(bucket, key, tc.headers)
-			s.uploadPart(bucket, key, uploadID, 1, "hello ")
-			s.uploadPart(bucket, key, uploadID, 2, "world")
-			s.completeUpload(bucket, key, uploadID, 1, 2)
+			p1 := s.uploadPart(bucket, key, uploadID, 1, "hello ")
+			p2 := s.uploadPart(bucket, key, uploadID, 2, "world")
+			s.completeUpload(bucket, key, uploadID, p1, p2)
 
 			w := s.getObject(bucket, key)
 			s.Equal("hello world", w.Body.String())
@@ -397,7 +389,7 @@ func (s *MultipartTestSuite) TestCompleteMultipartUploadCarriesInitiateMetadata(
 				s.Equal(want, w.Header().Get("x-amz-meta-"+name))
 			}
 			// The ETag survives alongside the recorded metadata.
-			s.Regexp(`^"[0-9a-f]{32}-2"$`, w.Header().Get("ETag"))
+			s.Equal(multipartETag("hello ", "world"), w.Header().Get("ETag"))
 			// s2's own bookkeeping keys must not leak as user metadata.
 			s.Empty(w.Header().Get("x-amz-meta-" + contentTypeMetadataKey))
 			s.Empty(w.Header().Get("x-amz-meta-" + etagMetadataKey))
@@ -405,38 +397,203 @@ func (s *MultipartTestSuite) TestCompleteMultipartUploadCarriesInitiateMetadata(
 	}
 }
 
-// An upload in flight across a server upgrade has no manifest.
-func (s *MultipartTestSuite) TestCompleteMultipartUploadWithoutManifest() {
-	const bucket, key = "mp-nomanifest", "file.bin"
-	s.createBucket(bucket)
+// Uploads are bound to their bucket/key; pre-v0.16 IDs have no record.
+func (s *MultipartTestSuite) TestUnknownOrMismatchedUpload() {
+	s.createBucket("mp-bind")
+	s.createBucket("mp-other")
+	uploadID := s.initiateUpload("mp-bind", "file.bin", nil)
+	p1 := s.uploadPart("mp-bind", "file.bin", uploadID, 1, "hello")
 
-	uploadID := s.initiateUpload(bucket, key, http.Header{"Content-Type": {"video/mp4"}})
-	s.uploadPart(bucket, key, uploadID, 1, "hello")
-	s.Require().NoError(s.storage(bucket).Delete(context.Background(), manifestKey(uploadID)))
+	handlers := []struct {
+		name    string
+		method  string
+		handler func(*server.Server, http.ResponseWriter, *http.Request)
+	}{
+		{name: "upload part", method: "PUT", handler: handleUploadPart},
+		{name: "complete", method: "POST", handler: handleCompleteMultipartUpload},
+		{name: "abort", method: "DELETE", handler: handleAbortMultipartUpload},
+	}
+	testCases := []struct {
+		caseName string
+		bucket   string
+		key      string
+		uploadID string
+	}{
+		{caseName: "never issued", bucket: "mp-bind", key: "file.bin", uploadID: strings.Repeat("0", 32)},
+		{caseName: "another key", bucket: "mp-bind", key: "other.bin", uploadID: uploadID},
+		{caseName: "another bucket", bucket: "mp-other", key: "file.bin", uploadID: uploadID},
+	}
+	for _, tc := range testCases {
+		for _, h := range handlers {
+			s.Run(tc.caseName+"/"+h.name, func() {
+				target := fmt.Sprintf("/%s/%s?partNumber=1&uploadId=%s", tc.bucket, tc.key, tc.uploadID)
+				req := httptest.NewRequest(h.method, target, strings.NewReader(completeBody(p1)))
+				req.SetPathValue("bucket", tc.bucket)
+				req.SetPathValue("key", tc.key)
+				w := httptest.NewRecorder()
+				h.handler(s.server, w, req)
 
-	s.completeUpload(bucket, key, uploadID, 1)
+				s.Equal(http.StatusNotFound, w.Code, w.Body.String())
+				var errResp ErrorResponse
+				s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &errResp))
+				s.Equal("NoSuchUpload", errResp.Code)
+			})
+		}
+	}
 
-	w := s.getObject(bucket, key)
-	s.Equal("hello", w.Body.String())
-	s.Equal(defaultContentType, w.Header().Get("Content-Type"))
+	// None of the rejected requests touched the real upload.
+	s.completeUpload("mp-bind", "file.bin", uploadID, p1)
+	s.Equal("hello", s.getObject("mp-bind", "file.bin").Body.String())
 }
 
-// Complete removes what it consumed: the listed parts and the manifest.
-func (s *MultipartTestSuite) TestCompleteMultipartUploadRemovesPartsAndManifest() {
-	const bucket, key = "mp-cleanup", "file.bin"
-	s.createBucket(bucket)
+func (s *MultipartTestSuite) TestCompleteMultipartUploadChecksPartETags() {
+	s.createBucket("mp-etag")
+	uploadID := s.initiateUpload("mp-etag", "file.bin", nil)
+	p1 := s.uploadPart("mp-etag", "file.bin", uploadID, 1, "hello")
+	hexETag := strings.Trim(p1.ETag, `"`)
 
-	uploadID := s.initiateUpload(bucket, key, nil)
-	s.uploadPart(bucket, key, uploadID, 1, "hello")
-	s.completeUpload(bucket, key, uploadID, 1)
-
-	ctx := context.Background()
-	strg := s.storage(bucket)
-	for _, name := range []string{manifestKey(uploadID), partKey(uploadID, 1)} {
-		exists, err := strg.Exists(ctx, name)
-		s.Require().NoError(err)
-		s.Falsef(exists, "%s should have been removed", name)
+	testCases := []struct {
+		caseName string
+		etag     string
+		wantCode int
+	}{
+		{caseName: "as returned", etag: p1.ETag, wantCode: http.StatusOK},
+		{caseName: "without quotes", etag: hexETag, wantCode: http.StatusOK},
+		{caseName: "upper case hex", etag: strings.ToUpper(hexETag), wantCode: http.StatusOK},
+		{caseName: "pretty-printed element", etag: "\n  " + p1.ETag + "\n", wantCode: http.StatusOK},
+		{caseName: "another part's etag", etag: `"` + strings.Repeat("0", 32) + `"`, wantCode: http.StatusBadRequest},
+		{caseName: "empty", etag: "", wantCode: http.StatusBadRequest},
 	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			// A fresh upload per row: a successful Complete consumes the parts.
+			uploadID := s.initiateUpload("mp-etag", "file.bin", nil)
+			s.uploadPart("mp-etag", "file.bin", uploadID, 1, "hello")
+
+			w := s.complete("mp-etag", "file.bin", uploadID, CompletePart{PartNumber: 1, ETag: tc.etag})
+
+			s.Equal(tc.wantCode, w.Code, w.Body.String())
+			if tc.wantCode != http.StatusOK {
+				var errResp ErrorResponse
+				s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &errResp))
+				s.Equal("InvalidPart", errResp.Code)
+			}
+		})
+	}
+}
+
+// abortDuring aborts the upload the first time the request body is read.
+type abortDuring struct {
+	abort func()
+	done  bool
+}
+
+func (a *abortDuring) Read([]byte) (int, error) {
+	if !a.done {
+		a.done = true
+		a.abort()
+	}
+	return 0, io.EOF
+}
+
+// An Abort that lands while a part streams in must not leave that part behind.
+func (s *MultipartTestSuite) TestUploadPartRacingAbort() {
+	ctx := context.Background()
+	s.createBucket("mp-race")
+	uploadID := s.initiateUpload("mp-race", "file.bin", nil)
+	s.uploadPart("mp-race", "file.bin", uploadID, 1, "hello")
+
+	trigger := &abortDuring{abort: func() { s.abortUpload("mp-race", "file.bin", uploadID) }}
+	req := httptest.NewRequest("PUT", "/mp-race/file.bin?partNumber=2&uploadId="+uploadID, io.MultiReader(trigger, strings.NewReader("world")))
+	req.SetPathValue("bucket", "mp-race")
+	req.SetPathValue("key", "file.bin")
+	req.ContentLength = 5
+	w := httptest.NewRecorder()
+	handleUploadPart(s.server, w, req)
+
+	s.True(trigger.done)
+	s.Equal(http.StatusNotFound, w.Code, w.Body.String())
+	var errResp ErrorResponse
+	s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &errResp))
+	s.Equal("NoSuchUpload", errResp.Code)
+
+	exists, err := s.server.Multipart.Storage().Exists(ctx, uploadID)
+	s.Require().NoError(err)
+	s.False(exists, "the late part must not outlive the abort")
+}
+
+// A part that exists but cannot be read is the server's fault, not the client's.
+func (s *MultipartTestSuite) TestCompleteMultipartUploadPartReadFailure() {
+	s.createBucket("mp-eio")
+	uploadID := s.initiateUpload("mp-eio", "file.bin", nil)
+	p1 := s.uploadPart("mp-eio", "file.bin", uploadID, 1, "hello")
+	// A corrupt sidecar makes the fs backend's Get fail with a decode error.
+	s.Require().NoError(s.server.Multipart.Storage().Put(context.Background(), s2.NewObjectBytes(uploadID+"/.meta/00001", []byte("{"))))
+
+	w := s.complete("mp-eio", "file.bin", uploadID, p1)
+	s.Equal(http.StatusInternalServerError, w.Code, w.Body.String())
+}
+
+// Parts left without a record are freed by repeating Abort, as on S3.
+func (s *MultipartTestSuite) TestAbortRemovesLeftoverParts() {
+	ctx := context.Background()
+	s.createBucket("mp-leftover")
+	uploadID := s.initiateUpload("mp-leftover", "file.bin", nil)
+	s.abortUpload("mp-leftover", "file.bin", uploadID)
+	// Written straight to the store: a part left by a cleanup that failed.
+	s.Require().NoError(s.server.Multipart.Storage().Put(ctx, s2.NewObjectBytes(uploadID+"/00001", []byte("late"))))
+
+	s.abortUpload("mp-leftover", "file.bin", uploadID)
+
+	exists, err := s.server.Multipart.Storage().Exists(ctx, uploadID)
+	s.Require().NoError(err)
+	s.False(exists)
+}
+
+// State lives outside the bucket and is fully removed on Complete and Abort.
+func (s *MultipartTestSuite) TestMultipartStateLifecycle() {
+	testCases := []struct {
+		caseName string
+		finish   func(bucket, key, uploadID string, p1 CompletePart)
+	}{
+		{caseName: "complete", finish: func(bucket, key, uploadID string, p1 CompletePart) { s.completeUpload(bucket, key, uploadID, p1) }},
+		{caseName: "abort", finish: func(bucket, key, uploadID string, _ CompletePart) { s.abortUpload(bucket, key, uploadID) }},
+	}
+	for i, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			ctx := context.Background()
+			bucket, key := fmt.Sprintf("mp-life-%d", i), "file.bin"
+			s.createBucket(bucket)
+
+			uploadID := s.initiateUpload(bucket, key, nil)
+			p1 := s.uploadPart(bucket, key, uploadID, 1, "hello")
+			s.uploadPart(bucket, key, uploadID, 2, "unlisted")
+
+			res, err := s.storage(bucket).List(ctx, s2.ListOptions{Recursive: true})
+			s.Require().NoError(err)
+			s.Empty(server.FilterKeep(res.Objects))
+
+			tc.finish(bucket, key, uploadID, p1)
+
+			exists, err := s.server.Multipart.Storage().Exists(ctx, uploadID)
+			s.Require().NoError(err)
+			s.False(exists)
+		})
+	}
+}
+
+// A part without a recorded ETag cannot contribute to the multipart ETag.
+func (s *MultipartTestSuite) TestCompleteMultipartUploadRejectsPartWithoutETag() {
+	s.createBucket("mp-noetag")
+	uploadID := s.initiateUpload("mp-noetag", "file.bin", nil)
+	s.Require().NoError(s.server.Multipart.PutPart(context.Background(), uploadID, 1, []byte("hello"), ""))
+
+	w := s.complete("mp-noetag", "file.bin", uploadID, CompletePart{PartNumber: 1, ETag: ""})
+
+	s.Equal(http.StatusBadRequest, w.Code)
+	var errResp ErrorResponse
+	s.Require().NoError(xml.Unmarshal(w.Body.Bytes(), &errResp))
+	s.Equal("InvalidPart", errResp.Code)
 }
 
 func TestPartsReader(t *testing.T) {
@@ -454,19 +611,15 @@ func TestPartsReader(t *testing.T) {
 		t.Run(tc.caseName, func(t *testing.T) {
 			parts := make([]s2.Object, len(tc.bodies))
 			var want string
-			var wantMD5s []byte
 			for i, body := range tc.bodies {
 				parts[i] = s2.NewObjectBytes("part", []byte(body))
 				want += body
-				h := md5.Sum([]byte(body)) // #nosec G401
-				wantMD5s = append(wantMD5s, h[:]...)
 			}
 
 			pr := &partsReader{parts: parts}
 			got, err := io.ReadAll(pr)
 			require.NoError(t, err)
 			assert.Equal(t, want, string(got))
-			assert.Equal(t, wantMD5s, pr.partMD5s)
 			assert.NoError(t, pr.Close())
 		})
 	}
@@ -511,5 +664,4 @@ func TestPartsReader_SmallBuffer(t *testing.T) {
 		require.NoError(t, err)
 	}
 	assert.Equal(t, "abcde", string(got))
-	assert.Len(t, pr.partMD5s, 2*md5.Size)
 }

--- a/server/handlers/s3api/utils.go
+++ b/server/handlers/s3api/utils.go
@@ -160,5 +160,8 @@ func s2ErrorToS3Error(err error) (string, string, int) {
 	if errors.Is(err, server.ErrReservedBucketName) {
 		return "InvalidBucketName", err.Error(), http.StatusBadRequest
 	}
+	if errors.Is(err, server.ErrNoSuchUpload) {
+		return "NoSuchUpload", "The specified upload does not exist", http.StatusNotFound
+	}
 	return "InternalError", err.Error(), http.StatusInternalServerError
 }

--- a/server/multipart.go
+++ b/server/multipart.go
@@ -2,7 +2,10 @@ package server
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"strings"
 
 	"github.com/mojatter/s2"
@@ -11,9 +14,21 @@ import (
 // multipartDir holds in-progress multipart state beside the buckets.
 const multipartDir = ".multipart"
 
+// ErrNoSuchUpload is an unknown upload, or one bound elsewhere.
+var ErrNoSuchUpload = errors.New("no such upload")
+
+// errNoRecord distinguishes a missing meta from one bound elsewhere.
+var errNoRecord = errors.New("no upload record")
+
 // isHiddenBucketEntry reports whether name is s2's own state, not a bucket.
 func isHiddenBucketEntry(name string) bool {
 	return strings.HasPrefix(name, ".")
+}
+
+// uploadRecord binds an upload ID to its target object.
+type uploadRecord struct {
+	Bucket string `json:"bucket"`
+	Key    string `json:"key"`
 }
 
 // MultipartStore stores in-progress uploads under <Root>/.multipart/<uploadId>/.
@@ -32,4 +47,135 @@ func newMultipartStore(ctx context.Context, root s2.Storage) (*MultipartStore, e
 // Storage returns the storage rooted at the multipart directory.
 func (ms *MultipartStore) Storage() s2.Storage {
 	return ms.strg
+}
+
+const uploadMetaName = "meta"
+
+func uploadPartName(n int) string {
+	return fmt.Sprintf("%05d", n)
+}
+
+// upload returns id's own storage, keeping fs sidecars inside it.
+func (ms *MultipartStore) upload(ctx context.Context, id string) (s2.Storage, error) {
+	return ms.strg.Sub(ctx, id)
+}
+
+func isNotExist(err error) bool {
+	return errors.Is(err, s2.ErrNotExist) || errors.Is(err, fs.ErrNotExist)
+}
+
+// Create records an upload of bucket/key; md is applied at completion.
+func (ms *MultipartStore) Create(ctx context.Context, id, bucket, key string, md s2.Metadata) error {
+	body, err := json.Marshal(uploadRecord{Bucket: bucket, Key: key})
+	if err != nil {
+		return err
+	}
+	u, err := ms.upload(ctx, id)
+	if err != nil {
+		return err
+	}
+	return u.Put(ctx, s2.NewObjectBytes(uploadMetaName, body, s2.WithMetadata(md)))
+}
+
+// load reads id's record; a meta lost before Open counts as missing.
+func (ms *MultipartStore) load(ctx context.Context, id string) (uploadRecord, s2.Metadata, error) {
+	u, err := ms.upload(ctx, id)
+	if err != nil {
+		return uploadRecord{}, nil, err
+	}
+	obj, err := u.Get(ctx, uploadMetaName)
+	if isNotExist(err) {
+		return uploadRecord{}, nil, errNoRecord
+	}
+	if err != nil {
+		return uploadRecord{}, nil, err
+	}
+	rc, err := obj.Open()
+	if isNotExist(err) {
+		return uploadRecord{}, nil, errNoRecord
+	}
+	if err != nil {
+		return uploadRecord{}, nil, err
+	}
+
+	defer rc.Close() //nolint:errcheck // read-only
+
+	var rec uploadRecord
+	if err := json.NewDecoder(rc).Decode(&rec); err != nil {
+		return uploadRecord{}, nil, fmt.Errorf("failed to read upload %s: %w", id, err)
+	}
+	md := obj.Metadata().Clone()
+	if md == nil {
+		md = make(s2.Metadata)
+	}
+	return rec, md, nil
+}
+
+// record is load plus the bucket/key binding check.
+func (ms *MultipartStore) record(ctx context.Context, id, bucket, key string) (s2.Metadata, error) {
+	rec, md, err := ms.load(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if rec.Bucket != bucket || rec.Key != key {
+		return nil, ErrNoSuchUpload
+	}
+	return md, nil
+}
+
+// Metadata returns id's headers; ErrNoSuchUpload unless it targets bucket/key.
+func (ms *MultipartStore) Metadata(ctx context.Context, id, bucket, key string) (s2.Metadata, error) {
+	md, err := ms.record(ctx, id, bucket, key)
+	if errors.Is(err, errNoRecord) {
+		return nil, ErrNoSuchUpload
+	}
+	return md, err
+}
+
+// Abort removes id; only a missing record skips the binding check.
+func (ms *MultipartStore) Abort(ctx context.Context, id, bucket, key string) error {
+	if _, err := ms.record(ctx, id, bucket, key); err != nil && !errors.Is(err, errNoRecord) {
+		return err
+	}
+	exists, err := ms.strg.Exists(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return ErrNoSuchUpload
+	}
+	return ms.Remove(ctx, id)
+}
+
+// PutPart stores part n of id with its ETag, dropping it if an Abort took the record.
+func (ms *MultipartStore) PutPart(ctx context.Context, id string, n int, data []byte, etag string) error {
+	u, err := ms.upload(ctx, id)
+	if err != nil {
+		return err
+	}
+	putErr := u.Put(ctx, s2.NewObjectBytes(uploadPartName(n), data, s2.WithMetadata(s2.Metadata{EtagMetadataKey: etag})))
+	// Only a record known to be gone drops the part; a failed probe leaves it.
+	if exists, err := u.Exists(ctx, uploadMetaName); err == nil && !exists {
+		_ = ms.Remove(ctx, id)
+		return ErrNoSuchUpload
+	}
+	return putErr
+}
+
+// Part returns part n of id.
+func (ms *MultipartStore) Part(ctx context.Context, id string, n int) (s2.Object, error) {
+	u, err := ms.upload(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return u.Get(ctx, uploadPartName(n))
+}
+
+// Remove deletes everything under id, walking only id's own directory.
+func (ms *MultipartStore) Remove(ctx context.Context, id string) error {
+	u, err := ms.upload(ctx, id)
+	if err != nil {
+		return err
+	}
+	return u.DeleteRecursive(ctx, "")
 }

--- a/server/multipart_test.go
+++ b/server/multipart_test.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"context"
+	"errors"
 	"io"
+	"io/fs"
 	"testing"
 
 	"github.com/mojatter/s2"
@@ -61,6 +63,239 @@ func (s *MultipartStoreTestSuite) TestIsHiddenBucketEntry() {
 	for _, tc := range testCases {
 		s.Run(tc.caseName, func() {
 			s.Equal(tc.want, isHiddenBucketEntry(tc.name))
+		})
+	}
+}
+
+func (s *MultipartStoreTestSuite) TestMetadata() {
+	ctx := context.Background()
+	ms := s.server.Multipart
+	s.Require().NoError(ms.Create(ctx, "id1", "photos", "a.jpg", s2.Metadata{"author": "uz"}))
+
+	testCases := []struct {
+		caseName string
+		id       string
+		bucket   string
+		key      string
+		wantErr  error
+	}{
+		{caseName: "match", id: "id1", bucket: "photos", key: "a.jpg"},
+		{caseName: "unknown id", id: "id2", bucket: "photos", key: "a.jpg", wantErr: ErrNoSuchUpload},
+		{caseName: "another key", id: "id1", bucket: "photos", key: "b.jpg", wantErr: ErrNoSuchUpload},
+		{caseName: "another bucket", id: "id1", bucket: "videos", key: "a.jpg", wantErr: ErrNoSuchUpload},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			md, err := ms.Metadata(ctx, tc.id, tc.bucket, tc.key)
+			if tc.wantErr != nil {
+				s.ErrorIs(err, tc.wantErr)
+				return
+			}
+			s.Require().NoError(err)
+			s.Equal("uz", md["author"])
+		})
+	}
+}
+
+// failingStorage fails every Get.
+type failingStorage struct {
+	s2.Storage
+	err error
+}
+
+func (f failingStorage) Sub(context.Context, string) (s2.Storage, error) { return f, nil }
+
+func (f failingStorage) Get(context.Context, string) (s2.Object, error) { return nil, f.err }
+
+// A backend failure must not read as an unknown upload.
+func (s *MultipartStoreTestSuite) TestMetadataSurfacesReadFailure() {
+	want := errors.New("backend unavailable")
+	ms := &MultipartStore{strg: failingStorage{err: want}}
+
+	_, err := ms.Metadata(context.Background(), "id1", "photos", "a.jpg")
+	s.ErrorIs(err, want)
+	s.NotErrorIs(err, ErrNoSuchUpload)
+}
+
+// existsFailingStorage stores objects but cannot answer Exists.
+type existsFailingStorage struct {
+	s2.Storage
+	err error
+}
+
+func (e existsFailingStorage) Sub(ctx context.Context, name string) (s2.Storage, error) {
+	sub, err := e.Storage.Sub(ctx, name)
+	return existsFailingStorage{sub, e.err}, err
+}
+
+func (e existsFailingStorage) Exists(context.Context, string) (bool, error) { return false, e.err }
+
+// A part stored after its upload was aborted must not outlive it.
+func (s *MultipartStoreTestSuite) TestPutPartAfterAbort() {
+	ctx := context.Background()
+	ms := s.newStore(s2.TypeOSFS)
+	s.Require().NoError(ms.Create(ctx, "id1", "photos", "a.jpg", nil))
+	s.Require().NoError(ms.Remove(ctx, "id1"))
+
+	err := ms.PutPart(ctx, "id1", 1, []byte("late"), `"x"`)
+
+	s.ErrorIs(err, ErrNoSuchUpload)
+	exists, err := ms.Storage().Exists(ctx, "id1")
+	s.Require().NoError(err)
+	s.False(exists)
+}
+
+// A probe that fails must not fail a part that is already stored.
+func (s *MultipartStoreTestSuite) TestPutPartIgnoresProbeFailure() {
+	ctx := context.Background()
+	ms := s.newStore(s2.TypeOSFS)
+	s.Require().NoError(ms.Create(ctx, "id1", "photos", "a.jpg", nil))
+	probeBroken := &MultipartStore{strg: existsFailingStorage{ms.Storage(), errors.New("probe failed")}}
+
+	s.Require().NoError(probeBroken.PutPart(ctx, "id1", 1, []byte("hello"), `"x"`))
+
+	obj, err := ms.Part(ctx, "id1", 1)
+	s.Require().NoError(err)
+	s.Equal(uint64(5), obj.Length())
+}
+
+// vanishingStorage loses meta between Get and Open, as a racing Abort does.
+type vanishingStorage struct{ s2.Storage }
+
+func (v vanishingStorage) Sub(context.Context, string) (s2.Storage, error) { return v, nil }
+
+func (v vanishingStorage) Get(context.Context, string) (s2.Object, error) {
+	return vanishingObject{s2.NewObjectBytes(uploadMetaName, nil)}, nil
+}
+
+type vanishingObject struct{ s2.Object }
+
+func (vanishingObject) Open() (io.ReadCloser, error) {
+	return nil, &fs.PathError{Op: "open", Path: uploadMetaName, Err: fs.ErrNotExist}
+}
+
+func (s *MultipartStoreTestSuite) TestMetadataOfVanishingRecord() {
+	ms := &MultipartStore{strg: vanishingStorage{}}
+
+	_, err := ms.Metadata(context.Background(), "id1", "photos", "a.jpg")
+	s.ErrorIs(err, ErrNoSuchUpload)
+}
+
+func (s *MultipartStoreTestSuite) TestAbort() {
+	testCases := []struct {
+		caseName string
+		setup    func(ctx context.Context, ms *MultipartStore)
+		bucket   string
+		key      string
+		wantErr  error
+		wantGone bool
+	}{
+		{
+			caseName: "bound upload",
+			setup: func(ctx context.Context, ms *MultipartStore) {
+				s.Require().NoError(ms.Create(ctx, "id1", "photos", "a.jpg", nil))
+			},
+			bucket: "photos", key: "a.jpg", wantGone: true,
+		},
+		{
+			caseName: "bound elsewhere is left alone",
+			setup: func(ctx context.Context, ms *MultipartStore) {
+				s.Require().NoError(ms.Create(ctx, "id1", "photos", "a.jpg", nil))
+			},
+			bucket: "photos", key: "b.jpg", wantErr: ErrNoSuchUpload,
+		},
+		{
+			caseName: "leftover parts without a record",
+			setup: func(ctx context.Context, ms *MultipartStore) {
+				u, err := ms.upload(ctx, "id1")
+				s.Require().NoError(err)
+				s.Require().NoError(u.Put(ctx, s2.NewObjectBytes(uploadPartName(1), []byte("x"))))
+			},
+			bucket: "photos", key: "a.jpg", wantGone: true,
+		},
+		{
+			// Reading it may fail for a moment; removing another upload's parts is forever.
+			caseName: "unreadable record",
+			setup: func(ctx context.Context, ms *MultipartStore) {
+				u, err := ms.upload(ctx, "id1")
+				s.Require().NoError(err)
+				s.Require().NoError(u.Put(ctx, s2.NewObjectBytes(uploadMetaName, []byte("{"))))
+			},
+			bucket: "photos", key: "a.jpg", wantErr: io.ErrUnexpectedEOF,
+		},
+		{
+			caseName: "nothing at all",
+			setup:    func(context.Context, *MultipartStore) {},
+			bucket:   "photos", key: "a.jpg", wantErr: ErrNoSuchUpload, wantGone: true,
+		},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			ctx := context.Background()
+			ms := s.newStore(s2.TypeOSFS)
+			tc.setup(ctx, ms)
+
+			err := ms.Abort(ctx, "id1", tc.bucket, tc.key)
+
+			if tc.wantErr != nil {
+				s.ErrorIs(err, tc.wantErr)
+			} else {
+				s.NoError(err)
+			}
+			exists, err := ms.Storage().Exists(ctx, "id1")
+			s.Require().NoError(err)
+			s.Equal(tc.wantGone, !exists)
+		})
+	}
+}
+
+func (s *MultipartStoreTestSuite) TestRemoveMissingIsNoop() {
+	for _, typ := range []s2.Type{s2.TypeOSFS, s2.TypeMemFS} {
+		s.Run(string(typ), func() {
+			s.NoError(s.newStore(typ).Remove(context.Background(), "id1"))
+		})
+	}
+}
+
+func (s *MultipartStoreTestSuite) newStore(typ s2.Type) *MultipartStore {
+	s.T().Helper()
+
+	cfg := DefaultConfig()
+	cfg.Type = typ
+	cfg.Root = s.T().TempDir()
+	cfg.ConsoleListen = ""
+	srv, err := NewServer(context.Background(), cfg)
+	s.Require().NoError(err)
+	return srv.Multipart
+}
+
+func (s *MultipartStoreTestSuite) TestRemove() {
+	testCases := []struct {
+		caseName string
+		typ      s2.Type
+	}{
+		{caseName: "osfs", typ: s2.TypeOSFS},
+		{caseName: "memfs", typ: s2.TypeMemFS},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			ctx := context.Background()
+			ms := s.newStore(tc.typ)
+
+			s.Require().NoError(ms.Create(ctx, "id1", "photos", "a.jpg", nil))
+			s.Require().NoError(ms.PutPart(ctx, "id1", 1, []byte("x"), `"etag"`))
+			s.Require().NoError(ms.Create(ctx, "id2", "photos", "b.jpg", nil))
+
+			s.Require().NoError(ms.Remove(ctx, "id1"))
+
+			// fs keeps metadata in .meta sidecars; they must go with the upload.
+			for _, name := range []string{"id1", ".meta/id1"} {
+				exists, err := ms.Storage().Exists(ctx, name)
+				s.Require().NoError(err)
+				s.Falsef(exists, "%s should have been removed", name)
+			}
+			_, err := ms.Metadata(ctx, "id2", "photos", "b.jpg")
+			s.NoError(err, "a sibling upload must survive")
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- In-progress multipart state moves out of the bucket into `server.MultipartStore` at `<Root>/.multipart/<uploadId>/`: a `meta` object (`{"bucket","key"}`, with the initiate headers as its metadata) plus the parts. Nothing s2 writes for an unfinished upload lands in the bucket's key namespace.
- `UploadPart`, `CompleteMultipartUpload` and `AbortMultipartUpload` check `meta` before touching any part and answer `NoSuchUpload` when it is missing or names another bucket or key. Before this, `?uploadId=X` against any key assembled X's parts onto that key.
- Complete builds the multipart ETag from the MD5s `UploadPart` records, checks each `<ETag>` in the request against them (`InvalidPart` on a mismatch, as S3 does), and writes the object and its ETag in one `Put`. That closes the window where the object existed without its ETag and the `s3` backend's 5 GiB `CopyObject` ceiling (#208). Complete and Abort then remove the upload's own directory, including parts the Complete did not list (#202).
- Abort can land while a part streams in: `UploadPart` re-checks the record after storing the part and removes the leftovers when it is gone, and Abort clears an upload whose record is missing, as S3 documents for Abort racing in-flight parts. fs `DeleteRecursive` (root module) no longer dereferences the nil entry `fs.WalkDir` hands it for a root it cannot stat.

## Behavior changes
- An upload started before the upgrade has no `meta`, so all three handlers answer `NoSuchUpload` and the client restarts it. Its parts stay under `__s2mp__/`, still hidden by `filterMultipart` for v0.16; the release notes will show how to delete them.
- A request naming another bucket or key is `NoSuchUpload` (404), and a parts list whose ETags do not match the stored parts is `InvalidPart`. Every SDK echoes the ETags `UploadPart` returned, so clients are unaffected.
- Deleting a bucket no longer removes the uploads targeting it: they stay under `.multipart/`, cannot be aborted (Abort answers `NoSuchBucket` first), and a bucket recreated under the same name can complete them. Binding an upload to a bucket's identity rather than its name belongs with the sweeper, which owns the reclaim path.
- The ETag comes from each part's recorded MD5, not from the bytes streamed at Complete, so a part re-uploaded during Complete changes the bytes but not the ETag. Retrying a part with the same body is unaffected.

## Test plan
- [x] `go vet ./...` and `go test ./...` in `server`, including the SDK-driven multipart integration tests, and in the root module's `fs`
- [x] Red against `main` and against earlier revisions of this PR, one case per behavior above: parts left inside the bucket, 200/204 for an unknown or mismatched upload, a wrong or empty `<ETag>` completing, an Abort mid-body leaving its part behind, `DeleteRecursive` panicking on a missing or unreadable root, Abort removing an upload whose record it could not read
- [ ] CI (`golangci-lint` cannot run locally -- Go 1.27 typecheck failure on `math/rand/v2`, also on `main`)

## Related
Part of #212, third of five. Closes #208. The sweeper comes next, with `ListMultipartUploads` / `ListParts`, and takes over reclaiming a deleted bucket's uploads; `filterMultipart` stays until v0.17.
