### PR TITLE
fix(server): Delete only the named bucket, not every bucket sharing its prefix

### DIFF
--- a/azblob/storage.go
+++ b/azblob/storage.go
@@ -261,7 +261,7 @@ func (s *azblobStorage) Delete(_ context.Context, name string) error {
 }
 
 func (s *azblobStorage) DeleteRecursive(ctx context.Context, prefix string) error {
-	fullPrefix := s.key(prefix)
+	fullPrefix := joinKeepSlash(s.prefix, prefix)
 	for {
 		res, err := s.client.listBlobs(ctx, s.container, fullPrefix, int32(defaultListLimit), "")
 		if err != nil {
@@ -320,4 +320,13 @@ func isBlobNotFound(err error) bool {
 		return false
 	}
 	return bloberror.HasCode(err, bloberror.BlobNotFound, bloberror.ContainerNotFound, bloberror.ResourceNotFound)
+}
+
+// joinKeepSlash is path.Join that keeps prefix's trailing slash, which confines a listing to that directory.
+func joinKeepSlash(base, prefix string) string {
+	p := path.Join(base, prefix)
+	if strings.HasSuffix(prefix, "/") && !strings.HasSuffix(p, "/") {
+		p += "/"
+	}
+	return p
 }

--- a/azblob/storage_test.go
+++ b/azblob/storage_test.go
@@ -455,8 +455,20 @@ func (s *StorageTestSuite) TestS2TestCopyMove() {
 }
 
 func (s *StorageTestSuite) TestS2TestDelete() {
-	_, strg := s.testMockStorage()
-	s.Require().NoError(s2test.TestStorageDelete(context.Background(), strg))
+	testCases := []struct {
+		caseName string
+		prefix   string
+	}{
+		{caseName: "no prefix"},
+		{caseName: "with prefix", prefix: "pfx"},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			_, strg := s.testMockStorage()
+			strg.(*azblobStorage).prefix = tc.prefix
+			s.Require().NoError(s2test.TestStorageDelete(context.Background(), strg))
+		})
+	}
 }
 
 func (s *StorageTestSuite) TestS2TestPutMetadata() {

--- a/gcs/storage.go
+++ b/gcs/storage.go
@@ -218,7 +218,7 @@ func (s *gcsStorage) Delete(_ context.Context, name string) error {
 }
 
 func (s *gcsStorage) DeleteRecursive(ctx context.Context, prefix string) error {
-	q := &storage.Query{Prefix: s.key(prefix)}
+	q := &storage.Query{Prefix: joinKeepSlash(s.prefix, prefix)}
 	it := s.client.bucket(s.bucket).objects(ctx, q)
 
 	for {
@@ -276,4 +276,13 @@ func mapNotExist(err error, name string) error {
 		return fmt.Errorf("%w: %s", s2.ErrNotExist, name)
 	}
 	return err
+}
+
+// joinKeepSlash is path.Join that keeps prefix's trailing slash, which confines a listing to that directory.
+func joinKeepSlash(base, prefix string) string {
+	p := path.Join(base, prefix)
+	if strings.HasSuffix(prefix, "/") && !strings.HasSuffix(p, "/") {
+		p += "/"
+	}
+	return p
 }

--- a/gcs/storage_test.go
+++ b/gcs/storage_test.go
@@ -486,8 +486,20 @@ func (s *StorageTestSuite) TestS2TestCopyMove() {
 }
 
 func (s *StorageTestSuite) TestS2TestDelete() {
-	_, strg := s.testMockStorage()
-	s.Require().NoError(s2test.TestStorageDelete(context.Background(), strg))
+	testCases := []struct {
+		caseName string
+		prefix   string
+	}{
+		{caseName: "no prefix"},
+		{caseName: "with prefix", prefix: "pfx"},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			_, strg := s.testMockStorage()
+			strg.(*gcsStorage).prefix = tc.prefix
+			s.Require().NoError(s2test.TestStorageDelete(context.Background(), strg))
+		})
+	}
 }
 
 func (s *StorageTestSuite) TestS2TestPutMetadata() {

--- a/s2test/s2test.go
+++ b/s2test/s2test.go
@@ -462,6 +462,30 @@ func TestStorageDelete(ctx context.Context, strg s2.Storage) error {
 		}
 	}
 
+	// A trailing slash confines the prefix to that directory, sparing names that merely share it.
+	nested := []string{"s2test-dir/a.txt", "s2test-dir/sub/b.txt"}
+	sibling := "s2test-dir-sibling/c.txt"
+	for _, f := range append(nested, sibling) {
+		if err := strg.Put(ctx, s2.NewObjectBytes(f, []byte("x"))); err != nil {
+			return fmt.Errorf("Put(%q) failed: %w", f, err)
+		}
+	}
+	if err := strg.DeleteRecursive(ctx, "s2test-dir/"); err != nil {
+		return fmt.Errorf("DeleteRecursive(%q) failed: %w", "s2test-dir/", err)
+	}
+	for _, f := range nested {
+		if ok, _ := strg.Exists(ctx, f); ok {
+			errorf("DeleteRecursive(%q): %q still exists", "s2test-dir/", f)
+		}
+	}
+	if ok, _ := strg.Exists(ctx, "s2test-dir"); ok {
+		errorf("DeleteRecursive(%q): the directory itself still exists", "s2test-dir/")
+	}
+	if ok, _ := strg.Exists(ctx, sibling); !ok {
+		errorf("DeleteRecursive(%q) removed %q, which only shares the prefix", "s2test-dir/", sibling)
+	}
+	_ = strg.Delete(ctx, sibling)
+
 	if len(errs) > 0 {
 		return fmt.Errorf("TestStorageDelete found %d errors:\n\t%s", len(errs), strings.Join(errs, "\n\t"))
 	}

--- a/s3/storage.go
+++ b/s3/storage.go
@@ -394,7 +394,7 @@ func (s *storage) Delete(ctx context.Context, name string) error {
 func (s *storage) DeleteRecursive(ctx context.Context, prefix string) error {
 	paginator := s3.NewListObjectsV2Paginator(s.client, &s3.ListObjectsV2Input{
 		Bucket: aws.String(s.bucket),
-		Prefix: aws.String(path.Join(s.prefix, prefix)),
+		Prefix: aws.String(joinKeepSlash(s.prefix, prefix)),
 	})
 
 	for paginator.HasMorePages() {
@@ -465,4 +465,13 @@ func (s *storage) SignedURL(ctx context.Context, opts s2.SignedURLOptions) (stri
 		}
 		return req.URL, nil
 	}
+}
+
+// joinKeepSlash is path.Join that keeps prefix's trailing slash, which confines a listing to that directory.
+func joinKeepSlash(base, prefix string) string {
+	p := path.Join(base, prefix)
+	if strings.HasSuffix(prefix, "/") && !strings.HasSuffix(p, "/") {
+		p += "/"
+	}
+	return p
 }

--- a/s3/storage_test.go
+++ b/s3/storage_test.go
@@ -401,8 +401,20 @@ func (s *StorageTestSuite) TestS2TestCopyMove() {
 }
 
 func (s *StorageTestSuite) TestS2TestDelete() {
-	_, strg := s.testMockClient()
-	s.Require().NoError(s2test.TestStorageDelete(context.Background(), strg))
+	testCases := []struct {
+		caseName string
+		prefix   string
+	}{
+		{caseName: "no prefix"},
+		{caseName: "with prefix", prefix: "pfx"},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			_, strg := s.testMockClient()
+			strg.(*storage).prefix = tc.prefix
+			s.Require().NoError(s2test.TestStorageDelete(context.Background(), strg))
+		})
+	}
 }
 
 func (s *StorageTestSuite) TestS2TestPutMetadata() {

--- a/server/buckets.go
+++ b/server/buckets.go
@@ -175,7 +175,8 @@ func (bs *Buckets) Delete(ctx context.Context, name string) error {
 	if isHiddenBucketEntry(name) {
 		return &ErrBucketNotFound{Name: name}
 	}
-	return bs.strg.DeleteRecursive(ctx, name)
+	// The slash keeps the prefix match off buckets whose names merely start with name.
+	return bs.strg.DeleteRecursive(ctx, name+"/")
 }
 
 func (bs *Buckets) CreateFolder(ctx context.Context, bucket, key string) error {

--- a/server/buckets_test.go
+++ b/server/buckets_test.go
@@ -144,15 +144,28 @@ func (s *BucketsTestSuite) TestGetAndPut() {
 
 func (s *BucketsTestSuite) TestDelete() {
 	ctx := context.Background()
-	s.Require().NoError(s.buckets.Create(ctx, "to-delete"))
-
-	ok, _ := s.buckets.Exists(ctx, "to-delete")
-	s.True(ok)
+	for _, name := range []string{"to-delete", "to-delete-archive", "to-delet"} {
+		s.Require().NoError(s.buckets.Create(ctx, name))
+	}
 
 	s.Require().NoError(s.buckets.Delete(ctx, "to-delete"))
 
-	ok, _ = s.buckets.Exists(ctx, "to-delete")
-	s.False(ok)
+	testCases := []struct {
+		caseName string
+		bucket   string
+		want     bool
+	}{
+		{caseName: "the bucket itself is gone", bucket: "to-delete", want: false},
+		{caseName: "a bucket sharing the prefix survives", bucket: "to-delete-archive", want: true},
+		{caseName: "a shorter name survives", bucket: "to-delet", want: true},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.caseName, func() {
+			ok, err := s.buckets.Exists(ctx, tc.bucket)
+			s.Require().NoError(err)
+			s.Equal(tc.want, ok)
+		})
+	}
 }
 
 func (s *BucketsTestSuite) TestCreateFolder() {

--- a/storage.go
+++ b/storage.go
@@ -112,6 +112,7 @@ type Storage interface {
 	// a no-op and does not return an error.
 	Delete(ctx context.Context, name string) error
 	// DeleteRecursive removes every object whose name begins with prefix.
+	// A prefix ending in "/" covers only that directory, not names that merely share it.
 	// The operation is best-effort and not atomic across objects.
 	DeleteRecursive(ctx context.Context, prefix string) error
 	// SignedURL returns a presigned URL for the object identified by opts.


### PR DESCRIPTION
## Summary
- `Buckets.Delete` passed the bare bucket name to `DeleteRecursive`, whose fs implementation keeps every entry for which `strings.HasPrefix(name, prefix)` holds. Deleting `photos` therefore also deleted `photos-archive` and every other bucket whose name starts with `photos`, through both `DELETE /{bucket}` and the console. Passing `name + "/"` confines the match to the bucket's own contents; `DeleteRecursive` already matches the directory entry itself via `dirName`, so the bucket directory still goes.
- The cloud backends dropped that slash. s3's `DeleteRecursive` always ran the prefix through `path.Join`, and gcs and azblob did whenever a storage-level prefix was configured; `path.Join` strips a trailing `/`, so on a `server_s3` build, and on gcs or azblob with a prefix, deleting `photos` still took `photos-archive` with it. All three now keep the caller's trailing slash (`joinKeepSlash`). A prefix without a slash behaves as before. The console's folder delete already passes `<folder>/`, so on those backends deleting folder `foo` also stopped taking `foo-bar/...` with it.
- The `Storage.DeleteRecursive` doc now says a prefix ending in `/` covers only that directory, not names that merely share it, and `s2test.TestStorageDelete` checks this for every backend: the directory's objects and the directory itself go, a sibling sharing the name prefix stays. The s3, gcs and azblob modules run it with and without a storage-level prefix.
- This is the immediate fix described in https://github.com/mojatter/s2/issues/207#issuecomment-5638525093. The scoped walk proposed in #207 remains the proper fix for the fs walk cost and would make the prefix filter unnecessary; it is not part of this PR.

## Behavior changes
- `s2test.TestStorageDelete` now requires that a prefix ending in `/` stays inside that directory. An out-of-tree `Storage` that joins the prefix with `path.Join` and drops the slash will start failing the shared test; the v0.16.0 release notes will call this out, as they did for `StartAfter` / `NextAfter` in v0.15.0.

## Test plan
- [x] `go vet ./...` and `go test ./...` in the root module, `s3`, `gcs`, `azblob` and `server`
- [x] Red against `main`: `TestDelete` creates `to-delete`, `to-delete-archive` and `to-delet`; without the slash, `to-delete-archive` is gone after deleting `to-delete`
- [x] Red against the first commit of this PR: the new `s2test` case fails on s3 with and without a storage-level prefix, and on gcs and azblob with one ("removed `s2test-dir-sibling/c.txt`, which only shares the prefix"); fs passes, since its `dirName` handling already honoured the slash
- [x] The cloud integration tests (`integ_test.go`), which also run `TestStorageDelete`, need live services and were not run

## Related
Part of #207.
